### PR TITLE
forward errors to lwcapi for rejected expressions

### DIFF
--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/LwcPublishActor.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/LwcPublishActor.scala
@@ -106,7 +106,7 @@ class LwcPublishActor(config: Config, registry: Registry, evaluator: Expressions
     if (values.nonEmpty) {
       val timestamp = fixTimestamp(values.head.timestamp)
       val payload = evaluator.eval(timestamp, values)
-      if (!payload.getMetrics.isEmpty) {
+      if (!payload.getMetrics.isEmpty || !payload.getMessages.isEmpty) {
         val entity = HttpEntity(MediaTypes.`application/json`, Json.encode(payload))
         val request = HttpRequest(HttpMethods.POST, evalUri, Nil, entity)
         mkRequest("lwc-eval", request).foreach { response =>

--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/package.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/package.scala
@@ -23,4 +23,5 @@ package object lwc {
   type JMap = java.util.Map[String, String]
 
   type MetricList = java.util.ArrayList[EvalPayload.Metric]
+  type MessageList = java.util.ArrayList[EvalPayload.Message]
 }

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExpressionsEvaluatorSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExpressionsEvaluatorSuite.scala
@@ -113,4 +113,12 @@ class ExpressionsEvaluatorSuite extends FunSuite {
     assert(payload.getMetrics.size() === 1)
     assert(payload.getMetrics.get(0).getValue === 4.0)
   }
+
+  test("sync: bad expressions") {
+    val evaluator = new ExpressionsEvaluator(config)
+    evaluator.sync(createSubs("node,i-00,:re,:sum"))
+    var payload = evaluator.eval(timestamp, data(1.0) ::: data(4.0))
+    assert(payload.getMetrics.isEmpty)
+    assert(payload.getMessages.size() === 1)
+  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
     val scala      = "2.12.6"
     val servo      = "0.12.25"
     val slf4j      = "1.7.25"
-    val spectator  = "0.76.0"
+    val spectator  = "0.78.0"
 
     val crossScala = Seq(scala)
   }


### PR DESCRIPTION
Expensive expressions that are being rejected will now be
indicated to the user with an explicit error message.