### PR TITLE
add client test app

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,18 @@ lazy val `iep-atlas` = project
     Dependencies.log4jSlf4j
   ))
 
+lazy val `iep-clienttest` = project
+  .configure(BuildSettings.profile)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.atlasModuleAkka,
+    Dependencies.iepGuice,
+    Dependencies.log4jApi,
+    Dependencies.log4jCore,
+    Dependencies.log4jSlf4j,
+    Dependencies.servoCore,
+    Dependencies.spectatorApi
+  ))
+
 lazy val `iep-lwc-bridge` = project
   .configure(BuildSettings.profile)
   .settings(libraryDependencies ++= Seq(

--- a/iep-clienttest/README.md
+++ b/iep-clienttest/README.md
@@ -1,0 +1,6 @@
+## Description
+
+Minimal application for testing the client library. It creates a configurable number of metrics
+of various types so we can see how much overhead is present in terms of local memory use,
+CPU overhead, etc. The app can be bundled with the Atlas or Servo registries to see what the
+publication overhead is.

--- a/iep-clienttest/src/main/resources/application.conf
+++ b/iep-clienttest/src/main/resources/application.conf
@@ -1,0 +1,12 @@
+netflix.iep.clienttest {
+
+  class = "com.netflix.iep.clienttest.SpectatorMetricLibrary"
+
+  tags-per-metric = 10
+  num-counters = 100000
+  num-timers = 100000
+  num-dist-summaries = 100000
+  num-gauges = 10000
+  num-polled-gauges = 100
+  num-slow-polled-gauges = 2
+}

--- a/iep-clienttest/src/main/resources/log4j2.xml
+++ b/iep-clienttest/src/main/resources/log4j2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn">
+    <Properties>
+        <Property name="dfltPattern">%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %-5level [%t] %class: %msg%n</Property>
+    </Properties>
+    <Appenders>
+        <Console name="STDERR" target="SYSTEM_ERR">
+            <PatternLayout pattern="${dfltPattern}"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.netflix.spectator" level="debug"/>
+        <Root level="info">
+            <AppenderRef ref="STDERR"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/iep-clienttest/src/main/scala/com/netflix/iep/clienttest/InstrumentationService.scala
+++ b/iep-clienttest/src/main/scala/com/netflix/iep/clienttest/InstrumentationService.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.clienttest
+
+import java.util.UUID
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+import com.netflix.iep.service.AbstractService
+import com.typesafe.config.Config
+import org.slf4j.LoggerFactory
+
+@Singleton
+class InstrumentationService @Inject() (config: Config, metrics: MetricLibrary) extends AbstractService {
+
+  private val logger = LoggerFactory.getLogger("")
+
+  private val tagsPerMetric = config.getInt("netflix.iep.clienttest.tags-per-metric")
+
+  private val numCounters = config.getInt("netflix.iep.clienttest.num-counters")
+  private val numTimers = config.getInt("netflix.iep.clienttest.num-timers")
+  private val numDistSummaries = config.getInt("netflix.iep.clienttest.num-dist-summaries")
+  private val numGauges = config.getInt("netflix.iep.clienttest.num-gauges")
+  private val numPolledGauges = config.getInt("netflix.iep.clienttest.num-polled-gauges")
+  private val numSlowPolledGauges = config.getInt("netflix.iep.clienttest.num-slow-polled-gauges")
+
+  // To minimize other noise in terms of memory use and computation we use the same base tag
+  // set for all metrics.
+  private val tagsData = (0 until tagsPerMetric)
+    .map { i =>
+      val key = f"$i%05d"
+      key -> UUID.randomUUID().toString
+    }
+    .toMap
+
+  private val executor = Executors.newScheduledThreadPool(2)
+  executor.scheduleWithFixedDelay(() => update(), 0L, 10, TimeUnit.SECONDS)
+
+  // Polled sources only need to be registered once
+  (0 until numPolledGauges).foreach { i =>
+    metrics.poll("polledGauge", createTags(i), i.toDouble)
+  }
+  (0 until numSlowPolledGauges).foreach { i =>
+    metrics.poll("slowPolledGauge", createTags(i), {
+      Thread.sleep(120000)
+      i.toDouble
+    })
+  }
+
+  private def update(): Unit = {
+    logger.info("update starting")
+    logger.info(s"updating $numCounters counters")
+    (0 until numCounters).foreach { i =>
+      metrics.increment("counter", createTags(i))
+    }
+    logger.info(s"updating $numTimers timers")
+    (0 until numTimers).foreach { i =>
+      metrics.recordTime("timer", createTags(i), i)
+    }
+    logger.info(s"updating $numDistSummaries distribution summaries")
+    (0 until numDistSummaries).foreach { i =>
+      metrics.recordTime("distSummary", createTags(i), i)
+    }
+    logger.info(s"updating $numGauges gauges")
+    (0 until numGauges).foreach { i =>
+      metrics.set("gauge", createTags(i), i)
+    }
+    logger.info("update complete")
+  }
+
+  private def createTags(i: Int): Map[String, String] = {
+    tagsData + ("id" -> i.toString)
+  }
+
+  override def startImpl(): Unit = ()
+
+  override def stopImpl(): Unit = {
+    executor.shutdownNow()
+  }
+}

--- a/iep-clienttest/src/main/scala/com/netflix/iep/clienttest/Main.scala
+++ b/iep-clienttest/src/main/scala/com/netflix/iep/clienttest/Main.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.clienttest
+
+import com.google.inject.AbstractModule
+import com.google.inject.Module
+import com.google.inject.multibindings.Multibinder
+import com.netflix.iep.guice.GuiceHelper
+import com.netflix.iep.service.Service
+import com.netflix.iep.service.ServiceManager
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.slf4j.LoggerFactory
+
+object Main {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private val config = ConfigFactory.load()
+
+  private def getBaseModules: java.util.List[Module] = {
+    val modules = GuiceHelper.getModulesUsingServiceLoader
+    if (!sys.env.contains("NETFLIX_ENVIRONMENT")) {
+      // If we are running in a local environment provide simple versions of registry
+      // and config bindings. These bindings are normally provided by the final package
+      // config for the app in the production setup.
+      modules.add(new AbstractModule {
+        override def configure(): Unit = {
+          bind(classOf[Registry]).toInstance(new NoopRegistry)
+          bind(classOf[Config]).toInstance(config)
+        }
+      })
+    }
+    modules
+  }
+
+  def main(args: Array[String]): Unit = {
+    try {
+      val modules = getBaseModules
+      modules.add(new InstrumentationModule)
+      val guice = new GuiceHelper
+      guice.start(modules)
+      guice.getInjector.getInstance(classOf[ServiceManager])
+      guice.addShutdownHook()
+    } catch {
+      // Send exceptions to main log file instead of wherever STDERR is sent for the process
+      case t: Throwable => logger.error("fatal error on startup", t)
+    }
+  }
+
+  class InstrumentationModule extends AbstractModule {
+    override def configure(): Unit = {
+      val cls = Class.forName(config.getString("netflix.iep.clienttest.class"))
+      bind(classOf[MetricLibrary]).to(cls.asInstanceOf[Class[MetricLibrary]])
+
+      val serviceBinder = Multibinder.newSetBinder(binder(), classOf[Service])
+      serviceBinder.addBinding().to(classOf[InstrumentationService])
+      bind(classOf[InstrumentationService])
+    }
+  }
+}

--- a/iep-clienttest/src/main/scala/com/netflix/iep/clienttest/MetricLibrary.scala
+++ b/iep-clienttest/src/main/scala/com/netflix/iep/clienttest/MetricLibrary.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.clienttest
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+import com.netflix.servo.monitor.BasicDistributionSummary
+import com.netflix.servo.monitor.BasicGauge
+import com.netflix.servo.monitor.DoubleGauge
+import com.netflix.servo.monitor.DynamicCounter
+import com.netflix.servo.monitor.DynamicTimer
+import com.netflix.servo.monitor.MonitorConfig
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.patterns.PolledMeter
+
+trait MetricLibrary {
+  def increment(name: String, tags: Map[String, String]): Unit
+
+  def recordTime(name: String, tags: Map[String, String], amount: Long): Unit
+
+  def recordAmount(name: String, tags: Map[String, String], amount: Long): Unit
+
+  def set(name: String, tags: Map[String, String], v: Double): Unit
+
+  def poll(name: String, tags: Map[String, String], f: => Double): Unit
+}
+
+@Singleton
+class ServoMetricLibrary extends MetricLibrary {
+
+  type JDouble = java.lang.Double
+
+  private val distSummaries = new ConcurrentHashMap[MonitorConfig, BasicDistributionSummary]()
+  private val gauges = new ConcurrentHashMap[MonitorConfig, DoubleGauge]()
+  private val polledGauges = new ConcurrentHashMap[MonitorConfig, BasicGauge[JDouble]]()
+
+  private def toMonitorConfig(name: String, tags: Map[String, String]): MonitorConfig = {
+    tags
+      .foldLeft(MonitorConfig.builder(name)) { (builder, t) =>
+        builder.withTag(t._1, t._2)
+      }
+      .build()
+  }
+
+  override def increment(name: String, tags: Map[String, String]): Unit = {
+    DynamicCounter.increment(toMonitorConfig(name, tags))
+  }
+
+  override def recordTime(name: String, tags: Map[String, String], amount: Long): Unit = {
+    DynamicTimer.record(toMonitorConfig(name, tags), TimeUnit.SECONDS, amount, TimeUnit.NANOSECONDS)
+  }
+
+  override def recordAmount(name: String, tags: Map[String, String], amount: Long): Unit = {
+    val config = toMonitorConfig(name, tags)
+    distSummaries.computeIfAbsent(config, c => new BasicDistributionSummary(c)).record(amount)
+  }
+
+  override def set(name: String, tags: Map[String, String], v: Double): Unit = {
+    val config = toMonitorConfig(name, tags)
+    gauges.computeIfAbsent(config, c => new DoubleGauge(c)).set(v)
+  }
+
+  override def poll(name: String, tags: Map[String, String], f: => Double): Unit = {
+    val config = toMonitorConfig(name, tags)
+    polledGauges.computeIfAbsent(config, c => new BasicGauge[JDouble](c, () => f))
+  }
+}
+
+@Singleton
+class SpectatorMetricLibrary @Inject() (registry: Registry) extends MetricLibrary {
+
+  private def toId(name: String, tags: Map[String, String]): Id = {
+    tags.foldLeft(registry.createId(name)) { (id, t) =>
+      id.withTag(t._1, t._2)
+    }
+  }
+
+  override def increment(name: String, tags: Map[String, String]): Unit = {
+    registry.counter(toId(name, tags)).increment()
+  }
+
+  override def recordTime(name: String, tags: Map[String, String], amount: Long): Unit = {
+    registry.timer(toId(name, tags)).record(amount, TimeUnit.NANOSECONDS)
+  }
+
+  override def recordAmount(name: String, tags: Map[String, String], amount: Long): Unit = {
+    registry.distributionSummary(toId(name, tags)).record(amount)
+  }
+
+  override def set(name: String, tags: Map[String, String], v: Double): Unit = {
+    registry.gauge(toId(name, tags)).set(v)
+  }
+
+  override def poll(name: String, tags: Map[String, String], f: => Double): Unit = {
+    PolledMeter.using(registry)
+      .withId(toId(name, tags))
+      .monitorValue(this, (obj: MetricLibrary) => f)
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,7 @@ object Dependencies {
     val jackson    = "2.8.9"
     val log4j      = "2.9.0"
     val scala      = "2.12.3"
+    val servo      = "0.12.17"
     val slf4j      = "1.7.25"
     val spectator  = "0.57.1"
 
@@ -69,6 +70,7 @@ object Dependencies {
   val scalaLogging       = "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"
   val scalaReflect       = "org.scala-lang" % "scala-reflect" % scala
   val scalatest          = "org.scalatest" %% "scalatest" % "3.0.0"
+  val servoCore          = "com.netflix.servo" % "servo-core" % servo
   val slf4jApi           = "org.slf4j" % "slf4j-api" % slf4j
   val slf4jLog4j         = "org.slf4j" % "slf4j-log4j12" % slf4j
   val slf4jSimple        = "org.slf4j" % "slf4j-simple" % slf4j


### PR DESCRIPTION
This is a simple application for testing the overhead
of the client. It creates a configurable number of metrics
of various types. The immediate use-case is to look into
some slowdowns we are seeing in collecting metrics due
to meltdown remediations.