### PR TITLE
add minimal example app to stream from lwc

### DIFF
--- a/atlas-stream/src/main/resources/application.conf
+++ b/atlas-stream/src/main/resources/application.conf
@@ -1,0 +1,8 @@
+
+atlas.akka {
+  api-endpoints = [
+    "com.netflix.atlas.akka.ConfigApi",
+    "com.netflix.atlas.akka.HealthcheckApi",
+    "com.netflix.atlas.stream.StreamApi"
+  ]
+}

--- a/atlas-stream/src/main/scala/com/netflix/atlas/stream/Main.scala
+++ b/atlas-stream/src/main/scala/com/netflix/atlas/stream/Main.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.stream
+
+import com.google.inject.AbstractModule
+import com.google.inject.Module
+import com.netflix.iep.guice.GuiceHelper
+import com.netflix.iep.service.ServiceManager
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.slf4j.LoggerFactory
+
+object Main {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private def getBaseModules: java.util.List[Module] = {
+    val modules = GuiceHelper.getModulesUsingServiceLoader
+    if (!sys.env.contains("NETFLIX_ENVIRONMENT")) {
+      // If we are running in a local environment provide simple version of the config
+      // binding. These bindings are normally provided by the final package
+      // config for the app in the production setup.
+      modules.add(new AbstractModule {
+        override def configure(): Unit = {
+          bind(classOf[Config]).toInstance(ConfigFactory.load())
+          bind(classOf[Registry]).toInstance(new NoopRegistry)
+        }
+      })
+    }
+    modules
+  }
+
+  def main(args: Array[String]): Unit = {
+    try {
+      val modules = getBaseModules
+      val guice = new GuiceHelper
+      guice.start(modules)
+      guice.getInjector.getInstance(classOf[ServiceManager])
+      guice.addShutdownHook()
+    } catch {
+      // Send exceptions to main log file instead of wherever STDERR is sent for the process
+      case t: Throwable => logger.error("fatal error on startup", t)
+    }
+  }
+
+}

--- a/atlas-stream/src/main/scala/com/netflix/atlas/stream/StreamApi.scala
+++ b/atlas-stream/src/main/scala/com/netflix/atlas/stream/StreamApi.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.stream
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.MediaTypes
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import com.netflix.atlas.akka.WebApi
+import com.netflix.atlas.eval.stream.Evaluator
+
+
+class StreamApi(evaluator: Evaluator) extends WebApi {
+
+  private val prefix = ByteString("data: ")
+  private val suffix = ByteString("\r\n")
+
+  def routes: Route = {
+    path("stream" / RemainingPath) { path =>
+      get {
+        extractUri { uri =>
+          val q = uri.rawQueryString.getOrElse("")
+          val atlasUri = s"$path?$q"
+          val src = Source.fromPublisher(evaluator.createPublisher(atlasUri))
+            .map { obj =>
+              prefix ++ ByteString(obj.toJson) ++ suffix
+            }
+          val entity = HttpEntity(MediaTypes.`text/event-stream`, src)
+          complete(HttpResponse(StatusCodes.OK, entity = entity))
+        }
+      }
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,26 @@
 lazy val root = project.in(file("."))
   .configure(BuildSettings.profile)
   .aggregate(
+    `atlas-stream`,
     `iep-archaius`,
     `iep-atlas`,
     `iep-lwc-bridge`,
     `iep-lwc-cloudwatch`)
   .settings(BuildSettings.noPackaging: _*)
+
+lazy val `atlas-stream` = project
+  .configure(BuildSettings.profile)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.atlasModuleAkka,
+    Dependencies.atlasModuleEval,
+    Dependencies.iepGuice,
+    Dependencies.log4jApi,
+    Dependencies.log4jCore,
+    Dependencies.log4jSlf4j,
+
+    Dependencies.akkaHttpTestkit % "test",
+    Dependencies.scalatest % "test"
+  ))
 
 lazy val `iep-archaius` = project
   .configure(BuildSettings.profile)


### PR DESCRIPTION
This app provides a single endpoint `/stream` that takes
and atlas URI as the rest of the path. For example:

```
/stream/http://atlas/api/v1/graph?q=name,rps,:sum
```