### PR TITLE
add support for publishing to multiple accounts

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val akkaHttpV  = "10.0.10"
     val atlas      = "1.6.0-SNAPSHOT"
     val aws        = "1.11.185"
-    val iep        = "1.0.4"
+    val iep        = "1.2.0"
     val guice      = "4.1.0"
     val jackson    = "2.8.9"
     val log4j      = "2.9.0"


### PR DESCRIPTION
For some of our use-cases the same forwarder cluster will
be used for supporting multiple AWS accounts. With this
change it will now honor the account field in the config.