### PR TITLE
do not intern the values while parsing

### DIFF
--- a/iep-lwc-bridge/src/main/resources/application.conf
+++ b/iep-lwc-bridge/src/main/resources/application.conf
@@ -4,20 +4,27 @@ netflix.iep.lwc.bridge {
   eval-uri = "http://localhost:7101/lwc/api/v1/evaluate"
 }
 
-atlas.akka {
-  api-endpoints = [
-    "com.netflix.atlas.akka.ConfigApi",
-    "com.netflix.atlas.akka.HealthcheckApi",
-    "com.netflix.atlas.webapi.PublishApi",
-    "com.netflix.iep.lwc.UpdateApi"
-  ]
+atlas {
+  akka {
+    api-endpoints = [
+      "com.netflix.atlas.akka.ConfigApi",
+      "com.netflix.atlas.akka.HealthcheckApi",
+      "com.netflix.atlas.webapi.PublishApi",
+      "com.netflix.iep.lwc.UpdateApi"
+    ]
 
-  actors = ${?atlas.akka.actors} [
-    {
-      name = "publish"
-      class = "com.netflix.iep.lwc.LwcPublishActor"
-    }
-  ]
+    actors = ${?atlas.akka.actors} [
+      {
+        name = "publish"
+        class = "com.netflix.iep.lwc.LwcPublishActor"
+      }
+    ]
+  }
+
+  webapi.publish {
+    // This is just a pass through, do not intern the values...
+    intern-while-parsing = false
+  }
 }
 
 // User specific configuration with settings for an internal deployment


### PR DESCRIPTION
Since this is not a sharded storage layer that will
keep the values for a long time, there is no need
to intern the strings and tag maps and it adds a
lot of overhead while processing.