### PR TITLE
use segmentMetadata for describing data sources

### DIFF
--- a/atlas-druid/src/test/resources/segmentMetadataResponse.json
+++ b/atlas-druid/src/test/resources/segmentMetadataResponse.json
@@ -1,0 +1,78 @@
+[
+  {
+    "id": "merged",
+    "intervals": null,
+    "columns": {
+      "__time": {
+        "type": "LONG",
+        "hasMultipleValues": false,
+        "size": 29937560,
+        "cardinality": null,
+        "minValue": null,
+        "maxValue": null,
+        "errorMessage": null
+      },
+      "test.metric.counter": {
+        "type": "LONG",
+        "hasMultipleValues": false,
+        "size": 23950048,
+        "cardinality": null,
+        "minValue": null,
+        "maxValue": null,
+        "errorMessage": null
+      },
+      "test.dim.1": {
+        "type": "STRING",
+        "hasMultipleValues": false,
+        "size": 3123,
+        "cardinality": 15,
+        "minValue": null,
+        "maxValue": null,
+        "errorMessage": null
+      },
+      "test.dim.2": {
+        "type": "STRING",
+        "hasMultipleValues": true,
+        "size": 9140,
+        "cardinality": 33,
+        "minValue": null,
+        "maxValue": null,
+        "errorMessage": null
+      },
+      "test.metric.histogram": {
+        "type": "netflixHistogram",
+        "hasMultipleValues": false,
+        "size": 0,
+        "cardinality": null,
+        "minValue": null,
+        "maxValue": null,
+        "errorMessage": null
+      }
+    },
+    "size": 158732338,
+    "numRows": 2993756,
+    "aggregators": {
+      "test.metric.counter": {
+        "type": "longSum",
+        "name": "test.metric.counter",
+        "fieldName": "test.metric.counter",
+        "expression": null
+      },
+      "test.metric.histogram": {
+        "type": "netflixHistogram",
+        "name": "test.metric.histogram",
+        "fieldName": "test.metric.histogram",
+        "quantile": 5e-324,
+        "quantiles": [],
+        "cdf": 5e-324,
+        "cdfs": [],
+        "compression": 50,
+        "histogram": true,
+        "staticBufferMax": 5000
+      }
+    },
+    "timestampSpec": null,
+    "queryGranularity": null,
+    "rollup": null
+  }
+]

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
@@ -241,14 +241,14 @@ class DruidDatabaseActorSuite extends FunSuite {
         "ds_1",
         Datasource(
           List("a", "b"),
-          List("m1", "m2")
+          List(Metric("m1", "LONG"), Metric("m2", "LONG"))
         )
       ),
       DatasourceMetadata(
         "ds_2",
         Datasource(
           List("a", "c"),
-          List("m1", "m3")
+          List(Metric("m1", "LONG"), Metric("m3", "LONG"))
         )
       )
     )


### PR DESCRIPTION
Switches to using segmentMetadata queries for understanding
the set of dimensions and metrics for a given data source.
This has two benefits: 1) it seems to be more reliable as
in some error cases the GET request to /datasources doesn't
show any dimensions, and 2) it gives us type information
that can be used to make a more informed choice about how
to query the data.

The main downside is that segmentMetadata seems to be quite
a bit more expensive to compute. The intervals are limited
to the tag query interval for now which seems to keep the
overhead to a reasonable level.