### PR TITLE
additional build metadata for jar file

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -39,7 +39,13 @@ object BuildSettings {
       IO.write(
         credentialsFile,
         bintray.BintrayCredentials.api.template(Bintray.user, Bintray.pass))
-    }
+    },
+
+    packageOptions in (Compile, packageBin) += Package.ManifestAttributes(
+      "Build-Date"   -> java.time.Instant.now().toString,
+      "Build-Number" -> sys.env.getOrElse("TRAVIS_BUILD_NUMBER", "unknown"),
+      "Commit"       -> sys.env.getOrElse("TRAVIS_COMMIT", "unknown")
+    )
   )
 
   val commonDeps = Seq(


### PR DESCRIPTION
Adds the build time and commit into the manifest for the
jar file to aide in debugging.