### PR TITLE
remove unnecessary dependency for iep-archaius

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,6 @@ lazy val `iep-archaius` = project
   .configure(BuildSettings.profile)
   .settings(libraryDependencies ++= Seq(
     Dependencies.atlasModuleAkka,
-    Dependencies.atlasModuleWebApi,
     Dependencies.awsDynamoDB,
     Dependencies.awsSTS,
     Dependencies.frigga,


### PR DESCRIPTION
The Atlas webapi is not needed for this app.