### PR TITLE
fix field name for regex filter

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidFilter.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidFilter.scala
@@ -74,7 +74,7 @@ object DruidFilter {
     val `type`: String = "selector"
   }
 
-  case class Regex(dimension: String, value: String) extends DruidFilter {
+  case class Regex(dimension: String, pattern: String) extends DruidFilter {
     val `type`: String = "regex"
   }
 


### PR DESCRIPTION
The field should be `pattern` and not `value`.