### PR TITLE
add option to log values for a subscription

### DIFF
--- a/iep-lwc-bridge/src/main/resources/application.conf
+++ b/iep-lwc-bridge/src/main/resources/application.conf
@@ -2,6 +2,11 @@
 netflix.iep.lwc.bridge {
   config-uri = "http://localhost:7101/lwc/api/v1/expressions"
   eval-uri = "http://localhost:7101/lwc/api/v1/evaluate"
+
+  logging {
+    // Subscription ids to log in detail for better debugging
+    subscriptions = []
+  }
 }
 
 atlas {

--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/AppModule.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/AppModule.scala
@@ -21,7 +21,7 @@ import com.netflix.iep.service.Service
 
 class AppModule extends AbstractModule {
   override def configure(): Unit = {
-    bind(classOf[ExpressionsEvaluator]).toInstance(new ExpressionsEvaluator)
+    bind(classOf[ExpressionsEvaluator]).to(classOf[ExpressionsEvaluator]).asEagerSingleton()
 
     val serviceBinder = Multibinder.newSetBinder(binder(), classOf[Service])
     serviceBinder.addBinding().to(classOf[ExprUpdateService])

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExprUpdateServiceSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExprUpdateServiceSuite.scala
@@ -39,7 +39,7 @@ class ExprUpdateServiceSuite extends FunSuite with BeforeAndAfter {
   private val config = ConfigFactory.load()
   private val clock = new ManualClock()
   private val registry = new DefaultRegistry(clock)
-  private val evaluator = new ExpressionsEvaluator
+  private val evaluator = new ExpressionsEvaluator(config)
 
   private val service = new ExprUpdateService(config, registry, evaluator)
 

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExpressionsEvaluatorSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExpressionsEvaluatorSuite.scala
@@ -17,11 +17,14 @@ package com.netflix.iep.lwc
 
 import com.netflix.atlas.core.model.Datapoint
 import com.netflix.spectator.atlas.impl.Subscription
+import com.typesafe.config.ConfigFactory
 import org.scalatest.FunSuite
 
 class ExpressionsEvaluatorSuite extends FunSuite {
 
   import scala.collection.JavaConverters._
+
+  private val config = ConfigFactory.load()
 
   // pick an arbitrary time
   private val timestamp = 42 * 60000
@@ -49,14 +52,14 @@ class ExpressionsEvaluatorSuite extends FunSuite {
   }
 
   test("eval with no expressions") {
-    val evaluator = new ExpressionsEvaluator
+    val evaluator = new ExpressionsEvaluator(config)
     val payload = evaluator.eval(timestamp, data(1.0))
     assert(payload.getTimestamp === timestamp)
     assert(payload.getMetrics.isEmpty)
   }
 
   test("eval with single expression") {
-    val evaluator = new ExpressionsEvaluator
+    val evaluator = new ExpressionsEvaluator(config)
     evaluator.sync(createSubs("node,i-00,:eq,:sum"))
     val payload = evaluator.eval(timestamp, data(1.0))
     assert(payload.getTimestamp === timestamp)
@@ -68,7 +71,7 @@ class ExpressionsEvaluatorSuite extends FunSuite {
   }
 
   test("eval with multiple datapoints for an aggregate") {
-    val evaluator = new ExpressionsEvaluator
+    val evaluator = new ExpressionsEvaluator(config)
     evaluator.sync(createSubs("node,i-00,:eq,:sum"))
     val payload = evaluator.eval(timestamp, data(1.0) ::: data(4.0))
     assert(payload.getTimestamp === timestamp)
@@ -80,7 +83,7 @@ class ExpressionsEvaluatorSuite extends FunSuite {
   }
 
   test("eval with multiple expressions") {
-    val evaluator = new ExpressionsEvaluator
+    val evaluator = new ExpressionsEvaluator(config)
     evaluator.sync(createSubs("node,i-00,:eq,:sum", "node,i-00,:eq,:max"))
     val payload = evaluator.eval(timestamp, data(1.0) ::: data(4.0))
     assert(payload.getTimestamp === timestamp)
@@ -93,7 +96,7 @@ class ExpressionsEvaluatorSuite extends FunSuite {
   }
 
   test("sync: add/remove expressions") {
-    val evaluator = new ExpressionsEvaluator
+    val evaluator = new ExpressionsEvaluator(config)
     evaluator.sync(createSubs("node,i-00,:eq,:sum"))
     var payload = evaluator.eval(timestamp, data(1.0) ::: data(4.0))
     assert(payload.getMetrics.size() === 1)

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/StatsApiSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/StatsApiSuite.scala
@@ -25,6 +25,7 @@ import com.netflix.atlas.akka.RequestHandler
 import com.netflix.atlas.core.model.Datapoint
 import com.netflix.atlas.json.Json
 import com.netflix.spectator.atlas.impl.Subscription
+import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfter
 import org.scalatest.FunSuite
 
@@ -36,7 +37,8 @@ class StatsApiSuite extends FunSuite with ScalatestRouteTest with BeforeAndAfter
 
   private implicit val routeTestTimeout = RouteTestTimeout(5.second)
 
-  private val evaluator = new ExpressionsEvaluator
+  private val config = ConfigFactory.load()
+  private val evaluator = new ExpressionsEvaluator(config)
   private val endpoint = new StatsApi(evaluator)
   private val routes = RequestHandler.standardOptions(endpoint.routes)
 


### PR DESCRIPTION
This would be used for more fine grained debugging of a
particular subscription id without all the noise of logging
all of the datapoints flowing through.