### PR TITLE
add inject annotation to expr updater

### DIFF
--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExprUpdateService.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExprUpdateService.scala
@@ -42,6 +42,7 @@ import com.netflix.spectator.api.patterns.PolledMeter
 import com.netflix.spectator.atlas.impl.Subscriptions
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
+import javax.inject.Inject
 
 import scala.util.Success
 
@@ -49,8 +50,11 @@ import scala.util.Success
 /**
   * Refresh the set of expressions from the LWC service.
   */
-class ExprUpdateService(config: Config, registry: Registry, evaluator: ExpressionsEvaluator)
-  extends AbstractService with StrictLogging {
+class ExprUpdateService @Inject() (
+  config: Config,
+  registry: Registry,
+  evaluator: ExpressionsEvaluator
+) extends AbstractService with StrictLogging {
 
   import scala.concurrent.duration._
 


### PR DESCRIPTION
Fixes:

```
1) Could not find a suitable constructor in com.netflix.iep.lwc.ExprUpdateService.
   Classes must have either one (and only one) constructor annotated with @Inject
   or a zero-argument constructor that is not private.
  at com.netflix.iep.lwc.ExprUpdateService.class(ExprUpdateService.scala:52)
  at com.netflix.iep.lwc.AppModule.configure(AppModule.scala:27)
```