### PR TITLE
fix test case to add groupByKeys

### DIFF
--- a/iep-lwc-cloudwatch/src/test/scala/com/netflix/iep/lwc/ForwardingServiceSuite.scala
+++ b/iep-lwc-cloudwatch/src/test/scala/com/netflix/iep/lwc/ForwardingServiceSuite.scala
@@ -138,6 +138,7 @@ class ForwardingServiceSuite extends FunSuite {
     val msg = TimeSeriesMessage(
       id = "abc",
       query = "name,ssCpuUser,:eq,:sum",
+      groupByKeys = Nil,
       start = 0L,
       end = 60000L,
       step = 60000L,


### PR DESCRIPTION
The TimeSeriesMessage now expects the set of keys
used in the final grouping (Netflix/atlas#783).