### PR TITLE
app to send LWC eval results to CloudWatch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,3 +56,20 @@ lazy val `iep-lwc-bridge` = project
     Dependencies.scalatest % "test"
   ))
 
+lazy val `iep-lwc-cloudwatch` = project
+  .configure(BuildSettings.profile)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.atlasModuleAkka,
+    Dependencies.atlasModuleEval,
+    Dependencies.awsCloudWatch,
+    Dependencies.iepGuice,
+    Dependencies.iepModuleAtlas,
+    Dependencies.iepModuleAws,
+    Dependencies.log4jApi,
+    Dependencies.log4jCore,
+    Dependencies.log4jSlf4j,
+
+    Dependencies.akkaHttpTestkit % "test",
+    Dependencies.scalatest % "test"
+  ))
+

--- a/iep-lwc-cloudwatch/README.md
+++ b/iep-lwc-cloudwatch/README.md
@@ -1,0 +1,3 @@
+
+Experiment of forwarding the results of LWC expressions to CloudWatch.
+

--- a/iep-lwc-cloudwatch/src/main/resources/application.conf
+++ b/iep-lwc-cloudwatch/src/main/resources/application.conf
@@ -1,0 +1,21 @@
+
+iep.lwc.cloudwatch {
+  uri = "http://localhost:7102/cloudwatch-forwarding/clusters/sync"
+  namespace = "NFLX/EPIC"
+
+  // Filter applied to URIs in the config, this is typically used to restrict a given instance
+  // to a subset of the configuration
+  filter = ".*"
+}
+
+atlas {
+  akka {
+    api-endpoints = [
+      "com.netflix.atlas.akka.ConfigApi",
+      "com.netflix.atlas.akka.HealthcheckApi"
+    ]
+  }
+}
+
+// User specific configuration with settings for an internal deployment
+include "custom.conf"

--- a/iep-lwc-cloudwatch/src/main/resources/log4j2.xml
+++ b/iep-lwc-cloudwatch/src/main/resources/log4j2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn">
+    <Properties>
+        <Property name="dfltPattern">%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %-5level [%t] %class: %msg%n</Property>
+    </Properties>
+    <Appenders>
+        <Console name="STDERR" target="SYSTEM_ERR">
+            <PatternLayout pattern="${dfltPattern}"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.netflix.iep" level="debug"/>
+        <Logger name="com.netflix.spectator" level="debug"/>
+        <Root level="info">
+            <AppenderRef ref="STDERR"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/AppModule.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/AppModule.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import com.google.inject.AbstractModule
+import com.google.inject.Provides
+import com.google.inject.multibindings.Multibinder
+import com.netflix.iep.aws.AwsClientFactory
+import com.netflix.iep.service.Service
+
+class AppModule extends AbstractModule {
+  override def configure(): Unit = {
+    val serviceBinder = Multibinder.newSetBinder(binder(), classOf[Service])
+    serviceBinder.addBinding().to(classOf[ForwardingService])
+  }
+
+  @Provides
+  private def awsCloudWatchClient(factory: AwsClientFactory): AmazonCloudWatch = {
+    factory.newInstance(classOf[AmazonCloudWatch])
+  }
+}

