### PR TITLE
adjust druid client settings

### DIFF
--- a/atlas-druid/src/main/resources/application.conf
+++ b/atlas-druid/src/main/resources/application.conf
@@ -19,3 +19,19 @@ atlas {
     ]
   }
 }
+
+akka.http {
+
+  server.request-timeout = 55s
+
+  host-connection-pool {
+    max-open-requests = 1024
+    max-connections = 1024
+
+    idle-timeout = 120s
+    client.idle-timeout = 30s
+
+    // https://github.com/akka/akka-http/issues/1836
+    response-entity-subscription-timeout = 35s
+  }
+}


### PR DESCRIPTION
Increase the max number of allowed requests and
connections to permit more concurrent requests.