### PR TITLE
ignore datapoints with a value of NaN

### DIFF
--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExpressionsEvaluator.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExpressionsEvaluator.scala
@@ -97,7 +97,7 @@ class ExpressionsEvaluator @Inject()(config: Config) extends StrictLogging {
   def eval(timestamp: Long, values: List[Datapoint]): EvalPayload = {
     val index = indexRef.get
     val aggregates = collection.mutable.AnyRefMap.empty[String, Aggregator]
-    values.foreach { v =>
+    values.filter(!_.value.isNaN).foreach { v =>
       val subs = index.matchingEntries(v.tags)
       if (subs.nonEmpty) {
         val pair = toPair(v)

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExpressionsEvaluatorSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExpressionsEvaluatorSuite.scala
@@ -82,6 +82,18 @@ class ExpressionsEvaluatorSuite extends FunSuite {
     assert(m.getValue === 5.0)
   }
 
+  test("eval with multiple datapoints ignores NaN values") {
+    val evaluator = new ExpressionsEvaluator(config)
+    evaluator.sync(createSubs("node,i-00,:eq,:sum"))
+    val payload = evaluator.eval(timestamp, data(7.0) ::: data(Double.NaN))
+    assert(payload.getTimestamp === timestamp)
+    assert(payload.getMetrics.size() === 1)
+
+    val m = payload.getMetrics.get(0)
+    assert(m.getId === "0")
+    assert(m.getValue === 7.0)
+  }
+
   test("eval with multiple expressions") {
     val evaluator = new ExpressionsEvaluator(config)
     evaluator.sync(createSubs("node,i-00,:eq,:sum", "node,i-00,:eq,:max"))


### PR DESCRIPTION
The client should not send values that are NaN, but if it
does occur go head and drop them here before the evaluate
step. This avoid spurious NaN lines showing up in the
streaming output.