### PR TITLE
fix the recovery for cloudwatch put

### DIFF
--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
@@ -200,15 +200,15 @@ object ForwardingService extends StrictLogging {
       .flatMapConcat { request =>
         val pub = Pagination.createPublisher(request, r => cwClient.putMetricData(r))
         Source.fromPublisher(pub)
-      }
-      .map { response =>
-        logger.debug(s"cloudwatch put result: $response")
-        NotUsed
-      }
-      .recover {
-        case t: Throwable =>
-          logger.warn("cloudwatch request failed", t)
-          NotUsed
+          .map { response =>
+            logger.debug(s"cloudwatch put result: $response")
+            NotUsed
+          }
+          .recover {
+            case t: Throwable =>
+              logger.warn("cloudwatch request failed", t)
+              NotUsed
+          }
       }
   }
 


### PR DESCRIPTION
Moved to the source to ensure that the flow doesn't stop
and cause the overall stream to fail.