### PR TITLE
add config option for tag query interval

### DIFF
--- a/atlas-druid/src/main/resources/application.conf
+++ b/atlas-druid/src/main/resources/application.conf
@@ -2,9 +2,11 @@
 atlas {
 
   // URI for the druid service
-  //druid {
-  //  uri = "http://localhost:7103/druid/v2"
-  //}
+  druid {
+    //uri = "http://localhost:7103/druid/v2"
+
+    tags-interval = 6h
+  }
 
   akka {
     actors = [

--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -16,7 +16,6 @@
 package com.netflix.atlas.druid
 
 import java.time.Instant
-import java.time.temporal.ChronoUnit
 
 import akka.NotUsed
 import akka.actor.Actor
@@ -59,6 +58,8 @@ class DruidDatabaseActor(config: Config) extends Actor with StrictLogging {
 
   private val client = new DruidClient(
     config.getConfig("atlas.druid"), sys, mat, Http().superPool[AccessLogger]())
+
+  private val tagsInterval = config.getDuration("atlas.druid.tags-interval")
 
   private var metadata: Metadata = Metadata(Nil)
 
@@ -181,7 +182,7 @@ class DruidDatabaseActor(config: Config) extends Actor with StrictLogging {
 
   private def tagsQueryInterval: String = {
     val now = Instant.now()
-    s"${now.minus(14, ChronoUnit.DAYS)}/$now"
+    s"${now.minus(tagsInterval)}/$now"
   }
 
   private def fetchData(ref: ActorRef, request: DataRequest): Unit = {


### PR DESCRIPTION
Adds an option to control the amount of time used when
performing searchs for the tags api. Before it was fixed
to 14 days. That can cause a lot of load on druid for
high cardinality dimensions.