### PR TITLE
 avoid entity size limit for fetch expressions

### DIFF
--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExprUpdateService.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExprUpdateService.scala
@@ -98,17 +98,16 @@ class ExprUpdateService @Inject()(
     Flow[HttpResponse]
       .flatMapConcat {
         case response if response.status == StatusCodes.OK =>
-          response.entity.dataBytes.reduce(_ ++ _).map { data =>
-            try {
+          response.entity
+            .withoutSizeLimit()
+            .dataBytes
+            .reduce(_ ++ _)
+            .map { data =>
               val exprs = Json.decode[Subscriptions](data.toArray).getExpressions
               evaluator.sync(exprs)
               lastUpdateTime.set(registry.clock().wallTime())
-            } catch {
-              case e: Exception =>
-                logger.error(s"failed to parse and sync expressions", e)
+              NotUsed
             }
-            NotUsed
-          }
         case response =>
           response.discardEntityBytes()
           Source.single(NotUsed)

--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExprUpdateService.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExprUpdateService.scala
@@ -103,9 +103,14 @@ class ExprUpdateService @Inject()(
             .dataBytes
             .reduce(_ ++ _)
             .map { data =>
-              val exprs = Json.decode[Subscriptions](data.toArray).getExpressions
-              evaluator.sync(exprs)
-              lastUpdateTime.set(registry.clock().wallTime())
+              try {
+                val exprs = Json.decode[Subscriptions](data.toArray).getExpressions
+                evaluator.sync(exprs)
+                lastUpdateTime.set(registry.clock().wallTime())
+              } catch {
+                case e: Exception =>
+                  logger.error("failed to parse and sync expressions", e)
+              }
               NotUsed
             }
         case response =>


### PR DESCRIPTION
The default limit is 8m and we have exceeded that in some
environments. Also, the current behavior seems to be it will
hang the stream with no clear error if this size is exceeded.
So for now we'll remove the size limit so at least the failure
mode will be more obvious.