### PR TITLE
do not send to lwc if payload is empty

### DIFF
--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/LwcPublishActor.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/LwcPublishActor.scala
@@ -127,10 +127,12 @@ class LwcPublishActor(config: Config, registry: Registry) extends Actor with Act
     val timestamp = values.head.timestamp
     val payload = evaluator.eval("all", fixTimestamp(timestamp), values.map(toPair).asJava)
 
-    val entity = HttpEntity(MediaTypes.`application/json`, Json.encode(payload))
-    val request = HttpRequest(HttpMethods.POST, evalUri, Nil, entity)
-    mkRequest("lwc-eval", request).onSuccess {
-      case response => response.discardEntityBytes()
+    if (!payload.getMetrics.isEmpty) {
+      val entity = HttpEntity(MediaTypes.`application/json`, Json.encode(payload))
+      val request = HttpRequest(HttpMethods.POST, evalUri, Nil, entity)
+      mkRequest("lwc-eval", request).onSuccess {
+        case response => response.discardEntityBytes()
+      }
     }
   }
 


### PR DESCRIPTION
The request was always getting sent before, now it
will only be sent if there is some metrics data.