### PR TITLE
use endpoint path directives

### DIFF
--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/UpdateApi.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/UpdateApi.scala
@@ -46,7 +46,7 @@ class UpdateApi @Inject() (
   import UpdateApi._
 
   def routes: Route = {
-    path("api" / "v4" / "update") {
+    endpointPath("api" / "v4" / "update") {
       post {
         parseEntity(customJson(p => processPayload(p, aggrRegistry))) { payload =>
           val src = Source.single(ByteString("{}"))

--- a/atlas-stream/src/main/scala/com/netflix/atlas/stream/StreamApi.scala
+++ b/atlas-stream/src/main/scala/com/netflix/atlas/stream/StreamApi.scala
@@ -25,6 +25,7 @@ import akka.http.scaladsl.server.Route
 import akka.stream.ThrottleMode
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import com.netflix.atlas.akka.CustomDirectives._
 import com.netflix.atlas.akka.WebApi
 import com.netflix.atlas.eval.stream.Evaluator
 
@@ -39,7 +40,7 @@ class StreamApi(evaluator: Evaluator) extends WebApi {
   private val heartbeat = ByteString(s"""data: {"type":"heartbeat"}\r\n\r\n""")
 
   def routes: Route = {
-    path("stream" / RemainingPath) { path =>
+    endpointPath("stream", RemainingPath) { path =>
       get {
         extractUri { uri =>
           val q = uri.rawQueryString.getOrElse("")

--- a/iep-archaius/src/main/scala/com/netflix/iep/archaius/PropertiesApi.scala
+++ b/iep-archaius/src/main/scala/com/netflix/iep/archaius/PropertiesApi.scala
@@ -27,6 +27,7 @@ import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
+import com.netflix.atlas.akka.CustomDirectives._
 import com.netflix.atlas.akka.WebApi
 import com.netflix.atlas.json.Json
 import com.netflix.frigga.Names
@@ -37,7 +38,7 @@ class PropertiesApi(
     implicit val actorRefFactory: ActorRefFactory) extends WebApi {
 
   def routes: Route = {
-    path("api" / "v1" / "property") {
+    endpointPath("api" / "v1" / "property") {
       get {
         parameter("asg") { asg =>
           extractRequest { request =>

--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/StatsApi.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/StatsApi.scala
@@ -21,6 +21,7 @@ import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import com.netflix.atlas.akka.CustomDirectives._
 import com.netflix.atlas.akka.WebApi
 import com.netflix.atlas.json.Json
 
@@ -30,7 +31,7 @@ import com.netflix.atlas.json.Json
 class StatsApi(evaluator: ExpressionsEvaluator) extends WebApi {
 
   override def routes: Route = {
-    pathPrefix("api" / "v1" / "stats") {
+    endpointPathPrefix("api" / "v1" / "stats") {
       get {
         val stats = Json.encode(evaluator.stats)
         val entity = HttpEntity(MediaTypes.`application/json`, stats)

--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/UpdateApi.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/UpdateApi.scala
@@ -33,7 +33,7 @@ class UpdateApi(implicit val actorRefFactory: ActorRefFactory) extends WebApi {
   private val publishRef = actorRefFactory.actorSelection("/user/publish")
 
   override def routes: Route = {
-    pathPrefix("database" / "v1" / "update") {
+    endpointPathPrefix("database" / "v1" / "update") {
       post {
         extractRequestContext { ctx =>
           parseEntity(customJson(p => PublishApi.decodeList(p))) { datapoints =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     val scala      = "2.12.6"
     val servo      = "0.12.25"
     val slf4j      = "1.7.25"
-    val spectator  = "0.74.4"
+    val spectator  = "0.76.0"
 
     val crossScala = Seq(scala)
   }


### PR DESCRIPTION
This will allow the endpoint to get configured correctly
for the common-ipc metrics.