### PR TITLE
update CW put grouping to include region

### DIFF
--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
@@ -256,7 +256,7 @@ object ForwardingService extends StrictLogging {
   def sendToCloudWatch(namespace: String, doPut: PutFunction): Flow[AccountDatum, NotUsed, NotUsed] = {
     import scala.collection.JavaConverters._
     Flow[AccountDatum]
-      .groupBy(Int.MaxValue, _.account)
+      .groupBy(Int.MaxValue, d => s"${d.region}.${d.account}") // one client per region/account
       .groupedWithin(20, 5.seconds)
       .flatMapConcat { data =>
         val request = new PutMetricDataRequest()


### PR DESCRIPTION
The grouping needs to match the lookup criteria for
the CloudWatch client. Otherwise all data points for
a batch will go to whatever region is first in the
list rather than the configured region.