--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ConfigManager.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ConfigManager.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc
+
+import akka.stream.Attributes
+import akka.stream.FlowShape
+import akka.stream.Inlet
+import akka.stream.Outlet
+import akka.stream.stage.GraphStage
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.InHandler
+import akka.stream.stage.OutHandler
+import com.netflix.iep.lwc.ForwardingService.ClusterConfig
+import com.netflix.iep.lwc.ForwardingService.Message
+import com.typesafe.scalalogging.StrictLogging
+
+class ConfigManager
+  extends GraphStage[FlowShape[Message, Map[String, ClusterConfig]]]
+  with StrictLogging {
+
+  private val in = Inlet[Message]("ConfigManager.in")
+  private val out = Outlet[Map[String, ClusterConfig]]("ConfigManager.out")
+
+  override val shape: FlowShape[Message, Map[String, ClusterConfig]] = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+
+      private val configs = scala.collection.mutable.AnyRefMap.empty[String, ClusterConfig]
+
+      override def onPush(): Unit = {
+        val msg = grab(in)
+        if (msg.response.isUpdate) {
+          val cluster = msg.cluster
+          try {
+            configs += cluster -> msg.response.clusterConfig
+            logger.info(s"updated configuration for cluster $cluster")
+          } catch {
+            case e: Exception =>
+              logger.warn(s"invalid config for cluster $cluster", e)
+          }
+        } else {
+          configs -= msg.cluster
+          logger.info(s"deleted configuration for cluster ${msg.cluster}")
+        }
+        push(out, configs.toMap)
+      }
+
+      override def onPull(): Unit = {
+        pull(in)
+      }
+
+      override def onUpstreamFinish(): Unit = {
+        completeStage()
+      }
+
+      setHandlers(in, out, this)
+    }
+  }
+}

