### PR TITLE
update msgType tag to match type field in messages

### DIFF
--- a/iep-lwc-loadgen/src/main/scala/com/netflix/iep/loadgen/LoadGenService.scala
+++ b/iep-lwc-loadgen/src/main/scala/com/netflix/iep/loadgen/LoadGenService.scala
@@ -29,6 +29,7 @@ import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
+import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.core.util.Strings
 import com.netflix.atlas.eval.model.ArrayData
 import com.netflix.atlas.eval.model.TimeSeriesMessage
@@ -118,8 +119,9 @@ class LoadGenService @Inject()(
   private def updateStats(envelope: Evaluator.MessageEnvelope): Unit = {
     val id = limiter(envelope.getId)
     envelope.getMessage match {
-      case tsm: TimeSeriesMessage => record(id, "TimeSeriesMessage", value(tsm))
-      case _                      => record(id, "DiagnosticMessage")
+      case tsm: TimeSeriesMessage => record(id, "timeseries", value(tsm))
+      case msg: DiagnosticMessage => record(id, msg.typeName)
+      case _                      => record(id, "unknown")
     }
   }
 


### PR DESCRIPTION
Use the same value as the type field in the messages coming
back to the user for the `msgType` dimension on the metric.