### PR TITLE
avoid checking the query again

### DIFF
--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExpressionsEvaluator.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExpressionsEvaluator.scala
@@ -70,8 +70,7 @@ class ExpressionsEvaluator {
     values.foreach { v =>
       val subs = index.matchingEntries(v.tags)
       subs.foreach { sub =>
-        // TODO: avoid duplicate check of query when spectator 0.62.0 is released
-        val aggr = aggregates.getOrElseUpdate(sub.getId, sub.dataExpr().aggregator())
+        val aggr = aggregates.getOrElseUpdate(sub.getId, newAggregator(sub))
         aggr.update(toPair(v))
       }
     }
@@ -86,6 +85,11 @@ class ExpressionsEvaluator {
     }
 
     new EvalPayload(timestamp, metrics)
+  }
+
+  private def newAggregator(sub: Subscription): Aggregator = {
+    val tags = sub.dataExpr().query().exactTags()
+    sub.dataExpr().aggregator(tags, false)
   }
 
   private def toPair(d: Datapoint): TagsValuePair = {


### PR DESCRIPTION
In this case the query has already been checked by
the index. It doesn't need to be rechecked when
creating the aggregator instance.