### PR TITLE
load generator for lwcapi

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ lazy val root = project.in(file("."))
     `iep-clienttest`,
     `iep-lwc-bridge`,
     `iep-lwc-cloudwatch`,
+    `iep-lwc-loadgen`,
     `iep-ses-monitor`)
   .settings(BuildSettings.noPackaging: _*)
 
@@ -126,6 +127,22 @@ lazy val `iep-lwc-cloudwatch` = project
     Dependencies.atlasModuleAkka,
     Dependencies.atlasModuleEval,
     Dependencies.awsCloudWatch,
+    Dependencies.iepGuice,
+    Dependencies.iepModuleAtlas,
+    Dependencies.iepModuleAws,
+    Dependencies.log4jApi,
+    Dependencies.log4jCore,
+    Dependencies.log4jSlf4j,
+
+    Dependencies.akkaHttpTestkit % "test",
+    Dependencies.scalatest % "test"
+  ))
+
+lazy val `iep-lwc-loadgen` = project
+  .configure(BuildSettings.profile)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.atlasModuleAkka,
+    Dependencies.atlasModuleEval,
     Dependencies.iepGuice,
     Dependencies.iepModuleAtlas,
     Dependencies.iepModuleAws,

--- a/iep-lwc-loadgen/README.md
+++ b/iep-lwc-loadgen/README.md
@@ -1,0 +1,45 @@
+
+## Description
+
+Service for generating load against a service running the Atlas LWCAPI. It is primarly used
+for helping to test new versions of the service and the eval client with a configured set
+of load to ensure there are no performance regressions.
+
+## Usage
+
+Update the `iep.lwc.loadgen.uris` config setting with a list of Atlas URIs to stream. Example:
+
+```
+iep.lwc.loadgen.uris = [
+  "http://localhost:7101/api/v1/graph?q=name,m1,:eq,:avg",
+  "http://localhost:7101/api/v1/graph?q=name,m2,:eq,:sum",
+  "http://localhost:7101/api/v1/graph?q=name,m3,:eq,:sum&step=10s"
+]
+```
+
+The default step size is 60s. It can be customized for a given URI by using the `step` query
+parameter.
+
+## Clone Existing Deployment
+
+To copy the expression set from an existing LWCAPI deployment, the following script can be
+adapted to generate the config:
+
+```bash
+#!/bin/bash
+
+LWC_HOST=localhost:7101
+ATLAS_HOST=localhost:7102
+CONF_FILE=iep-lwc-loadgen/src/main/resources/custom.conf
+
+curl -s "http://$LWC_HOST/lwc/api/v1/expressions" |
+  jq --arg host "$ATLAS_HOST" '
+    .expressions[] |
+    @text "http://\($host)/api/v1/graph?q=\(.expression)&step=\(.frequency / 1000)s"' |
+  awk '
+    BEGIN { print "iep.lwc.loadgen.uris = ["}
+    { print "  " $0 "," }
+    END { print "]" }
+  ' > $CONF_FILE
+```
+

--- a/iep-lwc-loadgen/src/main/resources/application.conf
+++ b/iep-lwc-loadgen/src/main/resources/application.conf
@@ -1,0 +1,18 @@
+
+iep.lwc.loadgen {
+  step = 60s
+  uris = [
+  ]
+}
+
+atlas {
+  akka {
+    api-endpoints = [
+      "com.netflix.atlas.akka.ConfigApi",
+      "com.netflix.atlas.akka.HealthcheckApi"
+    ]
+  }
+}
+
+// User specific configuration with settings for an internal deployment
+include "custom.conf"

