### PR TITLE
pass query in as filter to druid group by

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -221,6 +221,7 @@ class DruidDatabaseActor(config: Config) extends Actor with StrictLogging {
         dimensions = dimensions,
         intervals = intervals,
         aggregations = List(toAggregation(name, expr)),
+        filter = DruidFilter.forQuery(query),
         granularity = Granularity.millis(context.step)
       )
       client.groupBy(groupByQuery).map { result =>


### PR DESCRIPTION
When fetching the data form Druid the query was being
used to select the datasource and name, but was ignored
after that. Now it is converted to a filter and passed
to the group by request that is sent to Druid.