### PR TITLE
log region/account for failed requests

### DIFF
--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
@@ -326,7 +326,7 @@ object ForwardingService extends StrictLogging {
           }
           .recover {
             case t: Throwable =>
-              logger.warn("cloudwatch request failed", t)
+              logger.warn(s"cloudwatch request failed (region=$region, account=$account)", t)
               NotUsed
           }
       }


### PR DESCRIPTION
This context isn't provided when there is a failure
due to access denied for the AssumeRole.