--- a/iep-lwc-loadgen/src/main/resources/log4j2.xml
+++ b/iep-lwc-loadgen/src/main/resources/log4j2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn">
+    <Properties>
+        <Property name="dfltPattern">%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %-5level [%t] %class: %msg%n</Property>
+    </Properties>
+    <Appenders>
+        <Console name="STDERR" target="SYSTEM_ERR">
+            <PatternLayout pattern="${dfltPattern}"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.netflix.iep" level="debug"/>
+        <Logger name="com.netflix.spectator" level="debug"/>
+        <Root level="info">
+            <AppenderRef ref="STDERR"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/iep-lwc-loadgen/src/main/scala/com/netflix/iep/loadgen/AppModule.scala
+++ b/iep-lwc-loadgen/src/main/scala/com/netflix/iep/loadgen/AppModule.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.loadgen
+
+import com.google.inject.AbstractModule
+import com.google.inject.multibindings.Multibinder
+import com.netflix.iep.service.Service
+
+class AppModule extends AbstractModule {
+  override def configure(): Unit = {
+    val serviceBinder = Multibinder.newSetBinder(binder(), classOf[Service])
+    serviceBinder.addBinding().to(classOf[LoadGenService])
+  }
+}

--- a/iep-lwc-loadgen/src/main/scala/com/netflix/iep/loadgen/LoadGenService.scala
+++ b/iep-lwc-loadgen/src/main/scala/com/netflix/iep/loadgen/LoadGenService.scala
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.loadgen
+
+import java.util.concurrent.atomic.AtomicLong
+
+import javax.inject.Inject
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.Uri
+import akka.stream.AbruptTerminationException
+import akka.stream.ActorMaterializer
+import akka.stream.KillSwitch
+import akka.stream.KillSwitches
+import akka.stream.ThrottleMode
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import com.netflix.atlas.core.util.Strings
+import com.netflix.atlas.eval.model.ArrayData
+import com.netflix.atlas.eval.model.TimeSeriesMessage
+import com.netflix.atlas.eval.stream.Evaluator
+import com.netflix.iep.service.AbstractService
+import com.netflix.spectator.api.histogram.PercentileDistributionSummary
+import com.netflix.spectator.api.Functions
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.patterns.CardinalityLimiters
+import com.netflix.spectator.api.patterns.PolledMeter
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+
+class LoadGenService @Inject()(
+  config: Config,
+  registry: Registry,
+  evaluator: Evaluator,
+  implicit val system: ActorSystem
+) extends AbstractService
+    with StrictLogging {
+
+  private val streamFailures = registry.counter("loadgen.streamFailures")
+
+  private implicit val ec = scala.concurrent.ExecutionContext.global
+  private implicit val mat = ActorMaterializer()
+
+  private val limiter = CardinalityLimiters.mostFrequent(20)
+
+  private val clock = registry.clock()
+  private val lastSuccessfulPutTime = PolledMeter
+    .using(registry)
+    .withName("forwarding.timeSinceLastPut")
+    .monitorValue(new AtomicLong(clock.wallTime()), Functions.age(clock))
+
+  private var killSwitch: KillSwitch = _
+
+  override def startImpl(): Unit = {
+    killSwitch = Source
+      .repeat(dataSources)
+      .throttle(1, 1.minute, 1, ThrottleMode.Shaping)
+      .via(Flow.fromProcessor(() => evaluator.createStreamsProcessor()))
+      .watchTermination() { (_, f) =>
+        f.onComplete {
+          case Success(_) | Failure(_: AbruptTerminationException) =>
+            // AbruptTerminationException will be triggered if the associated ActorSystem
+            // is shutdown before the stream.
+            logger.info(s"shutting down forwarding stream")
+          case Failure(t) =>
+            streamFailures.increment()
+            logger.error(s"forwarding stream failed, attempting to restart", t)
+            startImpl()
+        }
+      }
+      .viaMat(KillSwitches.single)(Keep.right)
+      .toMat(Sink.foreach(updateStats))(Keep.left)
+      .run()
+  }
+
+  override def stopImpl(): Unit = {
+    if (killSwitch != null) killSwitch.shutdown()
+  }
+
+  private def dataSources: Evaluator.DataSources = {
+    import scala.collection.JavaConverters._
+    val defaultStep = config.getDuration("iep.lwc.loadgen.step")
+    val sources = config
+      .getStringList("iep.lwc.loadgen.uris")
+      .asScala
+      .zipWithIndex
+      .map {
+        case (uri, i) =>
+          val step = extractStep(uri).getOrElse(defaultStep)
+          val id = Strings.zeroPad(i, 6)
+          new Evaluator.DataSource(id, step, uri)
+      }
+    new Evaluator.DataSources(sources.toSet.asJava)
+  }
+
+  private def extractStep(uri: String): Option[java.time.Duration] = {
+    Uri(uri).query().get("step").map(Strings.parseDuration)
+  }
+
+  private def updateStats(envelope: Evaluator.MessageEnvelope): Unit = {
+    val id = limiter(envelope.getId)
+    envelope.getMessage match {
+      case tsm: TimeSeriesMessage => record(id, "TimeSeriesMessage", value(tsm))
+      case _                      => record(id, "DiagnosticMessage")
+    }
+  }
+
+  private def value(tsm: TimeSeriesMessage): Double = {
+    tsm.data match {
+      case ArrayData(vs) if vs.nonEmpty => vs.sum
+      case _                            => Double.NaN
+    }
+  }
+
+  private def record(id: String, msgType: String, value: Double = Double.NaN): Unit = {
+    val resultMessages = registry
+      .createId("loadgen.resultMessages")
+      .withTags("id", id, "msgType", msgType)
+    registry.counter(resultMessages).increment()
+    if (!value.isNaN) {
+      // Fractional amounts between 0 and 1 are more common for our use-cases than numbers
+      // large enough to overflow the long when multiplied by 1M. Since the distribution summary
+      // is primarily as a sanity check of the values when comparing one version to the next
+      // this step avoids mapping a larger range of relevant values to 0 when converting to
+      // a long.
+      val longValue = (value * 1e6).toLong
+      PercentileDistributionSummary
+        .builder(registry)
+        .withName("loadgen.valueDistribution")
+        .withTags(resultMessages.tags())
+        .build()
+        .record(longValue)
+    }
+  }
+}

