### PR TITLE
initial version of aggregator service

### DIFF
--- a/atlas-aggregator/README.md
+++ b/atlas-aggregator/README.md
@@ -1,0 +1,8 @@
+
+## Description
+
+> :warning: Experimental
+
+Prototype for a service that receives delta updates from clients and applies them to a local
+Atlas registry. This can be used with shortlived systems like FaaS where the state cannot be
+maintained locally for the full step interval.

--- a/atlas-aggregator/src/main/resources/application.conf
+++ b/atlas-aggregator/src/main/resources/application.conf
@@ -1,0 +1,8 @@
+
+atlas.akka {
+  api-endpoints = [
+    "com.netflix.atlas.akka.ConfigApi",
+    "com.netflix.atlas.akka.HealthcheckApi",
+    "com.netflix.atlas.aggregator.UpdateApi"
+  ]
+}

--- a/atlas-aggregator/src/main/resources/log4j2.xml
+++ b/atlas-aggregator/src/main/resources/log4j2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn">
+    <Properties>
+        <Property name="dfltPattern">%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %-5level [%t] %class: %msg%n</Property>
+    </Properties>
+    <Appenders>
+        <Console name="STDERR" target="SYSTEM_ERR">
+            <PatternLayout pattern="${dfltPattern}"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.netflix.iep" level="debug"/>
+        <Logger name="com.netflix.spectator" level="debug"/>
+        <Root level="info">
+            <AppenderRef ref="STDERR"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AppModule.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AppModule.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.aggregator
+
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+
+import com.google.inject.AbstractModule
+import com.google.inject.multibindings.Multibinder
+import com.netflix.iep.service.AbstractService
+import com.netflix.iep.service.Service
+import com.netflix.spectator.api.Clock
+import com.netflix.spectator.atlas.AtlasConfig
+import com.netflix.spectator.atlas.AtlasRegistry
+import com.typesafe.config.Config
+
+class AppModule extends AbstractModule {
+
+  import AppModule._
+
+  override def configure(): Unit = {
+    val serviceBinder = Multibinder.newSetBinder(binder(), classOf[Service])
+    serviceBinder.addBinding().to(classOf[AtlasAggregatorService])
+
+    bind(classOf[AtlasRegistry]).toProvider(classOf[AtlasRegistryProvider])
+  }
+}
+
+object AppModule {
+  class AggrConfig(config: Config) extends AtlasConfig {
+
+    override def get(k: String): String = {
+      if (config.hasPath(s"netflix.atlas.aggr.registry.$k")) config.getString(k) else null
+    }
+
+    override def commonTags(): java.util.Map[String, String] = {
+      val tags = new java.util.HashMap[String, String]()
+      tags.put("atlas.aggr", config.getString("netflix.iep.env.instance-id"))
+      tags
+    }
+  }
+
+  @Singleton
+  class AtlasAggregatorService @Inject()(registry: AtlasRegistry) extends AbstractService {
+    override def startImpl(): Unit = {
+      registry.start()
+    }
+
+    override def stopImpl(): Unit = {
+      registry.stop()
+    }
+  }
+
+  @Singleton
+  class AtlasRegistryProvider @Inject()(config: Config) extends Provider[AtlasRegistry] {
+    override def get(): AtlasRegistry = {
+      val cfg = new AggrConfig(config)
+      new AtlasRegistry(Clock.SYSTEM, cfg)
+    }
+  }
+}

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/Main.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/Main.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.aggregator
+
+import com.google.inject.AbstractModule
+import com.google.inject.Module
+import com.netflix.iep.guice.GuiceHelper
+import com.netflix.iep.service.ServiceManager
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.slf4j.LoggerFactory
+
+object Main {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private def getBaseModules: java.util.List[Module] = {
+    val modules = GuiceHelper.getModulesUsingServiceLoader
+    modules.add(new AppModule)
+    if (!sys.env.contains("NETFLIX_ENVIRONMENT")) {
+      // If we are running in a local environment provide simple version of the config
+      // binding. These bindings are normally provided by the final package
+      // config for the app in the production setup.
+      modules.add(new AbstractModule {
+        override def configure(): Unit = {
+          bind(classOf[Config]).toInstance(ConfigFactory.load())
+          bind(classOf[Registry]).toInstance(new NoopRegistry)
+        }
+      })
+    }
+    modules
+  }
+
+  def main(args: Array[String]): Unit = {
+    try {
+      val modules = getBaseModules
+      val guice = new GuiceHelper
+      guice.start(modules)
+      guice.getInjector.getInstance(classOf[ServiceManager])
+      guice.addShutdownHook()
+    } catch {
+      // Send exceptions to main log file instead of wherever STDERR is sent for the process
+      case t: Throwable => logger.error("fatal error on startup", t)
+    }
+  }
+
+}

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/UpdateApi.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/UpdateApi.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.aggregator
+
+import javax.inject.Inject
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.MediaTypes
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonToken
+import com.netflix.atlas.akka.CustomDirectives._
+import com.netflix.atlas.akka.WebApi
+import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.atlas.eval.stream.Evaluator
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.atlas.AtlasRegistry
+import com.typesafe.scalalogging.StrictLogging
+
+
+class UpdateApi @Inject() (
+  evaluator: Evaluator,
+  aggrRegistry: AtlasRegistry
+) extends WebApi {
+
+  require(aggrRegistry != null, "no binding for aggregate registry")
+
+  import UpdateApi._
+
+  def routes: Route = {
+    path("api" / "v4" / "update") {
+      post {
+        parseEntity(customJson(p => processPayload(p, aggrRegistry))) { payload =>
+          val src = Source.single(ByteString("{}"))
+          val entity = HttpEntity(MediaTypes.`application/json`, src)
+          complete(HttpResponse(StatusCodes.OK, entity = entity))
+        }
+      }
+    }
+  }
+}
+
+object UpdateApi extends StrictLogging {
+
+  import com.netflix.atlas.json.JsonParserHelper._
+
+  type TagMap = SmallHashMap[String, String]
+
+  private val ADD = 0
+  private val MAX = 10
+
+  def processPayload(parser: JsonParser, registry: AtlasRegistry): Unit = {
+    requireNextToken(parser, JsonToken.START_ARRAY)
+    val numStrings = nextInt(parser)
+    val strings = loadStringTable(numStrings, parser)
+
+    var t = parser.nextToken()
+    while (t != null && t != JsonToken.END_ARRAY) {
+      val numTags = parser.getIntValue
+      val tags = loadTags(numTags, strings, parser)
+      // TODO: validate num tags and lengths
+      val op = nextInt(parser)
+      val value = nextDouble(parser)
+      val id = createId(registry, tags)
+      op match {
+        case ADD =>
+          logger.debug(s"received updated, ADD $id $value")
+          registry.doubleCounter(id).add(value)
+        case MAX =>
+          logger.debug(s"received updated, MAX $id $value")
+          registry.maxGauge(id).set(value)
+        case unk => throw new IllegalArgumentException(
+          s"unknown operation $unk, expected add ($ADD) or max ($MAX)")
+      }
+      t = parser.nextToken()
+    }
+  }
+
+  private def loadStringTable(n: Int, parser: JsonParser): Array[String] = {
+    val strings = new Array[String](n)
+    var i = 0
+    while (i < n) {
+      strings(i) = nextString(parser)
+      i += 1
+    }
+    strings
+  }
+
+  private def loadTags(n: Int, strings: Array[String], parser: JsonParser): TagMap = {
+    val tags = new SmallHashMap.Builder[String, String](n * 2)
+    var i = 0
+    while (i < n) {
+      val k = strings(nextInt(parser))
+      val v = strings(nextInt(parser))
+      tags.add(k, v)
+      i += 1
+    }
+    tags.result
+  }
+
+  private def createId(registry: AtlasRegistry, tags: TagMap): Id = {
+    val name = tags("name")
+    val otherTags = (tags - "name").asInstanceOf[TagMap]
+    registry.createId(name, otherTags.asJavaMap)
+  }
+}

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AppModuleSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AppModuleSuite.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.aggregator
+
+import javax.inject.Singleton
+
+import com.google.inject.AbstractModule
+import com.google.inject.ConfigurationException
+import com.google.inject.Guice
+import com.google.inject.Provider
+import com.netflix.atlas.aggregator.AppModuleSuite.RegistryProvider
+import com.netflix.spectator.api.Clock
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.atlas.AtlasConfig
+import com.netflix.spectator.atlas.AtlasRegistry
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+
+class AppModuleSuite extends FunSuite {
+
+  private val config = ConfigFactory.load()
+
+  test("aggr registry only") {
+    val injector = Guice.createInjector(
+      new AppModule,
+      new AbstractModule {
+        override def configure(): Unit = {
+          bind(classOf[Config]).toInstance(config)
+        }
+      })
+
+    val aggr = injector.getInstance(classOf[AtlasRegistry])
+    assert(aggr != null)
+
+    intercept[ConfigurationException] {
+      injector.getInstance(classOf[Registry])
+    }
+  }
+
+  test("app and aggr registry") {
+    val injector = Guice.createInjector(
+      new AppModule,
+      new AbstractModule {
+        override def configure(): Unit = {
+          bind(classOf[Config]).toInstance(config)
+          bind(classOf[Registry]).toProvider(classOf[RegistryProvider])
+        }
+      })
+
+    val app = injector.getInstance(classOf[Registry])
+    val aggr = injector.getInstance(classOf[AtlasRegistry])
+    assert(app != aggr)
+  }
+}
+
+object AppModuleSuite {
+  @Singleton
+  class RegistryProvider extends Provider[Registry] {
+    override def get(): Registry = {
+      val cfg = new AtlasConfig {
+        override def get(k: String): String = null
+      }
+      new AtlasRegistry(Clock.SYSTEM, cfg)
+    }
+  }
+}

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.aggregator
+
+import com.fasterxml.jackson.core.JsonFactory
+import com.netflix.spectator.api.ManualClock
+import com.netflix.spectator.atlas.AtlasConfig
+import com.netflix.spectator.atlas.AtlasRegistry
+import org.scalatest.FunSuite
+
+class UpdateApiSuite extends FunSuite {
+
+  private val factory = new JsonFactory()
+
+  test("simple payload") {
+    val clock = new ManualClock()
+    val registry = new AtlasRegistry(clock, UpdateApiSuite.config)
+    val parser = factory.createParser(
+      """
+        |[
+        |  2,
+        |  "name",
+        |  "cpu",
+        |  1,
+        |  0, 1,
+        |  0,
+        |  42.0
+        |]
+      """.stripMargin)
+    UpdateApi.processPayload(parser, registry)
+    clock.setWallTime(62000)
+    assert(registry.doubleCounter(registry.createId("cpu")).actualCount() === 42.0)
+  }
+
+  test("payload with additional tags") {
+    val clock = new ManualClock()
+    val registry = new AtlasRegistry(clock, UpdateApiSuite.config)
+    val parser = factory.createParser(
+      """
+        |[
+        |  6,
+        |  "name",
+        |  "cpu",
+        |  "app",
+        |  "www",
+        |  "zone",
+        |  "1e",
+        |  3,
+        |  0, 1, 2, 3, 4, 5,
+        |  0,
+        |  42.0
+        |]
+      """.stripMargin)
+    UpdateApi.processPayload(parser, registry)
+    clock.setWallTime(62000)
+    val id = registry.createId("cpu", "app", "www", "zone", "1e")
+    assert(registry.doubleCounter(id).actualCount() === 42.0)
+  }
+}
+
+object UpdateApiSuite {
+  private val config = new AtlasConfig {
+    override def get(k: String): String = null
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@
 lazy val root = project.in(file("."))
   .configure(BuildSettings.profile)
   .aggregate(
+    `atlas-aggregator`,
     `atlas-druid`,
     `atlas-stream`,
     `iep-archaius`,
@@ -10,6 +11,23 @@ lazy val root = project.in(file("."))
     `iep-lwc-bridge`,
     `iep-lwc-cloudwatch`)
   .settings(BuildSettings.noPackaging: _*)
+
+lazy val `atlas-aggregator` = project
+  .configure(BuildSettings.profile)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.atlasJson,
+    Dependencies.atlasModuleAkka,
+    Dependencies.atlasModuleEval,
+    Dependencies.iepGuice,
+    Dependencies.iepNflxEnv,
+    Dependencies.log4jApi,
+    Dependencies.log4jCore,
+    Dependencies.log4jSlf4j,
+    Dependencies.spectatorAtlas,
+
+    Dependencies.akkaHttpTestkit % "test",
+    Dependencies.scalatest % "test"
+  ))
 
 lazy val `atlas-druid` = project
   .configure(BuildSettings.profile)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     val scala      = "2.12.4"
     val servo      = "0.12.20"
     val slf4j      = "1.7.25"
