### PR TITLE
fix ending to use CRLFCRLF

### DIFF
--- a/atlas-stream/src/main/scala/com/netflix/atlas/stream/StreamApi.scala
+++ b/atlas-stream/src/main/scala/com/netflix/atlas/stream/StreamApi.scala
@@ -33,9 +33,9 @@ import scala.concurrent.duration._
 class StreamApi(evaluator: Evaluator) extends WebApi {
 
   private val prefix = ByteString("data: ")
-  private val suffix = ByteString("\r\n")
+  private val suffix = ByteString("\r\n\r\n")
 
-  private val heartbeat = ByteString(s"""data: {"type":"heartbeat"}\r\n""")
+  private val heartbeat = ByteString(s"""data: {"type":"heartbeat"}\r\n\r\n""")
 
   def routes: Route = {
     path("stream" / RemainingPath) { path =>


### PR DESCRIPTION
Before it was just doing it once and the brower doesn't
seem to like it. Doubled it up and tested with javacript
EventSource:

```html
<html>
<head>
  <title>SSE test</title>
</head>
<body>
  <pre id="content"></pre>
  <script>
  var uri = "http://localhost:7101/stream/http://localhost:7001/api/v1/graph?q=name,ssCpu,:re,:avg,(,name,),:by";
  var source = new EventSource(uri);
  source.onmessage = function(event) {
    document.getElementById("content").innerHTML += event.data + "\n";
  };
  </script>
</body>
</html>
```