--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc
+
+import java.nio.charset.StandardCharsets
+import java.util.Date
+import java.util.regex.Pattern
+import javax.inject.Inject
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpMethods
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.StatusCodes
+import akka.stream.ActorMaterializer
+import akka.stream.KillSwitch
+import akka.stream.KillSwitches
+import akka.stream.ThrottleMode
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Framing
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import com.amazonaws.services.cloudwatch.model.Dimension
+import com.amazonaws.services.cloudwatch.model.MetricDatum
+import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.TextNode
+import com.netflix.atlas.akka.AccessLogger
+import com.netflix.atlas.core.util.Strings
+import com.netflix.atlas.eval.model.ArrayData
+import com.netflix.atlas.eval.model.TimeSeriesMessage
+import com.netflix.atlas.eval.stream.Evaluator
+import com.netflix.atlas.json.Json
+import com.netflix.atlas.json.JsonSupport
+import com.netflix.iep.aws.Pagination
+import com.netflix.iep.service.AbstractService
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+
+import scala.concurrent.duration._
+import scala.util.Try
+
+class ForwardingService @Inject()(
+  config: Config,
+  registry: Registry,
+  evaluator: Evaluator,
+  cwClient: AmazonCloudWatch,
+  implicit val system: ActorSystem)
+
+  extends AbstractService {
+
+  import ForwardingService._
+
+  private implicit val mat = ActorMaterializer()
+
+  private var killSwitch: KillSwitch = _
+
+  override def startImpl(): Unit = {
+    val pattern = Pattern.compile(config.getString("iep.lwc.cloudwatch.filter"))
+    val uri = config.getString("iep.lwc.cloudwatch.uri")
+    val client = Http().superPool[AccessLogger]()
+    killSwitch = httpSource(uri, client)
+      .via(configInput(registry))
+      .via(toDataSources(pattern))
+      .via(Flow.fromProcessor(() => evaluator.createStreamsProcessor()))
+      .via(toMetricDatum(registry))
+      .via(toCloudWatchPut)
+      .via(sendToCloudWatch(cwClient))
+      .viaMat(KillSwitches.single)(Keep.right)
+      .toMat(Sink.ignore)(Keep.left)
+      .run()
+  }
+
+  override def stopImpl(): Unit = {
+    if (killSwitch != null) killSwitch.shutdown()
+  }
+
+}
+
+object ForwardingService extends StrictLogging {
+
+  //
+  // Helpers for constructing parts of the stream
+  //
+
+  type Client = Flow[(HttpRequest, AccessLogger), (Try[HttpResponse], AccessLogger), NotUsed]
+
+  private val MaxFrameLength = 65536
+
+  def httpSource(uri: String, client: Client): Source[ByteString, NotUsed] = {
+    val request = HttpRequest(HttpMethods.GET, uri)
+    Source.repeat(request)
+      .throttle(1, 1.second, 1, ThrottleMode.Shaping)
+      .map(r => r -> AccessLogger.newClientLogger("configbin", r))
+      .via(client)
+      .map {
+        case (result, accessLog) =>
+          accessLog.complete(result)
+          result
+      }
+      .filter(_.isSuccess)
+      .flatMapConcat(r => Source(r.toOption.toList))
+      .filter(_.status == StatusCodes.OK)
+      .flatMapConcat(_.entity.withoutSizeLimit().dataBytes)
+      .recover {
+        case t: Throwable =>
+          logger.warn("configbin stream failed", t)
+          ByteString.empty
+      }
+  }
+
+  def configInput(registry: Registry): Flow[ByteString, Map[String, ClusterConfig], NotUsed] = {
+    val baseId = registry.createId("forwarding.configMessages")
+    val heartbeats = registry.counter(baseId.withTag("id", "heartbeat"))
+    val invalid = registry.counter(baseId.withTag("id", "invalid"))
+    val updates = registry.counter(baseId.withTag("id", "update"))
+    val deletes = registry.counter(baseId.withTag("id", "delete"))
+
+    Flow[ByteString]
+      .via(Framing.delimiter(ByteString("\n"), MaxFrameLength, allowTruncation = true))
+      .map(_.decodeString(StandardCharsets.UTF_8))
+      .map(s => Message(s))
+      .filter { msg =>
+        msg match {
+          case m if m.isHeartbeat => logger.debug(m.responseString); heartbeats.increment()
+          case m if m.isInvalid   => invalid.increment()
+          case m if m.isUpdate    => (if (m.response.isDelete) deletes else updates).increment()
+        }
+        msg.isUpdate
+      }
+      .via(new ConfigManager)
+  }
+
+  def toDataSources(pattern: Pattern): Flow[Map[String, ClusterConfig], Evaluator.DataSources, NotUsed] = {
+    Flow[Map[String, ClusterConfig]]
+      .map { configs =>
+        import scala.collection.JavaConverters._
+        val exprs = configs.values.flatMap { config =>
+          config.expressions
+            .filter(e => pattern.matcher(e.atlasUri).matches())
+            .map(_.toDataSource)
+        }
+        new Evaluator.DataSources(exprs.toSet.asJava)
+      }
+  }
+
+  def toMetricDatum(registry: Registry): Flow[Evaluator.MessageEnvelope, MetricDatum, NotUsed] = {
+    val datapoints = registry.counter("forwarding.cloudWatchDatapoints")
+
+    Flow[Evaluator.MessageEnvelope]
+      .filter { env =>
+        env.getMessage match {
+          case ts: TimeSeriesMessage =>
+            datapoints.increment()
+            true
+          case other: JsonSupport =>
+            logger.debug(s"diagnostic message: ${other.toJson}")
+            false
+        }
+      }
+      .map { env =>
+        val expr = Json.decode[ForwardingExpression](env.getId)
+        val msg = env.getMessage.asInstanceOf[TimeSeriesMessage]
+        expr.createMetricDatum(msg)
+      }
+  }
+
+  def toCloudWatchPut: Flow[MetricDatum, PutMetricDataRequest, NotUsed] = {
+    import scala.collection.JavaConverters._
+    Flow[MetricDatum]
+      .groupedWithin(20, 5.seconds)
+      .map { data =>
+        new PutMetricDataRequest()
+          .withNamespace("NFLX/EPIC")
+          .withMetricData(data.asJava)
+      }
+  }
+
+  def sendToCloudWatch(cwClient: AmazonCloudWatch): Flow[PutMetricDataRequest, NotUsed, NotUsed] = {
+    Flow[PutMetricDataRequest]
+      .flatMapConcat { request =>
+        val pub = Pagination.createPublisher(request, r => cwClient.putMetricData(r))
+        Source.fromPublisher(pub)
+      }
+      .map { response =>
+        logger.debug(s"cloudwatch put result: $response")
+        NotUsed
+      }
+      .recover {
+        case t: Throwable =>
+          logger.warn("cloudwatch request failed", t)
+          NotUsed
+      }
+  }
+
+  //
+  // Model objects for configs
+  //
+
+  case class Message(str: String) {
+    val (cluster: String, responseString: String) = {
+      val pos = str.indexOf("->")
+      if (pos < 0)
+        null.asInstanceOf[String] -> null.asInstanceOf[String]
+      else
+        str.substring(0, pos) -> str.substring(pos + 2)
+    }
+
+    private def isNullOrEmpty(s: String): Boolean = s == null || s.isEmpty
+
+    def isInvalid: Boolean = isNullOrEmpty(cluster) || isNullOrEmpty(responseString)
+
+    def isHeartbeat: Boolean = cluster == "heartbeat"
+
+    def isUpdate: Boolean = !(isInvalid || isHeartbeat)
+
+    def response: ConfigBinResponse = {
+      Json.decode[ConfigBinResponse](responseString)
+    }
+  }
+
+  case class ConfigBinResponse(version: ConfigBinVersion, payload: JsonNode) {
+    def isUpdate: Boolean = !isDelete
+    def isDelete: Boolean = payload.isTextual && payload.asText().isEmpty
+
+    def clusterConfig: ClusterConfig = {
+      require(isUpdate, "cannot retrieve config from a delete response")
+      Json.decode[ClusterConfig](payload.toString)
+    }
+  }
+
+  object ConfigBinResponse {
+    def apply(version: ConfigBinVersion, payload: ClusterConfig): ConfigBinResponse = {
+      val data = Json.decode[JsonNode](Json.encode(payload))
+      apply(version, data)
+    }
+
+    def delete(version: ConfigBinVersion): ConfigBinResponse = {
+      apply(version, new TextNode(""))
+    }
+  }
+
+  case class ConfigBinVersion(
+    ts: Long,
+    hash: String,
+    user: Option[String] = None,
+    comment: Option[String] = None)
+
+  case class ClusterConfig(email: String, expressions: List[ForwardingExpression])
+
+  case class ForwardingExpression(
+    atlasUri: String,
+    account: String,
+    metricName: String,
+    dimensions: List[ForwardingDimension] = Nil) {
+
+    require(atlasUri != null, "atlasUri cannot be null")
+    require(account != null, "account cannot be null")
+    require(metricName != null, "metricName cannot be null")
+
+    def toDataSource: Evaluator.DataSource = {
+      val id = Json.encode(this)
+      new Evaluator.DataSource(id, atlasUri)
+    }
+
+    def createMetricDatum(msg: TimeSeriesMessage): MetricDatum = {
+      import scala.collection.JavaConverters._
+      // TODO: account handling
+      val name = Strings.substitute(metricName, msg.tags)
+
+      val value = msg.data match {
+        case data: ArrayData => data.values(0)
+        case _               => Double.NaN
+      }
+
+      new MetricDatum()
+        .withMetricName(name)
+        .withDimensions(dimensions.map(_.toDimension(msg.tags)).asJava)
+        .withTimestamp(new Date(msg.start))
+        .withValue(value)
+    }
+  }
+
+  case class ForwardingDimension(name: String, value: String) {
+    def toDimension(tags: Map[String, String]): Dimension = {
+      new Dimension()
+        .withName(name)
+        .withValue(Strings.substitute(value, tags))
+    }
+  }
+}

