### PR TITLE
use SmallHashMap.asJavaMap

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   object Versions {
     val akka       = "2.5.4"
     val akkaHttpV  = "10.0.10"
-    val atlas      = "1.6.0-rc.6"
+    val atlas      = "1.6.0-SNAPSHOT"
     val aws        = "1.11.185"
     val iep        = "1.0.4"
     val guice      = "4.1.0"


### PR DESCRIPTION
When passing the tags to the evaluator it will end up
doing a lot of get and contains calls on the java map.
The custom wrapper is more efficient for those use-cases
and avoids the object allocation.