### PR TITLE
Add retry for UnknownHostException

### DIFF
--- a/iep-ses-monitor/src/main/resources/application.conf
+++ b/iep-ses-monitor/src/main/resources/application.conf
@@ -1,6 +1,7 @@
 
 iep.ses.monitor {
   notification-queue-name = "ses_notifications"
+  sqs-unknown-host-retry-delay = 11 s
 }
 
 atlas {


### PR DESCRIPTION
There have been occasional, transient DNS blips resulting in an
`UnknownHostException` communicating with the SQS host. This currently
causes the stream to fail permanently, since the stream restart logic
can't retrieve the queue URI until the DNS name starts resolving
again.

This commit adds retries for retrieving the queue URI on
`UnknownHostException`, and a metric for queue URI retrieval failure.