### PR TITLE
druid: improve handling of OR queries

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -387,7 +387,18 @@ object DruidDatabaseActor {
   def rangeKeys(query: Query): Set[String] = {
     query match {
       case Query.And(q1, q2) => rangeKeys(q1) ++ rangeKeys(q2)
+      case Query.Or(q1, q2)  => rangeKeysOr(q1) ++ rangeKeysOr(q2)
       case Query.Equal(_, _) => Set.empty
+      case q: Query.KeyQuery => Set(q.k)
+      case _                 => Set.empty
+    }
+  }
+
+  /** All keys should be extracted from an OR subtree in the expression. */
+  private def rangeKeysOr(query: Query): Set[String] = {
+    query match {
+      case Query.And(q1, q2) => rangeKeysOr(q1) ++ rangeKeysOr(q2)
+      case Query.Or(q1, q2)  => rangeKeysOr(q1) ++ rangeKeysOr(q2)
       case q: Query.KeyQuery => Set(q.k)
       case _                 => Set.empty
     }

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
@@ -136,9 +136,15 @@ class DruidDatabaseActorSuite extends FunSuite {
     assert(rangeKeys(query) === expected)
   }
 
-  test("rangeKeys: ignore OR subtree") {
-    val expected = Set.empty[String]
-    val query = Query.And(Query.Equal("a", "1"), Query.Or(Query.HasKey("b"), Query.HasKey("c")))
+  test("rangeKeys: extract keys in OR subtree") {
+    val expected = Set("b", "c")
+    val query = Query.And(
+      Query.Equal("a", "1"),
+      Query.Or(
+        Query.Equal("b", "2"),
+        Query.HasKey("c")
+      )
+    )
     assert(rangeKeys(query) === expected)
   }
 


### PR DESCRIPTION
OR clauses can result in multiple values and need to be
included in the group by result similar to IN or regex.