### PR TITLE
add support for publishing to CW cross-region

### DIFF
--- a/iep-lwc-cloudwatch/src/main/resources/application.conf
+++ b/iep-lwc-cloudwatch/src/main/resources/application.conf
@@ -17,5 +17,22 @@ atlas {
   }
 }
 
+netflix.iep.aws {
+  // Configs for clients named by region, used to allow publishing across
+  // regions
+  eu-west-1 {
+    region = "eu-west-1"
+  }
+  us-west-1 {
+    region = "us-west-1"
+  }
+  us-west-2 {
+    region = "us-west-2"
+  }
+  us-east-1 {
+    region = "us-east-1"
+  }
+}
+
 // User specific configuration with settings for an internal deployment
 include "custom.conf"


### PR DESCRIPTION
Though we generally try to keep the data flow regionally
isolated, there are some use-cases where we need the data
from one region in another. Current example is reservation
data tracked from a centrallized tool that needs to be
used for auto-scaling in various regions.