--- a/iep-lwc-loadgen/src/main/scala/com/netflix/iep/loadgen/Main.scala
+++ b/iep-lwc-loadgen/src/main/scala/com/netflix/iep/loadgen/Main.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.loadgen
+
+import com.google.inject.AbstractModule
+import com.google.inject.Module
+import com.netflix.iep.guice.GuiceHelper
+import com.netflix.iep.service.ServiceManager
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.slf4j.LoggerFactory
+
+object Main {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private def getBaseModules: java.util.List[Module] = {
+    val modules = GuiceHelper.getModulesUsingServiceLoader
+    if (!sys.env.contains("NETFLIX_ENVIRONMENT")) {
+      // If we are running in a local environment provide simple version of the config
+      // binding. These bindings are normally provided by the final package
+      // config for the app in the production setup.
+      modules.add(new AbstractModule {
+        override def configure(): Unit = {
+          bind(classOf[Config]).toInstance(ConfigFactory.load())
+        }
+      })
+    }
+    modules
+  }
+
+  def main(args: Array[String]): Unit = {
+    try {
+      val modules = getBaseModules
+      modules.add(new AppModule)
+      val guice = new GuiceHelper
+      guice.start(modules)
+      guice.getInjector.getInstance(classOf[ServiceManager])
+      guice.addShutdownHook()
+    } catch {
+      // Send exceptions to main log file instead of wherever STDERR is sent for the process
+      case t: Throwable => logger.error("fatal error on startup", t)
+    }
+  }
+
+}


### PR DESCRIPTION
Runs the Atlas eval library with a configured set of
data sources. Can be used for load testing of the server
and client libraries. Results of the evaluation are used
to generate some basic summary metrics, but are otherwise
ignored.