### PR TITLE
Fix Guice injection issue

### DIFF
--- a/iep-ses-monitor/src/main/scala/com/netflix/iep/ses/AppModule.scala
+++ b/iep-ses-monitor/src/main/scala/com/netflix/iep/ses/AppModule.scala
@@ -41,4 +41,9 @@ class AppModule extends AbstractModule {
       .withClientConfiguration(PredefinedClientConfigurations.defaultConfig().withGzip(true))
       .build()
   }
+
+  @Provides
+  def providesNotificationLogger(): NotificationLogger = {
+    SesNotificationLogger
+  }
 }

--- a/iep-ses-monitor/src/main/scala/com/netflix/iep/ses/NotificationLogger.scala
+++ b/iep-ses-monitor/src/main/scala/com/netflix/iep/ses/NotificationLogger.scala
@@ -1,0 +1,5 @@
+package com.netflix.iep.ses
+
+trait NotificationLogger {
+  def log(message: String): Unit
+}

--- a/iep-ses-monitor/src/main/scala/com/netflix/iep/ses/SesNotificationLogger.scala
+++ b/iep-ses-monitor/src/main/scala/com/netflix/iep/ses/SesNotificationLogger.scala
@@ -1,0 +1,10 @@
+package com.netflix.iep.ses
+import org.slf4j.LoggerFactory
+
+object SesNotificationLogger extends NotificationLogger {
+  private val logger = LoggerFactory.getLogger("com.netflix.iep.ses.SesNotificationLogger")
+
+  override def log(message: String): Unit = {
+    logger.info(message)
+  }
+}

--- a/iep-ses-monitor/src/test/scala/com/netflix/iep/ses/SesMonitoringServiceSuite.scala
+++ b/iep-ses-monitor/src/test/scala/com/netflix/iep/ses/SesMonitoringServiceSuite.scala
@@ -484,17 +484,16 @@ class SesMonitoringServiceSuite extends FunSuite with Matchers with BeforeAndAft
           """.stripMargin
 
     var loggerCalled = false
-    val loggerSpy = (message: String) => {
-      message shouldEqual messageBody
-      loggerCalled = true
-    }
 
     val sesMonitoringService = new SesMonitoringService(
       ConfigFactory.load(),
       new NoopRegistry(),
       DummyAmazonSQSAsync,
       system,
-      loggerSpy
+      message => {
+        message shouldEqual messageBody
+        loggerCalled = true
+      }
     )
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()


### PR DESCRIPTION
Guice injection does not recognize the default fifth parameter of
`SesMonitoringService`. I created a trait and a default implementation
for an `@Provider` in the `AppModule`, while still enabling tests to
provide a spy implementation.