--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/Main.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/Main.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc
+
+import com.google.inject.AbstractModule
+import com.google.inject.Module
+import com.netflix.iep.guice.GuiceHelper
+import com.netflix.iep.service.ServiceManager
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.slf4j.LoggerFactory
+
+object Main {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private def getBaseModules: java.util.List[Module] = {
+    val modules = GuiceHelper.getModulesUsingServiceLoader
+    if (!sys.env.contains("NETFLIX_ENVIRONMENT")) {
+      // If we are running in a local environment provide simple version of the config
+      // binding. These bindings are normally provided by the final package
+      // config for the app in the production setup.
+      modules.add(new AbstractModule {
+        override def configure(): Unit = {
+          bind(classOf[Config]).toInstance(ConfigFactory.load())
+        }
+      })
+    }
+    modules
+  }
+
+  def main(args: Array[String]): Unit = {
+    try {
+      val modules = getBaseModules
+      modules.add(new AppModule)
+      val guice = new GuiceHelper
+      guice.start(modules)
+      guice.getInjector.getInstance(classOf[ServiceManager])
+      guice.addShutdownHook()
+    } catch {
+      // Send exceptions to main log file instead of wherever STDERR is sent for the process
+      case t: Throwable => logger.error("fatal error on startup", t)
+    }
+  }
+
+}

