### PR TITLE
use QueryIndex for LWC bridge

### DIFF
--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExpressionsEvaluator.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExpressionsEvaluator.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc
+
+import java.util.concurrent.atomic.AtomicReference
+
+import com.netflix.atlas.core.index.QueryIndex
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.QueryVocabulary
+import com.netflix.atlas.core.stacklang.Interpreter
+import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.spectator.atlas.impl.DataExpr.Aggregator
+import com.netflix.spectator.atlas.impl.EvalPayload
+import com.netflix.spectator.atlas.impl.Subscription
+import com.netflix.spectator.atlas.impl.TagsValuePair
+
+/**
+  * Evaluate a set of data expressions from the LWC API service. This performs the same
+  * basic role as the Evaluator class from the Spectator Atlas registry, but leverages the
+  * query index from Atlas so it can scale to a much larger set of expressions.
+  */
+class ExpressionsEvaluator {
+  import ExpressionsEvaluator._
+
+  private val indexRef = new AtomicReference[QueryIndex[Subscription]](emptyIndex)
+
+  /**
+    * Synchronize the set of subscriptions for this evaluator with the specified list. Typically
+    * the list will come from the `/expressions` endpoint of the LWC API service.
+    */
+  def sync(subs: SubscriptionList): Unit = {
+    import scala.collection.JavaConverters._
+    val index = QueryIndex.create(subs.asScala.map(toEntry).toList)
+
+    // TODO: send diagnostic message about ignored expressions.
+    // The top level fallback entries are removed to greatly reduce the cost. These entries
+    // would need to get checked against every datapoint and are typically costly regex queries.
+    // For a simple test remove the 46 top-level fallback expressions of 18.5k overall improved
+    // throughput by 3x.
+    indexRef.set(index.copy(entries = Nil))
+  }
+
+  private def toEntry(sub: Subscription): QueryIndex.Entry[Subscription] = {
+    // Convert from spectator Query object to atlas Query object needed for the index
+    val atlasQuery = parseQuery(sub.dataExpr().query().toString)
+    QueryIndex.Entry(atlasQuery, sub)
+  }
+
+  /**
+    * Evaluate a set of datapoints and generate a payload for the `/evaluate` endpoint
+    * of the LWC API service.
+    */
+  def eval(timestamp: Long, values: List[Datapoint]): EvalPayload = {
+    val index = indexRef.get
+    val aggregates = collection.mutable.AnyRefMap.empty[String, Aggregator]
+    values.foreach { v =>
+      val subs = index.matchingEntries(v.tags)
+      subs.foreach { sub =>
+        // TODO: avoid duplicate check of query when spectator 0.62.0 is released
+        val aggr = aggregates.getOrElseUpdate(sub.getId, sub.dataExpr().aggregator())
+        aggr.update(toPair(v))
+      }
+    }
+
+    val metrics = new MetricList
+    aggregates.toList.foreach {
+      case (id, aggr) =>
+        aggr.result().forEach { pair =>
+          val m = new EvalPayload.Metric(id, pair.tags(), pair.value())
+          metrics.add(m)
+        }
+    }
+
+    new EvalPayload(timestamp, metrics)
+  }
+
+  private def toPair(d: Datapoint): TagsValuePair = {
+    import scala.collection.JavaConverters._
+    // Use custom java map wrapper from SmallHashMap if possible for improved
+    // performance during the eval.
+    val jmap = d.tags match {
+      case m: SmallHashMap[_, _] => m.asInstanceOf[SmallHashMap[String, String]].asJavaMap
+      case m                     => m.asJava
+    }
+    new TagsValuePair(jmap, d.value)
+  }
+}
+
+object ExpressionsEvaluator {
+  private val interpreter = Interpreter(QueryVocabulary.words)
+
+  private val emptyIndex = QueryIndex.create[Subscription](Nil)
+
+  def parseQuery(str: String): Query = {
+    val stack = interpreter.execute(str).stack
+    require(stack.lengthCompare(1) == 0, s"invalid query: $str")
+    stack.head.asInstanceOf[Query]
+  }
+}

--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/package.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/package.scala
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.iep.lwc
+package com.netflix.iep
 
-import com.google.inject.AbstractModule
+import com.netflix.spectator.atlas.impl.EvalPayload
+import com.netflix.spectator.atlas.impl.Subscription
 
