### PR TITLE
avoid crashing if invalid uri is used in config

### DIFF
--- a/iep-lwc-loadgen/src/main/scala/com/netflix/iep/loadgen/LoadGenService.scala
+++ b/iep-lwc-loadgen/src/main/scala/com/netflix/iep/loadgen/LoadGenService.scala
@@ -154,6 +154,9 @@ class LoadGenService @Inject()(
 object LoadGenService {
 
   def extractStep(uri: String): Option[java.time.Duration] = {
-    Try(Uri(uri)).toOption.flatMap(_.query().get("step").map(Strings.parseDuration))
+    val result = Try {
+      Uri(uri).query().get("step").map(Strings.parseDuration)
+    }
+    result.toOption.flatten
   }
 }

--- a/iep-lwc-loadgen/src/test/scala/com/netflix/iep/loadgen/LoadGenServiceSuite.scala
+++ b/iep-lwc-loadgen/src/test/scala/com/netflix/iep/loadgen/LoadGenServiceSuite.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014-2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.loadgen
+
+import java.time.Duration
+
+import org.scalatest.FunSuite
+
+class LoadGenServiceSuite extends FunSuite {
+  test("extract step from uri") {
+    val actual = LoadGenService.extractStep("/graph?q=name,foo,:eq&step=60s")
+    assert(actual === Some(Duration.ofSeconds(60)))
+  }
+
+  test("extract step from uri, not present") {
+    val actual = LoadGenService.extractStep("/graph?q=name,foo,:eq")
+    assert(actual === None)
+  }
+
+  test("extract step from uri, invalid uri") {
+    val actual = LoadGenService.extractStep("/graph?q=name,{{ .SpinnakerApp }},:eq")
+    assert(actual === None)
+  }
+}

--- a/iep-lwc-loadgen/src/test/scala/com/netflix/iep/loadgen/LoadGenServiceSuite.scala
+++ b/iep-lwc-loadgen/src/test/scala/com/netflix/iep/loadgen/LoadGenServiceSuite.scala
@@ -34,4 +34,9 @@ class LoadGenServiceSuite extends FunSuite {
     val actual = LoadGenService.extractStep("/graph?q=name,{{ .SpinnakerApp }},:eq")
     assert(actual === None)
   }
+
+  test("extract step from uri, invalid step") {
+    val actual = LoadGenService.extractStep("/graph?q=name,foo,:eq&step=bad")
+    assert(actual === None)
+  }
 }


### PR DESCRIPTION
When extracting the step it would crash before if there was
an invalid uri. Now it will fallback to the default step and
let the eval library handle the invalid uris passed in as part
of the set of data sources.