### PR TITLE
increase initial delay for properties loader

### DIFF
--- a/iep-archaius/src/main/scala/com/netflix/iep/archaius/PropertiesLoader.scala
+++ b/iep-archaius/src/main/scala/com/netflix/iep/archaius/PropertiesLoader.scala
@@ -36,7 +36,7 @@ class PropertiesLoader(config: Config, propContext: PropertiesContext, dynamoSer
 
   import scala.concurrent.duration._
   import scala.concurrent.ExecutionContext.Implicits.global
-  context.system.scheduler.schedule(0.seconds, 5.seconds, self, PropertiesLoader.Tick)
+  context.system.scheduler.schedule(5.seconds, 5.seconds, self, PropertiesLoader.Tick)
 
   def receive: Receive = {
     case PropertiesLoader.Tick =>


### PR DESCRIPTION
For test cases having an initial delay of `0.seconds` can
cause the automatic tick to come through at the wrong time
and cause spurious test failures.