-class AppModule extends AbstractModule {
-  override def configure(): Unit = {
-    bind(classOf[ExpressionsEvaluator]).toInstance(new ExpressionsEvaluator)
-  }
+package object lwc {
+  type SubscriptionList = java.util.List[Subscription]
+  type JMap = java.util.Map[String, String]
+
+  type MetricList = java.util.ArrayList[EvalPayload.Metric]
 }

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExpressionsEvaluatorSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExpressionsEvaluatorSuite.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc
+
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.spectator.atlas.impl.Subscription
+import org.scalatest.FunSuite
+
+class ExpressionsEvaluatorSuite extends FunSuite {
+
+  import scala.collection.JavaConverters._
+
+  // pick an arbitrary time
+  private val timestamp = 42 * 60000
+
+  private def createSubs(exprs: String*): SubscriptionList = {
+    val subs = exprs.zipWithIndex.map {
+      case (expr, i) =>
+        new Subscription()
+          .withId(i.toString)
+          .withFrequency(60000)
+          .withExpression(expr)
+    }
+    subs.asJava
+  }
+
+  private def data(values: Double*): List[Datapoint] = {
+    values.toList.zipWithIndex.map {
+      case (v, i) =>
+        val tags = Map(
+          "name" -> "cpu",
+          "node" -> f"i-$i%02d"
+        )
+        Datapoint(tags, timestamp, v, 60000)
+    }
+  }
+
+  test("eval with no expressions") {
+    val evaluator = new ExpressionsEvaluator
+    val payload = evaluator.eval(timestamp, data(1.0))
+    assert(payload.getTimestamp === timestamp)
+    assert(payload.getMetrics.isEmpty)
+  }
+
+  test("eval with single expression") {
+    val evaluator = new ExpressionsEvaluator
+    evaluator.sync(createSubs("node,i-00,:eq,:sum"))
+    val payload = evaluator.eval(timestamp, data(1.0))
+    assert(payload.getTimestamp === timestamp)
+    assert(payload.getMetrics.size() === 1)
+
+    val m = payload.getMetrics.get(0)
+    assert(m.getId === "0")
+    assert(m.getValue === 1.0)
+  }
+
+  test("eval with multiple datapoints for an aggregate") {
+    val evaluator = new ExpressionsEvaluator
+    evaluator.sync(createSubs("node,i-00,:eq,:sum"))
+    val payload = evaluator.eval(timestamp, data(1.0) ::: data(4.0))
+    assert(payload.getTimestamp === timestamp)
+    assert(payload.getMetrics.size() === 1)
+
+    val m = payload.getMetrics.get(0)
+    assert(m.getId === "0")
+    assert(m.getValue === 5.0)
+  }
+
+  test("eval with multiple expressions") {
+    val evaluator = new ExpressionsEvaluator
+    evaluator.sync(createSubs("node,i-00,:eq,:sum", "node,i-00,:eq,:max"))
+    val payload = evaluator.eval(timestamp, data(1.0) ::: data(4.0))
+    assert(payload.getTimestamp === timestamp)
+    assert(payload.getMetrics.size() === 2)
+
+    payload.getMetrics.asScala.foreach { m =>
+      val expected = if (m.getId == "0") 5.0 else 4.0
+      assert(m.getValue === expected)
+    }
+  }
+
+  test("sync: add/remove expressions") {
+    val evaluator = new ExpressionsEvaluator
+    evaluator.sync(createSubs("node,i-00,:eq,:sum"))
+    var payload = evaluator.eval(timestamp, data(1.0) ::: data(4.0))
+    assert(payload.getMetrics.size() === 1)
+    assert(payload.getMetrics.get(0).getValue === 5.0)
+
+    // Add expression
+    evaluator.sync(createSubs("node,i-00,:eq,:sum", "node,i-00,:eq,:max"))
+    payload = evaluator.eval(timestamp, data(1.0) ::: data(4.0))
+    assert(payload.getMetrics.size() === 2)
+
+    // Remove expression
+    evaluator.sync(createSubs("node,i-00,:eq,:max"))
+    payload = evaluator.eval(timestamp, data(1.0) ::: data(4.0))
+    assert(payload.getMetrics.size() === 1)
+    assert(payload.getMetrics.get(0).getValue === 4.0)
+  }
+}


### PR DESCRIPTION
Refactors the expression evaluation for the LWC bridge
to levarage the Atlas query index. Before it was only
segmenting by application. If a larger portion of the
queries due not have an exact match on application,
cluster, or asg, then we cannot extract an application
and they would get placed in the catch all bucket.
Expressions in the catch all must be checked against
all datapoints flowing through the system.

With the query index we can drill down based on any
equal clauses in the query. For the actual data set
that was causing problems there are 18.5k expressions
and 2500 were in the catch all bucket. Using the query
index that top-level fallback set reduced to 46. As
a further optimization we are now ignoring those top-level
fallbacks from the index and requiring the user to be
more restrictive on the query.