-    val spectator  = "0.60.0"
+    val spectator  = "0.63.0"
 
     val crossScala = Seq(scala)
   }
@@ -75,6 +75,7 @@ object Dependencies {
   val slf4jLog4j         = "org.slf4j" % "slf4j-log4j12" % slf4j
   val slf4jSimple        = "org.slf4j" % "slf4j-simple" % slf4j
   val spectatorApi       = "com.netflix.spectator" % "spectator-api" % spectator
+  val spectatorAtlas     = "com.netflix.spectator" % "spectator-reg-atlas" % spectator
   val spectatorLog4j     = "com.netflix.spectator" % "spectator-ext-log4j2" % spectator
   val spectatorM2        = "com.netflix.spectator" % "spectator-reg-metrics2" % spectator
   val spectatorSandbox   = "com.netflix.spectator" % "spectator-ext-sandbox" % spectator


### PR DESCRIPTION
This is an initial prototype for an aggregator service
to receive deltas from stateless clients. The api is
similar to internal aggregator that has been used for
a while to perform inline removal of the node dimension.
In this case updates are forwarded to an AtlasRegistry
so it will behave like a normal client on behalf of
the clients.

For more details see Netflix/spectator#432.

Left as future work:

- Reduce the expiration period for the Atlas registry.
  This will require changes on the Spectator side to
  improve the cleanup.
- Minimal validation of datapoints. In particular checks
  for tag length and number of tags should be performed.
- Automatic rollup based on cardinality or churn. This
  is to protect the backends and avoid explosion of metrics
  volume if improper tagging is used. In particular with
  FaaS systems there is a concern about dimensions that
  might have a request id. Ideally, rollups will apply to
  the Atlas publish path, but not the LWC path. This would
  allow users to get full dimensions on-demand via
  streaming.
- Check how resilient we are to DDoS. A concern with this
  approach is poorly written clients may send a delta for
  every counter update in a tight loop. For big clusters
  this could be problematic.