### PR TITLE
disable connection reuse for stream endpoint

### DIFF
--- a/atlas-stream/src/main/scala/com/netflix/atlas/stream/StreamApi.scala
+++ b/atlas-stream/src/main/scala/com/netflix/atlas/stream/StreamApi.scala
@@ -20,6 +20,7 @@ import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.Connection
 import akka.http.scaladsl.server.Route
 import akka.stream.ThrottleMode
 import akka.stream.scaladsl.Source
@@ -53,7 +54,8 @@ class StreamApi(evaluator: Evaluator) extends WebApi {
             }
             .merge(heartbeatSrc)
           val entity = HttpEntity(MediaTypes.`text/event-stream`, src)
-          complete(HttpResponse(StatusCodes.OK, entity = entity))
+          val headers = List(Connection("close"))
+          complete(HttpResponse(StatusCodes.OK, headers = headers, entity = entity))
         }
       }
     }


### PR DESCRIPTION
These will be long-lived connections and when behind a load
balancer. AWS ELBs will wait for a long time after the client
goes away hoping the request will complete and it can reuse
the connection. In this case the stream will never complete.
Setting connection close should let the load balancer know it
can give up on the connection without waiting.