### PR TITLE
add heartbeats to ensure frequent traffic

### DIFF
--- a/atlas-stream/src/main/scala/com/netflix/atlas/stream/StreamApi.scala
+++ b/atlas-stream/src/main/scala/com/netflix/atlas/stream/StreamApi.scala
@@ -21,10 +21,13 @@ import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
+import akka.stream.ThrottleMode
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import com.netflix.atlas.akka.WebApi
 import com.netflix.atlas.eval.stream.Evaluator
+
+import scala.concurrent.duration._
 
 
 class StreamApi(evaluator: Evaluator) extends WebApi {
@@ -32,16 +35,23 @@ class StreamApi(evaluator: Evaluator) extends WebApi {
   private val prefix = ByteString("data: ")
   private val suffix = ByteString("\r\n")
 
+  private val heartbeat = ByteString(s"""data: {"type":"heartbeat"}\r\n""")
+
   def routes: Route = {
     path("stream" / RemainingPath) { path =>
       get {
         extractUri { uri =>
           val q = uri.rawQueryString.getOrElse("")
           val atlasUri = s"$path?$q"
+
+          val heartbeatSrc = Source.repeat(heartbeat)
+            .throttle(1, 5.seconds, 1, ThrottleMode.Shaping)
+
           val src = Source.fromPublisher(evaluator.createPublisher(atlasUri))
             .map { obj =>
               prefix ++ ByteString(obj.toJson) ++ suffix
             }
+            .merge(heartbeatSrc)
           val entity = HttpEntity(MediaTypes.`text/event-stream`, src)
           complete(HttpResponse(StatusCodes.OK, entity = entity))
         }


### PR DESCRIPTION
To make sure there aren't any timeouts when running
using a larger step size, this change will output a
heartbeat message every 5 seconds.