### PR TITLE
Update SesNotification logger name

### DIFF
--- a/iep-ses-monitor/src/main/resources/log4j2.xml
+++ b/iep-ses-monitor/src/main/resources/log4j2.xml
@@ -16,7 +16,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="com.netflix.iep.SesNotificationLogger" level="info"/>
+        <Logger name="com.netflix.iep.ses.SesNotificationLogger" level="info"/>
         <Logger name="com.netflix.iep" level="debug"/>
         <Logger name="com.netflix.spectator" level="debug"/>
         <Root level="info">


### PR DESCRIPTION
With the introduction of the NotificationLogger trait and default
implementation, I updated the name of the logger to match the package
structure. Update the log4j.xml configuration.