### PR TITLE
partition the expressions for loadgen

### DIFF
--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExpressionsEvaluatorSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExpressionsEvaluatorSuite.scala
@@ -117,7 +117,7 @@ class ExpressionsEvaluatorSuite extends FunSuite {
   test("sync: bad expressions") {
     val evaluator = new ExpressionsEvaluator(config)
     evaluator.sync(createSubs("node,i-00,:re,:sum"))
-    var payload = evaluator.eval(timestamp, data(1.0) ::: data(4.0))
+    val payload = evaluator.eval(timestamp, data(1.0) ::: data(4.0))
     assert(payload.getMetrics.isEmpty)
     assert(payload.getMessages.size() === 1)
   }


### PR DESCRIPTION
Changes lwc loadgen to run one evaluator per group of
expressions. This more closely simulates the behavior
of internal usage.