### PR TITLE
server side filter for multi-value dimensions

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -112,7 +112,7 @@ object DruidClient {
   // http://druid.io/docs/latest/querying/searchquery.html
   case class SearchQuery(
     dataSource: String,
-    searchDimensions: List[String],
+    searchDimensions: List[DimensionSpec],
     intervals: List[String],
     filter: Option[DruidFilter] = None,
     sort: DruidSort = DruidSort.Lexicographic,
@@ -140,13 +140,35 @@ object DruidClient {
   // http://druid.io/docs/latest/querying/groupbyquery.html
   case class GroupByQuery(
     dataSource: String,
-    dimensions: List[String],
+    dimensions: List[DimensionSpec],
     intervals: List[String],
     aggregations: List[Aggregation],
     filter: Option[DruidFilter] = None,
     granularity: Granularity = Granularity.millis(60000),
   ) {
     val queryType: String = "groupBy"
+  }
+
+  trait DimensionSpec
+
+  case class DefaultDimensionSpec(dimension: String, outputName: String) extends DimensionSpec {
+    val `type`: String = "default"
+    val outputType: String = "STRING"
+  }
+
+  case class ListFilteredDimensionSpec(
+    delegate: DimensionSpec,
+    values: List[String],
+    isWhitelist: Boolean = true
+  ) extends DimensionSpec {
+    val `type`: String = "listFiltered"
+  }
+
+  case class RegexFilteredDimensionSpec(
+    delegate: DimensionSpec,
+    pattern: String
+  ) extends DimensionSpec {
+    val `type`: String = "regexFiltered"
   }
 
   case class Aggregation(`type`: String, fieldName: String) {

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.druid
+
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.druid.DruidClient._
+import org.scalatest.FunSuite
+
+class DruidDatabaseActorSuite extends FunSuite {
+
+  import DruidDatabaseActor._
+
+  test("dimension to spec no matches") {
+    val spec = toDimensionSpec("key",  Query.Equal("app", "www"))
+    val expected = DefaultDimensionSpec("key", "key")
+    assert(spec === expected)
+  }
+
+  test("dimension to spec: equal query") {
+    val spec = toDimensionSpec("app",  Query.Equal("app", "www"))
+    val expected = ListFilteredDimensionSpec(
+      DefaultDimensionSpec("app", "app"),
+      List("www"))
+    assert(spec === expected)
+  }
+
+  test("dimension to spec: in query") {
+    val spec = toDimensionSpec("app",  Query.In("app", List("a", "b", "c")))
+    val expected = ListFilteredDimensionSpec(
+      DefaultDimensionSpec("app", "app"),
+      List("a", "b", "c"))
+    assert(spec === expected)
+  }
+
+  test("dimension to spec: regex query") {
+    val spec = toDimensionSpec("app",  Query.Regex("app", "www"))
+    val expected = RegexFilteredDimensionSpec(
+      DefaultDimensionSpec("app", "app"),
+      "^www.*")
+    assert(spec === expected)
+  }
+
+  test("dimension to spec: has key query") {
+    val spec = toDimensionSpec("app",  Query.HasKey("app"))
+    val expected = DefaultDimensionSpec("key", "key")
+    assert(spec === expected)
+  }
+
+  test("dimension to spec: gt query") {
+    val spec = toDimensionSpec("app",  Query.GreaterThan("app", "www"))
+    val expected = DefaultDimensionSpec("key", "key")
+    assert(spec === expected)
+  }
+
+  test("dimension to spec: nested") {
+    val spec = toDimensionSpec("app",
+      Query.And(
+        Query.Regex("app", "www"),
+        Query.And(
+          Query.Equal("app", "abc"),
+          Query.In("app", List("a", "b", "c"))
+        )
+      )
+    )
+    val expected = ListFilteredDimensionSpec(
+      ListFilteredDimensionSpec(
+        RegexFilteredDimensionSpec(
+          DefaultDimensionSpec("app", "app"),
+          "^www.*"),
+        List("abc")
+      ),
+      List("a", "b", "c")
+    )
+    assert(spec === expected)
+  }
+}

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
@@ -55,13 +55,13 @@ class DruidDatabaseActorSuite extends FunSuite {
 
   test("dimension to spec: has key query") {
     val spec = toDimensionSpec("app",  Query.HasKey("app"))
-    val expected = DefaultDimensionSpec("key", "key")
+    val expected = DefaultDimensionSpec("app", "app")
     assert(spec === expected)
   }
 
   test("dimension to spec: gt query") {
     val spec = toDimensionSpec("app",  Query.GreaterThan("app", "www"))
-    val expected = DefaultDimensionSpec("key", "key")
+    val expected = DefaultDimensionSpec("app", "app")
     assert(spec === expected)
   }
 


### PR DESCRIPTION
Uses the filtering dimension spec where possible to have
druid filter out the result set on the server side. We
still to the local filtering for cases where the list or
regex filter specs do not match the query intent.