### PR TITLE
use prefix when accessing config settings

### DIFF
--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AppModule.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AppModule.scala
@@ -44,7 +44,8 @@ object AppModule {
   class AggrConfig(config: Config) extends AtlasConfig {
 
     override def get(k: String): String = {
-      if (config.hasPath(s"netflix.atlas.aggr.registry.$k")) config.getString(k) else null
+      val prop = s"netflix.atlas.aggr.registry.$k"
+      if (config.hasPath(prop)) config.getString(prop) else null
     }
 
     override def commonTags(): java.util.Map[String, String] = {

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AppModuleSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AppModuleSuite.scala
@@ -21,7 +21,6 @@ import com.google.inject.AbstractModule
 import com.google.inject.ConfigurationException
 import com.google.inject.Guice
 import com.google.inject.Provider
-import com.netflix.atlas.aggregator.AppModuleSuite.RegistryProvider
 import com.netflix.spectator.api.Clock
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.atlas.AtlasConfig
@@ -31,6 +30,8 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.FunSuite
 
 class AppModuleSuite extends FunSuite {
+
+  import AppModuleSuite._
 
   private val config = ConfigFactory.load()
 
@@ -64,6 +65,24 @@ class AppModuleSuite extends FunSuite {
     val app = injector.getInstance(classOf[Registry])
     val aggr = injector.getInstance(classOf[AtlasRegistry])
     assert(app != aggr)
+  }
+
+  test("aggr config should use prefix") {
+    val config = ConfigFactory.parseString(
+      """
+        |netflix.atlas.aggr.registry.atlas.uri = "test"
+      """.stripMargin)
+    val aggr = new AppModule.AggrConfig(config)
+    assert(aggr.uri() === "test")
+  }
+
+  test("aggr config should use default for missing props") {
+    val config = ConfigFactory.parseString(
+      """
+        |netflix.atlas.aggr.registry.atlas.uri = "test"
+      """.stripMargin)
+    val aggr = new AppModule.AggrConfig(config)
+    assert(aggr.batchSize() === 10000)
   }
 }
 


### PR DESCRIPTION
The AggrConfig was only applying the prefix when checking
if the key exists not when reading it. This would fail with
a missing config key exception for any key that was actually
set.