### PR TITLE
add initial version of simple property service

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,27 @@
 lazy val root = project.in(file("."))
   .configure(BuildSettings.profile)
   .aggregate(
+    `iep-archaius`,
     `iep-atlas`)
   .settings(BuildSettings.noPackaging: _*)
+
+lazy val `iep-archaius` = project
+  .configure(BuildSettings.profile)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.atlasModuleAkka,
+    Dependencies.atlasModuleWebApi,
+    Dependencies.awsDynamoDB,
+    Dependencies.awsSTS,
+    Dependencies.frigga,
+    Dependencies.iepGuice,
+    Dependencies.iepNflxEnv,
+    Dependencies.log4jApi,
+    Dependencies.log4jCore,
+    Dependencies.log4jSlf4j,
+
+    Dependencies.akkaHttpTestkit % "test",
+    Dependencies.scalatest % "test"
+  ))
 
 lazy val `iep-atlas` = project
   .configure(BuildSettings.profile)

--- a/iep-archaius/README.md
+++ b/iep-archaius/README.md
@@ -1,0 +1,3 @@
+
+Sample property service that can be used with
+[iep-module-archaius2](https://github.com/Netflix/iep/tree/master/iep-module-archaius2).

--- a/iep-archaius/src/main/resources/application.conf
+++ b/iep-archaius/src/main/resources/application.conf
@@ -1,0 +1,22 @@
+
+netflix.iep.archaius {
+  use-dynamic = false
+  sync-init = false
+  table = "atlas.deploy.dynamic.properties"
+}
+
+atlas.akka {
+  api-endpoints = [
+    "com.netflix.atlas.akka.ConfigApi",
+    "com.netflix.atlas.akka.HealthcheckApi",
+    "com.netflix.iep.archaius.PropertiesApi"
+  ]
+
+  actors = ${?atlas.akka.actors} [
+    {
+      name = "props-refresh"
+      class = "com.netflix.iep.archaius.PropertiesLoader"
+    }
+  ]
+}
+

--- a/iep-archaius/src/main/resources/log4j2.xml
+++ b/iep-archaius/src/main/resources/log4j2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn">
+    <Properties>
+        <Property name="dfltPattern">%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %-5level [%t] %class: %msg%n</Property>
+    </Properties>
+    <Appenders>
+        <Console name="STDERR" target="SYSTEM_ERR">
+            <PatternLayout pattern="${dfltPattern}"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.netflix.iep" level="debug"/>
+        <Logger name="com.netflix.spectator" level="debug"/>
+        <Root level="info">
+            <AppenderRef ref="STDERR"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/iep-archaius/src/main/scala/com/netflix/iep/archaius/DynamoService.scala
+++ b/iep-archaius/src/main/scala/com/netflix/iep/archaius/DynamoService.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.archaius
+
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.atomic.AtomicLong
+import javax.inject.Inject
+import javax.inject.Singleton
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
+import com.netflix.iep.service.AbstractService
+import com.typesafe.config.Config
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+/**
+  * Provides access to a dynamo client and a dedicated thread pool for executing
+  * calls. Sample usage:
+  *
+  * ```
+  * val future = dynamoService.execute { client =>
+  *   client.scan(new ScanRequest().withTableName("foo"))
+  * }
+  * ```
+  */
+@Singleton
+class DynamoService @Inject() (
+    client: AmazonDynamoDB,
+    config: Config) extends AbstractService {
+
+  private val nextId = new AtomicLong()
+  private val pool = Executors.newFixedThreadPool(
+    Runtime.getRuntime.availableProcessors(),
+    new ThreadFactory {
+      override def newThread(r: Runnable): Thread = {
+        new Thread(r, s"dynamo-db-${nextId.getAndIncrement()}")
+      }
+    })
+  private val ec = ExecutionContext.fromExecutorService(pool)
+
+  override def startImpl(): Unit = ()
+
+  override def stopImpl(): Unit = {
+    client match {
+      case c: AmazonDynamoDBClient => c.shutdown()
+      case _ =>
+    }
+  }
+
+  def execute[T](task: AmazonDynamoDB => T): Future[T] = Future(task(client))(ec)
+}

--- a/iep-archaius/src/main/scala/com/netflix/iep/archaius/Main.scala
+++ b/iep-archaius/src/main/scala/com/netflix/iep/archaius/Main.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.archaius
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
+import com.google.inject.AbstractModule
+import com.google.inject.Module
+import com.google.inject.Provides
+import com.google.inject.multibindings.Multibinder
+import com.netflix.iep.guice.BaseModule
+import com.netflix.iep.guice.GuiceHelper
+import com.netflix.iep.service.Service
+import com.netflix.iep.service.ServiceManager
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.slf4j.LoggerFactory
+
+object Main {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private def getBaseModules: java.util.List[Module] = {
+    val modules = GuiceHelper.getModulesUsingServiceLoader
+    if (!sys.env.contains("NETFLIX_ENVIRONMENT")) {
+      // If we are running in a local environment provide simple versions of registry
+      // and config bindings. These bindings are normally provided by the final package
+      // config for the app in the production setup.
+      modules.add(new AbstractModule {
+        override def configure(): Unit = {
+          bind(classOf[Registry]).toInstance(new NoopRegistry)
+          bind(classOf[Config]).toInstance(ConfigFactory.load())
+        }
+      })
+    }
+    modules
+  }
+
+  def main(args: Array[String]): Unit = {
+    try {
+      val modules = getBaseModules
+      modules.add(new ServerModule)
+      val guice = new GuiceHelper
+      guice.start(modules)
+      guice.getInjector.getInstance(classOf[ServiceManager])
+      guice.addShutdownHook()
+    } catch {
+      // Send exceptions to main log file instead of wherever STDERR is sent for the process
+      case t: Throwable => logger.error("fatal error on startup", t)
+    }
+  }
+
+  class ServerModule extends BaseModule {
+    override def configure(): Unit = {
+      val serviceBinder = Multibinder.newSetBinder(binder(), classOf[Service])
+      serviceBinder.addBinding().toConstructor(getConstructor(classOf[DynamoService]))
+      bind(classOf[DynamoService])
+      bind(classOf[PropertiesContext])
+    }
+
+    @Provides
+    private def providesDynamoDBClient(config: Config): AmazonDynamoDB = {
+      val region = config.getString("netflix.iep.env.region")
+      val client = new AmazonDynamoDBClient(new DefaultAWSCredentialsProviderChain)
+      client.setEndpoint(s"dynamodb.$region.amazonaws.com")
+      client
+    }
+  }
+}

--- a/iep-archaius/src/main/scala/com/netflix/iep/archaius/PropertiesApi.scala
+++ b/iep-archaius/src/main/scala/com/netflix/iep/archaius/PropertiesApi.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.archaius
+
+import java.io.StringWriter
+import java.util.Properties
+
+import akka.actor.ActorRefFactory
+import akka.http.scaladsl.model.HttpCharsets
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.MediaTypes
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
+import com.netflix.atlas.akka.WebApi
+import com.netflix.atlas.json.Json
+import com.netflix.frigga.Names
+
+
+class PropertiesApi(
+    val propContext: PropertiesContext,
+    implicit val actorRefFactory: ActorRefFactory) extends WebApi {
+
+  def routes: Route = {
+    path("api" / "v1" / "property") {
+      get {
+        parameter("asg") { asg =>
+          extractRequest { request =>
+            val cluster = Names.parseName(asg).getCluster
+            if (propContext.initialized) {
+              val props = propContext.getClusterProps(cluster)
+              complete(encode(request, props))
+            } else {
+              complete(HttpResponse(StatusCodes.ServiceUnavailable))
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private def encode(request: HttpRequest, props: List[PropertiesApi.Property]): HttpResponse = {
+    val useJson = request.headers.exists(h => h.is("accept") && h.value == "application/json")
+    if (useJson) {
+      HttpResponse(StatusCodes.OK, entity = HttpEntity(MediaTypes.`application/json`, Json.encode(props)))
+    } else {
+      val ps = new Properties
+      props.foreach { p => ps.setProperty(p.key, p.value) }
+      val writer = new StringWriter()
+      ps.store(writer, s"count: ${ps.size}")
+      writer.close()
+      val entity = HttpEntity(MediaTypes.`text/plain`.toContentType(HttpCharsets.`UTF-8`), writer.toString)
+      HttpResponse(StatusCodes.OK, entity = entity)
+    }
+  }
+}
+
+object PropertiesApi {
+  case class Property(id: String, cluster: String, key: String, value: String, timestamp: Long)
+}
+

--- a/iep-archaius/src/main/scala/com/netflix/iep/archaius/PropertiesContext.scala
+++ b/iep-archaius/src/main/scala/com/netflix/iep/archaius/PropertiesContext.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.archaius
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import javax.inject.Inject
+import javax.inject.Singleton
+
+import com.netflix.spectator.api.Functions
+import com.netflix.spectator.api.Registry
+import com.typesafe.scalalogging.StrictLogging
+
+/**
+  * Context for accessing property values from the storage system. This class can be
+  * asynchronously updated so that local access to properties does not need to result
+  * into a separate call to the storage layer.
+  */
+@Singleton
+class PropertiesContext @Inject() (registry: Registry) extends StrictLogging {
+
+  private val clock = registry.clock()
+
+  /**
+    * Tracks the age for the properties cache. This can be used for a simple alert to
+    * detect staleness.
+    */
+  private val lastUpdateTime = registry.gauge(
+    "iep.props.cacheAge",
+    new AtomicLong(clock.wallTime()),
+    Functions.AGE)
+
+  private val updateLatch = new AtomicReference[CountDownLatch](new CountDownLatch(1))
+  private val ref = new AtomicReference[PropList]()
+
+  /** Update the properties cache for this context. */
+  def update(props: PropList): Unit = {
+    lastUpdateTime.set(clock.wallTime())
+    ref.set(props)
+    logger.debug(s"properties updated from dynamodb, size = ${props.size}")
+    updateLatch.get().countDown()
+  }
+
+  /**
+    * Returns true if properties have been updated at least once. Users of this class should
+    * check that it has been properly initialized before consuming properties.
+    */
+  def initialized: Boolean = ref.get != null
+
+  /** Return all properties. */
+  def getAll: PropList = ref.get
+
+  /** Return all properties for the specified cluster. */
+  def getClusterProps(cluster: String): PropList = ref.get.filter(_.cluster == cluster)
+
+  /** Used for testing. This returns a latch that will get updated along with properties. */
+  private[archaius] def latch: CountDownLatch = {
+    val latch = new CountDownLatch(1)
+    updateLatch.set(latch)
+    latch
+  }
+}

--- a/iep-archaius/src/main/scala/com/netflix/iep/archaius/PropertiesLoader.scala
+++ b/iep-archaius/src/main/scala/com/netflix/iep/archaius/PropertiesLoader.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.archaius
+
+import akka.actor.Actor
+import com.amazonaws.services.dynamodbv2.model.ScanRequest
+import com.netflix.atlas.json.Json
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+
+import scala.util.Failure
+import scala.util.Success
+
+/**
+  * Actor for loading properties from dynamodb. Properties will get updated in the provided
+  * `PropertiesContext`.
+  */
+class PropertiesLoader(
+    config: Config,
+    propContext: PropertiesContext,
+    dynamoService: DynamoService) extends Actor with StrictLogging {
+
+  private val table = config.getString("netflix.iep.archaius.table")
+
+  import scala.concurrent.duration._
+  import scala.concurrent.ExecutionContext.Implicits.global
+  context.system.scheduler.schedule(0.seconds, 5.seconds, self, PropertiesLoader.Tick)
+
+  def receive: Receive = {
+    case PropertiesLoader.Tick =>
+      val future = dynamoService.execute { client =>
+        val matches = List.newBuilder[PropertiesApi.Property]
+        val request = new ScanRequest().withTableName(table)
+        var response = client.scan(request)
+        matches ++= process(response.getItems)
+        while (response.getLastEvaluatedKey != null) {
+          request.setExclusiveStartKey(response.getLastEvaluatedKey)
+          response = client.scan(request)
+          matches ++= process(response.getItems)
+        }
+        matches.result()
+      }
+
+      future.onComplete {
+        case Success(vs) => propContext.update(vs)
+        case Failure(t)  => logger.error("failed to refresh properties from dynamodb", t)
+      }
+  }
+
+  private def process(items: Items): PropList = {
+    import scala.collection.JavaConverters._
+    items.asScala
+      .filter(_.containsKey("data"))
+      .map(_.get("data").getS)
+      .map(s => Json.decode[PropertiesApi.Property](s))
+      .toList
+  }
+}
+
+object PropertiesLoader {
+  case object Tick
+}

--- a/iep-archaius/src/main/scala/com/netflix/iep/archaius/package.scala
+++ b/iep-archaius/src/main/scala/com/netflix/iep/archaius/package.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+
+/**
+  * Helper types for working with properties.
+  */
+package object archaius {
+  type AttrMap = java.util.Map[String, AttributeValue]
+  type Items = java.util.List[AttrMap]
+  type PropList = List[PropertiesApi.Property]
+}

--- a/iep-archaius/src/test/scala/com/netflix/iep/archaius/MockDynamoDB.scala
+++ b/iep-archaius/src/test/scala/com/netflix/iep/archaius/MockDynamoDB.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.archaius
+
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.amazonaws.services.dynamodbv2.model.ScanResult
+
+class MockDynamoDB extends InvocationHandler {
+
+  var scanResult: ScanResult = null
+
+  override def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
+    method.getName match {
+      case "scan" => scanResult
+      case _      => throw new UnsupportedOperationException(method.toString)
+    }
+  }
+
+  def client: AmazonDynamoDB = {
+    val clsLoader = Thread.currentThread().getContextClassLoader
+    val proxy = Proxy.newProxyInstance(clsLoader, Array(classOf[AmazonDynamoDB]), this)
+    proxy.asInstanceOf[AmazonDynamoDB]
+  }
+}

--- a/iep-archaius/src/test/scala/com/netflix/iep/archaius/PropertiesApiSuite.scala
+++ b/iep-archaius/src/test/scala/com/netflix/iep/archaius/PropertiesApiSuite.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.archaius
+
+import java.io.StringReader
+import java.util.Properties
+
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.MediaTypes
+import akka.http.scaladsl.model.StatusCode
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.testkit.RouteTestTimeout
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.netflix.atlas.akka.RequestHandler
+import com.netflix.atlas.json.Json
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.ManualClock
+import org.scalatest.FunSuite
+
+
+class PropertiesApiSuite extends FunSuite with ScalatestRouteTest {
+  import scala.concurrent.duration._
+  implicit val routeTestTimeout = RouteTestTimeout(5.second)
+
+  val clock = new ManualClock()
+  val registry = new DefaultRegistry(clock)
+  val propContext = new PropertiesContext(registry)
+  val endpoint = new PropertiesApi(propContext, system)
+  val routes = RequestHandler.standardOptions(endpoint.routes)
+
+  private def assertJsonContentType(response: HttpResponse): Unit = {
+    assert(response.entity.contentType.mediaType === MediaTypes.`application/json`)
+  }
+
+  private def assertResponse(response: HttpResponse, expected: StatusCode): Unit = {
+    assert(response.status === expected)
+    assertJsonContentType(response)
+  }
+
+  test("no asg") {
+    Get("/api/v1/property") ~> routes ~> check {
+      assert(response.status === StatusCodes.BadRequest)
+    }
+  }
+
+  test("empty") {
+    propContext.update(Nil)
+    Get("/api/v1/property?asg=foo-main-v001") ~>
+      addHeader(Accept(MediaTypes.`application/json`)) ~>
+      routes ~>
+      check {
+        assert(response.status === StatusCodes.OK)
+        assert(responseAs[String] === "[]")
+      }
+  }
+
+  test("properties response") {
+    propContext.update(List(
+      PropertiesApi.Property("foo-main::a", "foo-main", "a", "b", 12345L),
+      PropertiesApi.Property("foo-main::1", "foo-main", "1", "2", 12345L),
+      PropertiesApi.Property("bar-main::c", "bar-main", "c", "d", 12345L)
+    ))
+    Get("/api/v1/property?asg=foo-main-v001") ~> routes ~> check {
+      assert(response.status === StatusCodes.OK)
+      val props = new Properties
+      props.load(new StringReader(responseAs[String]))
+      assert(props.size === 2)
+      assert(props.getProperty("a") === "b")
+      assert(props.getProperty("1") === "2")
+    }
+  }
+
+  test("json response") {
+    propContext.update(List(
+      PropertiesApi.Property("foo-main::a", "foo-main", "a", "b", 12345L)
+    ))
+    Get("/api/v1/property?asg=foo-main-v001") ~>
+      addHeader(Accept(MediaTypes.`application/json`)) ~>
+      routes ~>
+      check {
+        assert(response.status === StatusCodes.OK)
+        val props = Json.decode[List[PropertiesApi.Property]](responseAs[String])
+        assert(props === List(PropertiesApi.Property("foo-main::a", "foo-main", "a", "b", 12345L)))
+      }
+  }
+}

--- a/iep-archaius/src/test/scala/com/netflix/iep/archaius/PropertiesLoaderSuite.scala
+++ b/iep-archaius/src/test/scala/com/netflix/iep/archaius/PropertiesLoaderSuite.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.archaius
+
+import akka.actor.ActorSystem
+import akka.testkit.ImplicitSender
+import akka.testkit.TestActorRef
+import akka.testkit.TestKit
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import com.amazonaws.services.dynamodbv2.model.ScanResult
+import com.netflix.atlas.json.Json
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.ManualClock
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FunSuiteLike
+
+
+class PropertiesLoaderSuite extends TestKit(ActorSystem())
+  with ImplicitSender
+  with FunSuiteLike
+  with BeforeAndAfterAll {
+
+  val config = ConfigFactory.parseString(
+    """
+      |netflix.iep.archaius.table = "test"
+    """.stripMargin)
+
+  val clock = new ManualClock()
+  val registry = new DefaultRegistry(clock)
+  val propContext = new PropertiesContext(registry)
+
+  val ddb = new MockDynamoDB
+  val service = new DynamoService(ddb.client, config)
+
+  val items = newItems("foo-main", Map("a" -> "b", "1" -> "2"))
+  items.addAll(newItems("bar-main", Map("c" -> "d")))
+  ddb.scanResult = new ScanResult().withItems(items)
+
+  val ref = TestActorRef(new PropertiesLoader(config, propContext, service))
+
+  override def afterAll(): Unit = {
+    system.terminate()
+  }
+
+  private def waitForUpdate(): Unit = {
+    val latch = propContext.latch
+    ref ! PropertiesLoader.Tick
+    latch.await()
+  }
+
+  test("init") {
+    waitForUpdate()
+    assert(propContext.initialized)
+    assert(propContext.getAll === List(
+      PropertiesApi.Property("foo-main::a", "foo-main", "a", "b", 12345L),
+      PropertiesApi.Property("foo-main::1", "foo-main", "1", "2", 12345L),
+      PropertiesApi.Property("bar-main::c", "bar-main", "c", "d", 12345L)
+    ))
+  }
+
+  test("update") {
+    val items = newItems("foo-main", Map("a" -> "b"))
+    items.addAll(newItems("bar-main", Map("c" -> "d")))
+    ddb.scanResult = new ScanResult().withItems(items)
+
+    waitForUpdate()
+
+    assert(propContext.getAll === List(
+      PropertiesApi.Property("foo-main::a", "foo-main", "a", "b", 12345L),
+      PropertiesApi.Property("bar-main::c", "bar-main", "c", "d", 12345L)
+    ))
+  }
+
+  private def newItems(cluster: String, props: Map[String, String]): Items = {
+    val items = new java.util.ArrayList[AttrMap]()
+    props.foreach { case (k, v) =>
+      val prop = PropertiesApi.Property(s"$cluster::$k", cluster, k, v, 12345L)
+      val value = new AttributeValue().withS(Json.encode(prop))
+      val timestamp = new AttributeValue().withS("12345")
+      val m = new java.util.HashMap[String, AttributeValue]()
+      m.put("data", value)
+      m.put("timestamp", timestamp)
+      items.add(m)
+    }
+    items
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,17 +2,17 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val akka       = "2.4.12"
-    val atlas      = "1.5.0"
-    val aws        = "1.11.37"
-    val iep        = "0.4.10"
+    val akka       = "2.4.16"
+    val akkaHttpV  = "10.0.3"
+    val atlas      = "1.6.0-rc.3"
+    val aws        = "1.11.93"
+    val iep        = "0.4.16"
     val guice      = "4.1.0"
-    val jackson    = "2.8.3"
+    val jackson    = "2.8.6"
     val log4j      = "2.7"
     val scala      = "2.11.8"
-    val slf4j      = "1.7.21"
-    val spectator  = "0.43.0"
-    val spray      = "1.3.4"
+    val slf4j      = "1.7.23"
+    val spectator  = "0.52.0"
 
     val crossScala = Seq(scala)
   }
@@ -20,6 +20,8 @@ object Dependencies {
   import Versions._
 
   val akkaActor          = "com.typesafe.akka" %% "akka-actor" % akka
+  val akkaHttpCore       = "com.typesafe.akka" %% "akka-http-core" % akkaHttpV
+  val akkaHttpTestkit    = "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV
   val akkaSlf4j          = "com.typesafe.akka" %% "akka-slf4j" % akka
   val akkaTestkit        = "com.typesafe.akka" %% "akka-testkit" % akka
   val atlasJson          = "com.netflix.atlas_v1" %% "atlas-json" % atlas
@@ -27,11 +29,13 @@ object Dependencies {
   val atlasModuleWebApi  = "com.netflix.atlas_v1" %% "atlas-module-webapi" % atlas
   val awsCloudWatch      = "com.amazonaws" % "aws-java-sdk-cloudwatch" % aws
   val awsCore            = "com.amazonaws" % "aws-java-sdk-core" % aws
+  val awsDynamoDB        = "com.amazonaws" % "aws-java-sdk-dynamodb" % aws
   val awsEC2             = "com.amazonaws" % "aws-java-sdk-ec2" % aws
   val awsS3              = "com.amazonaws" % "aws-java-sdk-s3" % aws
+  val awsSTS             = "com.amazonaws" % "aws-java-sdk-sts" % aws
   val caffeine           = "com.github.ben-manes.caffeine" % "caffeine" % "2.3.3"
   val equalsVerifier     = "nl.jqno.equalsverifier" % "equalsverifier" % "2.1.3"
-  val frigga             = "com.netflix.frigga" % "frigga" % "0.15.0"
+  val frigga             = "com.netflix.frigga" % "frigga" % "0.17.0"
   val guiceCore          = "com.google.inject" % "guice" % guice
   val guiceMulti         = "com.google.inject.extensions" % "guice-multibindings" % guice
   val iepGuice           = "com.netflix.iep" % "iep-guice" % iep
@@ -39,8 +43,10 @@ object Dependencies {
   val iepModuleArchaius2 = "com.netflix.iep" % "iep-module-archaius2" % iep
   val iepModuleAtlas     = "com.netflix.iep" % "iep-module-atlas" % iep
   val iepModuleAws       = "com.netflix.iep" % "iep-module-aws" % iep
+  val iepModuleAwsMetrics= "com.netflix.iep" % "iep-module-awsmetrics" % iep
   val iepModuleEureka    = "com.netflix.iep" % "iep-module-eureka" % iep
   val iepModuleJmx       = "com.netflix.iep" % "iep-module-jmxport" % iep
+  val iepNflxEnv         = "com.netflix.iep" % "iep-nflxenv" % iep
   val iepService         = "com.netflix.iep" % "iep-service" % iep
   val jacksonAnno2       = "com.fasterxml.jackson.core" % "jackson-annotations" % jackson
   val jacksonCore2       = "com.fasterxml.jackson.core" % "jackson-core" % jackson
@@ -69,9 +75,5 @@ object Dependencies {
   val spectatorLog4j     = "com.netflix.spectator" % "spectator-ext-log4j2" % spectator
   val spectatorM2        = "com.netflix.spectator" % "spectator-reg-metrics2" % spectator
   val spectatorSandbox   = "com.netflix.spectator" % "spectator-ext-sandbox" % spectator
-  val sprayCan           = "io.spray" %% "spray-can" % spray
-  val sprayClient        = "io.spray" %% "spray-client" % spray
-  val sprayRouting       = "io.spray" %% "spray-routing" % spray
-  val sprayTestkit       = "io.spray" %% "spray-testkit" % spray
   val typesafeConfig     = "com.typesafe" % "config" % "1.3.1"
 }


### PR DESCRIPTION
This is a simple property service backed by a DynamoDB table
that can be used with `iep-module-archaius2`. This service
currently only supports the read operations. Writes are
managed by a deployment service internally.