--- a/iep-lwc-cloudwatch/src/test/scala/com/netflix/iep/lwc/ForwardingServiceSuite.scala
+++ b/iep-lwc-cloudwatch/src/test/scala/com/netflix/iep/lwc/ForwardingServiceSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc
+
+import org.scalatest.FunSuite
+
+class ForwardingServiceSuite extends FunSuite {
+
+  import ForwardingService._
+
+  private val version =
+    """{"ts":1505226236957,"hash":"2d4d"}"""
+
+  private val versionWithUser =
+    """{"ts":1505226236957,"hash":"2d4d","user":"brh","comment":"update"}"""
+
+  private val expr =
+    """name,http.req.complete,:eq,statistic,count,:eq,:and,:sum,(,nf.account,nf.asg,),:by"""
+
+  private val payload =
+    s"""{"email":"bob@example.com","expressions":[{"atlasUri":"$expr","account":"$$(nf.account)","metricName":"requestsPerSecond","dimensions":[{"name":"AutoScalingGroupName","value":"$$(nf.asg)"}]}]}"""
+
+  test("parse update response") {
+    val sample = s"""cluster->{"version":$versionWithUser,"payload":$payload}"""
+    val msg = Message(sample)
+
+    val expectedResponse = ConfigBinResponse(
+      ConfigBinVersion(1505226236957L, "2d4d", Some("brh"), Some("update")),
+      ClusterConfig("bob@example.com", List(
+        ForwardingExpression(
+          atlasUri = expr,
+          account = "$(nf.account)",
+          metricName = "requestsPerSecond",
+          dimensions = List(
+            ForwardingDimension("AutoScalingGroupName", "$(nf.asg)")
+          ))
+      ))
+    )
+
+    assert(msg.cluster === "cluster")
+    assert(msg.response.isUpdate)
+    assert(msg.response === expectedResponse)
+  }
+
+  test("parse delete response") {
+    val sample = s"""cluster->{"version":$version,"payload":""}"""
+    val msg = Message(sample)
+
+    val expectedResponse = ConfigBinResponse.delete(ConfigBinVersion(1505226236957L, "2d4d"))
+
+    assert(msg.cluster === "cluster")
+    assert(msg.response.isDelete)
+    assert(msg.response === expectedResponse)
+  }
+
+  test("parse heartbeat") {
+    val sample = s"""heartbeat->1,i-12345,1a7fb69e-005c-4ebc-bf05-aba3386c682f,1"""
+    val msg = Message(sample)
+
+    val expectedResponse = ConfigBinResponse.delete(ConfigBinVersion(1505226236957L, "2d4d"))
+
+    assert(msg.cluster === "heartbeat")
+    assert(msg.isHeartbeat)
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,6 +26,7 @@ object Dependencies {
   val akkaTestkit        = "com.typesafe.akka" %% "akka-testkit" % akka
   val atlasJson          = "com.netflix.atlas_v1" %% "atlas-json" % atlas
   val atlasModuleAkka    = "com.netflix.atlas_v1" %% "atlas-module-akka" % atlas
+  val atlasModuleEval    = "com.netflix.atlas_v1" %% "atlas-module-eval" % atlas
   val atlasModuleWebApi  = "com.netflix.atlas_v1" %% "atlas-module-webapi" % atlas
   val awsCloudWatch      = "com.amazonaws" % "aws-java-sdk-cloudwatch" % aws
   val awsCore            = "com.amazonaws" % "aws-java-sdk-core" % aws


### PR DESCRIPTION
This is a simple experimental app that receives configs
from ConfigBin, evaluates the expressions using LWC, and
then forwards the results to CloudWatch. The use-case is
to drive auto-scaling policies based on custom metrics.