### PR TITLE
adjust values to fit CloudWatch restrictions

### DIFF
--- a/iep-lwc-cloudwatch/src/test/scala/com/netflix/iep/lwc/ForwardingServiceSuite.scala
+++ b/iep-lwc-cloudwatch/src/test/scala/com/netflix/iep/lwc/ForwardingServiceSuite.scala
@@ -75,4 +75,32 @@ class ForwardingServiceSuite extends FunSuite {
     assert(msg.cluster === "heartbeat")
     assert(msg.isHeartbeat)
   }
+
+  //
+  // CloudWatch Truncate tests
+  //
+
+  test("truncate: NaN") {
+    assert(truncate(Double.NaN) === 0.0)
+  }
+
+  test("truncate: Infinity") {
+    assert(truncate(Double.PositiveInfinity) === math.pow(2.0, 360))
+  }
+
+  test("truncate: -Infinity") {
+    assert(truncate(Double.NegativeInfinity) === -math.pow(2.0, 360))
+  }
+
+  test("truncate: large value") {
+    assert(truncate(math.pow(2.0, 400)) === math.pow(2.0, 360))
+  }
+
+  test("truncate: negative large value") {
+    assert(truncate(-math.pow(2.0, 400)) === -math.pow(2.0, 360))
+  }
+
+  test("truncate: large negative exponent") {
+    assert(truncate(math.pow(2.0, -400)) === 0.0)
+  }
 }


### PR DESCRIPTION
To reduce the number of put calls, the sends to CloudWatch
are batched. The downside is that if a value is invalid, then
the whole batch gets rejected. In particular, we were seeing
NaN values cause the batch to fail with:

```
com.amazonaws.services.cloudwatch.model.InvalidParameterValueException:
  The value ? for parameter MetricData.member.1.Value is invalid.
  (Service: AmazonCloudWatch; Status Code: 400;
   Error Code: InvalidParameterValue; Request ID: XYZ)
```

This change adds a truncate step that coerces the value to
fit the CloudWatch restrictions. The truncation logic was
borrowed from the Servo library and has been used for many
years in that library.