### PR TITLE
add sample eureka configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val `iep-atlas` = project
     Dependencies.iepModuleAdmin,
     Dependencies.iepModuleArchaius2,
     Dependencies.iepModuleAtlas,
-    //Dependencies.iepModuleEureka,
+    Dependencies.iepModuleEureka,
     Dependencies.iepModuleJmx,
     Dependencies.log4jApi,
     Dependencies.log4jCore,

--- a/iep-atlas/README.md
+++ b/iep-atlas/README.md
@@ -26,6 +26,13 @@ To run the example:
 $ sbt iep-atlas/run
 ```
 
+By default it will disable the Eureka registration. To enable, modify
+[eureka-client.properties][eureka-config] to talk to your Eureka instance. For
+more details see the [Eureka documentation][eureka-docs].
+
+[eureka-config]: https://github.com/Netflix-Skunkworks/iep-apps/blob/master/iep-atlas/src/main/resources/eureka-client.properties
+[eureka-docs]: https://github.com/Netflix/eureka/wiki/Configuring-Eureka
+
 ## Packaging
 
 For Debian/Ubuntu:

--- a/iep-atlas/src/main/resources/eureka-client.properties
+++ b/iep-atlas/src/main/resources/eureka-client.properties
@@ -1,0 +1,32 @@
+
+netflix.appinfo.name=atlas
+netflix.appinfo.asgName=atlas-local
+netflix.appinfo.port=7101
+netflix.appinfo.securePort=7102
+netflix.appinfo.vipAddress=atlas-local:7001
+
+eureka.region=us-east-1
+eureka.preferSameZone=true
+eureka.validateInstanceId=false
+
+# Do lookup via txt records
+#eureka.shouldUseDns=true
+#eureka.eurekaServer.domainName=localhost
+#eureka.eurekaServer.port=7001
+#eureka.eurekaServer.context=v2
+#eureka.eurekaServer.connectTimeout=5000
+#eureka.eurekaServer.readTimeout=8000
+#eureka.eurekaServer.gzipContent=true
+
+# Local with no eureka running, from testconfig:
+# https://github.com/Netflix/iep/blob/master/iep-eureka-testconfig/src/main/resources
+netflix.appinfo.validateInstanceId=false
+netflix.appinfo.datacenter=default
+eureka.shouldUseDns=false
+eureka.shouldFetchRegistry=false
+eureka.serviceUrl.default=http://localhost/eureka/v2/
+eureka.registration.enabled=false
+
+# HACK: avoid delays talking to aws metadata service when running in some environments
+# like travis
+netflix.appinfo.mt.num_retries=0


### PR DESCRIPTION
Add sample eureka config for running locally with no
Eureka server and link to config page for users to
configure for their own eureka service.