### PR TITLE
split expressions into groups based on the app

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ lazy val `iep-lwc-bridge` = project
   .settings(libraryDependencies ++= Seq(
     Dependencies.atlasModuleAkka,
     Dependencies.atlasModuleWebApi,
+    Dependencies.frigga,
     Dependencies.iepGuice,
     Dependencies.iepModuleAtlas,
     Dependencies.log4jApi,


### PR DESCRIPTION
Intead of using one group for the evaluator, split the
expressions into groups based on the app. This should
significantly reduce the number of expressions that need
to get checked for a datapoint as it is flowing through
the system.