### PR TITLE
Add endpoint for removing purge eligible expressions

### DIFF
--- a/iep-lwc-cloudwatch-model/src/main/scala/com/netflix/iep/lwc/fwd/cw/ConfigBinVersion.scala
+++ b/iep-lwc-cloudwatch-model/src/main/scala/com/netflix/iep/lwc/fwd/cw/ConfigBinVersion.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc.fwd.cw
+
+case class ConfigBinVersion(
+  ts: Long,
+  hash: String,
+  user: Option[String] = None,
+  comment: Option[String] = None
+)

--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
@@ -486,13 +486,6 @@ object ForwardingService extends StrictLogging {
     }
   }
 
-  case class ConfigBinVersion(
-    ts: Long,
-    hash: String,
-    user: Option[String] = None,
-    comment: Option[String] = None
-  )
-
   case class ForwardingMsgEnvelope(
     id: ExpressionId,
     accountDatum: Option[AccountDatum],

--- a/iep-lwc-fwding-admin/src/main/resources/application.conf
+++ b/iep-lwc-fwding-admin/src/main/resources/application.conf
@@ -18,4 +18,5 @@ blocking-dispatcher {
 iep.lwc.fwding-admin {
   age-limit = 10m
   queue-size-limit = 10000
+  cw-expr-uri = "http://localhost:7102/api/v2/cloudwatch-forwarding/clusters/%s"
 }

--- a/iep-lwc-fwding-admin/src/main/resources/cw-fwding-cfg-schema.json
+++ b/iep-lwc-fwding-admin/src/main/resources/cw-fwding-cfg-schema.json
@@ -14,7 +14,6 @@
       "expressions": {
         "description": "List of metric expressions",
         "type": "array",
-        "minItems": 1,
         "uniqueItems": true,
         "items": {
           "type": "object",

--- a/iep-lwc-fwding-admin/src/main/resources/cw-fwding-cfg-schema.json
+++ b/iep-lwc-fwding-admin/src/main/resources/cw-fwding-cfg-schema.json
@@ -70,7 +70,6 @@
       "checksToSkip": {
         "description": "The list of validations to skip",
         "type": "array",
-        "minItems": 1,
         "uniqueItems": true,
         "items": {
           "type": "string",

--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/Api.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/Api.scala
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.netflix.atlas.akka.CustomDirectives._
 import com.netflix.atlas.akka.WebApi
 import com.netflix.atlas.json.Json
+import com.netflix.iep.lwc.fwd.cw.ExpressionId
 import com.netflix.iep.lwc.fwd.cw.Report
 import com.netflix.spectator.api.Registry
 import com.typesafe.scalalogging.StrictLogging
@@ -36,6 +37,7 @@ class Api(
   schemaValidation: SchemaValidation,
   cwExprValidations: CwExprValidations,
   markerService: MarkerService,
+  purger: Purger,
   exprDetailsDao: ExpressionDetailsDao,
   system: ActorSystem
 ) extends WebApi
@@ -126,8 +128,16 @@ class Api(
           }
         }
       }
+    } ~
+    endpointPath("api" / "v1" / "cw" / "expr" / "purge") {
+      delete {
+        entity(as[JsonNode]) { json =>
+          complete {
+            purger.purge(Json.decode[List[ExpressionId]](json))
+          }
+        }
+      }
     }
-
   }
 
 }

--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/AppModule.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/AppModule.scala
@@ -27,6 +27,7 @@ class AppModule extends AbstractModule {
     val serviceBinder = Multibinder.newSetBinder(binder(), classOf[Service])
     serviceBinder.addBinding().to(classOf[MarkerServiceImpl])
     bind(classOf[MarkerService]).to(classOf[MarkerServiceImpl])
+    bind(classOf[Purger]).to(classOf[PurgerImpl])
     bind(classOf[ExpressionDetailsDao]).to(classOf[ExpressionDetailsDaoImpl])
   }
 

--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/ExpressionDetailsDao.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/ExpressionDetailsDao.scala
@@ -15,9 +15,7 @@
  */
 package com.netflix.iep.lwc.fwd.admin
 
-import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
 import com.amazonaws.services.dynamodbv2.document.DynamoDB
 import com.amazonaws.services.dynamodbv2.document.Item
 import com.amazonaws.services.dynamodbv2.document.PrimaryKey

--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/Purger.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/Purger.scala
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc.fwd.admin
+import java.nio.charset.StandardCharsets
+
+import akka.Done
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import com.netflix.atlas.akka.AccessLogger
+import com.netflix.atlas.akka.StreamOps
+import com.netflix.atlas.json.Json
+import com.netflix.iep.lwc.fwd.cw._
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+import javax.inject.Inject
+
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+trait Purger {
+  def purge(expressions: List[ExpressionId]): Future[Done]
+}
+
+class PurgerImpl @Inject()(
+  config: Config,
+  implicit val system: ActorSystem
+) extends Purger
+    with StrictLogging {
+  import PurgerImpl._
+
+  private implicit val mat = ActorMaterializer()
+
+  private val cwExprUri = config.getString("iep.lwc.fwding-admin.cw-expr-uri")
+  private val client = Http().superPool[AccessLogger]()
+
+  override def purge(expressions: List[ExpressionId]): Future[Done] = {
+
+    Source(expressions.groupBy(_.key))
+      .flatMapConcat { exprGrp =>
+        val (k, _) = exprGrp
+        Source
+          .single(k)
+          .via(getClusterConfig(cwExprUri, client))
+          .map(out => (exprGrp, out))
+
+      }
+      .map {
+        case ((k, e), c) =>
+          (
+            k,
+            removeExpressions(
+              e.map(_.expression),
+              c.payload
+            ).map(
+              ClusterCfgPayload(
+                c.version.copy(user = Some("admin"), comment = Some("Cleanup")),
+                _
+              )
+            )
+          )
+      }
+      .via(doPurge(cwExprUri, client))
+      .runWith(Sink.ignore)
+  }
+
+}
+
+object PurgerImpl extends StrictLogging {
+
+  type Client = Flow[(HttpRequest, AccessLogger), (Try[HttpResponse], AccessLogger), NotUsed]
+
+  def getClusterConfig(
+    cwExprUri: String,
+    client: Client
+  ): Flow[String, ClusterCfgPayload, NotUsed] = {
+    Flow[String]
+      .map(key => HttpRequest(HttpMethods.GET, Uri(cwExprUri.format(key))))
+      .map(r => r -> AccessLogger.newClientLogger("configbin", r))
+      .via(client)
+      .map {
+        case (result, accessLog) =>
+          accessLog.complete(result)
+
+          result match {
+            case Failure(e) => logger.error("Reading cw expression failed", e)
+            case _          =>
+          }
+
+          result
+      }
+      .collect { case Success(r) => r }
+      .filter(_.status == StatusCodes.OK)
+      .flatMapConcat(r => r.entity.dataBytes)
+      .map { d =>
+        Json
+          .decode[ClusterCfgPayload](
+            d.decodeString(StandardCharsets.UTF_8)
+          )
+      }
+  }
+
+  def removeExpressions(
+    expressions: List[ForwardingExpression],
+    clusterCfg: ClusterConfig
+  ): Option[ClusterConfig] = {
+    val e = clusterCfg.expressions.diff(expressions)
+
+    if (e.nonEmpty) {
+      Some(clusterCfg.copy(expressions = e))
+    } else {
+      None
+    }
+  }
+
+  def doPurge(
+    cwExprUri: String,
+    client: Client
+  ): Flow[(String, Option[ClusterCfgPayload]), NotUsed, NotUsed] = {
+    Flow[(String, Option[ClusterCfgPayload])]
+      .map {
+        case (k, c) =>
+          c.map { cfg =>
+              HttpRequest(
+                HttpMethods.PUT,
+                Uri(cwExprUri.format(k)),
+                entity = Json.encode(cfg)
+              ).withHeaders(RawHeader("conditional", "true"))
+            }
+            .getOrElse(
+              HttpRequest(
+                HttpMethods.DELETE,
+                Uri(s"${cwExprUri.format(k)}?user=admin&comment=cleanup")
+              )
+            )
+      }
+      .map { r =>
+        r -> AccessLogger.newClientLogger("configbin", r)
+      }
+      .via(client)
+      .via(StreamOps.map { (t, mat) =>
+        val (result, accessLog) = t
+        accessLog.complete(result)
+        result match {
+          case Success(response) =>
+            response.discardEntityBytes()(mat)
+          case Failure(e) =>
+            logger.error(s"Purging cw expression failed", e)
+        }
+        NotUsed
+      })
+  }
+
+}
+
+case class ClusterCfgPayload(
+  version: ConfigBinVersion,
+  payload: ClusterConfig
+)

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ExpressionDetailsDaoTestImpl.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ExpressionDetailsDaoTestImpl.scala
@@ -22,4 +22,5 @@ class ExpressionDetailsDaoTestImpl extends ExpressionDetailsDao {
   override def scan(): List[ExpressionId] = Nil
   override def queryPurgeEligible(now: Long, events: List[String]): List[ExpressionId] = Nil
   override def delete(id: ExpressionId): Unit = {}
+  override def isPurgeEligible(ed: ExpressionDetails, now: Long): Boolean = true
 }

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/PurgerSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/PurgerSuite.scala
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc.fwd.admin
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import com.netflix.atlas.akka.AccessLogger
+import com.netflix.atlas.json.Json
+import com.netflix.iep.lwc.fwd.cw.ClusterConfig
+import com.netflix.iep.lwc.fwd.cw.ConfigBinVersion
+import com.netflix.iep.lwc.fwd.cw.ForwardingExpression
+import org.scalatest.FunSuite
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.util.Success
+
+class PurgerSuite extends FunSuite {
+
+  import PurgerImpl._
+
+  private implicit val system = ActorSystem(getClass.getSimpleName)
+  private implicit val mat = ActorMaterializer()
+
+  test("Read cluster config") {
+
+    val cfgPayload = ClusterCfgPayload(
+      ConfigBinVersion(1552669178072L, "", None, None),
+      ClusterConfig("", List(ForwardingExpression("", "", None, "")))
+    )
+
+    val client: Client =
+      Flow[(HttpRequest, AccessLogger)]
+        .map {
+          case (_, accessLogger) =>
+            (
+              Success(
+                HttpResponse(
+                  StatusCodes.OK,
+                  entity = HttpEntity(MediaTypes.`application/json`, Json.encode(cfgPayload))
+                )
+              ),
+              accessLogger
+            )
+        }
+
+    val future = Source
+      .single("config1")
+      .via(getClusterConfig("http://local/%s", client))
+      .runWith(Sink.head)
+
+    val actual = Await.result(future, Duration.Inf)
+
+    assert(actual === cfgPayload)
+  }
+
+  test("Read cluster config that is not found") {
+
+    val client: Client =
+      Flow[(HttpRequest, AccessLogger)]
+        .map {
+          case (_, accessLogger) =>
+            (
+              Success(HttpResponse(StatusCodes.NotFound)),
+              accessLogger
+            )
+        }
+
+    val future = Source
+      .single("config1")
+      .via(getClusterConfig("http://local/%s", client))
+      .runWith(Sink.headOption)
+
+    val actual = Await.result(future, Duration.Inf)
+
+    assert(actual === None)
+  }
+
+  test("Update cluster config") {
+    val expressions = List(
+      ForwardingExpression("uri1", "", None, ""),
+      ForwardingExpression("uri2", "", None, ""),
+      ForwardingExpression("uri2", "", None, "")
+    )
+
+    val clusterConfig = ClusterConfig("", expressions)
+
+    val toPurge = expressions.filter(_.atlasUri == "uri1")
+    val actual = removeExpressions(toPurge, clusterConfig)
+
+    val expected = expressions.filterNot(_.atlasUri == "uri1")
+    assert(actual === Some(ClusterConfig("", expected)))
+  }
+
+  test("Remove cluster config") {
+    val exprs = List(ForwardingExpression("uri1", "", None, ""))
+    val clusterConfig = ClusterConfig("", exprs)
+
+    val actual = removeExpressions(exprs, clusterConfig)
+
+    assert(actual === None)
+  }
+
+  test("Send out PUT req for purging expr in cluster config") {
+    val requests = List.newBuilder[HttpRequest]
+    val client: Client =
+      Flow[(HttpRequest, AccessLogger)]
+        .map {
+          case (request, accessLogger) =>
+            requests += request
+            (Success(HttpResponse(StatusCodes.OK)), accessLogger)
+        }
+
+    val cfgPayload = ClusterCfgPayload(
+      ConfigBinVersion(1552669178072L, "", None, None),
+      ClusterConfig("", List(ForwardingExpression("", "", None, "")))
+    )
+
+    val future = Source
+      .single(("config1", Some(cfgPayload)))
+      .via(doPurge("http://local/%s", client))
+      .runWith(Sink.head)
+
+    val expected = HttpRequest(
+      HttpMethods.PUT,
+      Uri("http://local/config1"),
+      entity = Json.encode(cfgPayload)
+    ).withHeaders(RawHeader("conditional", "true"))
+
+    val result = Await.result(future, Duration.Inf)
+
+    assert(result === NotUsed)
+    assert(requests.result() === List(expected))
+  }
+
+  test("Send out DELETE req for removing a cluster config") {
+    val requests = List.newBuilder[HttpRequest]
+    val client: Client =
+      Flow[(HttpRequest, AccessLogger)]
+        .map {
+          case (request, accessLogger) =>
+            requests += request
+            (Success(HttpResponse(StatusCodes.OK)), accessLogger)
+        }
+
+    val future = Source
+      .single(("config1", None))
+      .via(doPurge("http://local/%s", client))
+      .runWith(Sink.head)
+
+    val expected = HttpRequest(
+      HttpMethods.DELETE,
+      Uri("http://local/config1?user=admin&comment=cleanup"),
+    )
+
+    val result = Await.result(future, Duration.Inf)
+
+    assert(result === NotUsed)
+    assert(requests.result() === List(expected))
+  }
+
+}

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/SchemaValidationSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/SchemaValidationSuite.scala
@@ -70,7 +70,7 @@ class SchemaValidationSuite extends FunSuite with TestAssertions with CwForwardi
     )
   }
 
-  test("Fail when no expression is found") {
+  test("Allow empty list for expressions") {
     val config =
       """
         |{
@@ -78,11 +78,7 @@ class SchemaValidationSuite extends FunSuite with TestAssertions with CwForwardi
         |  "expressions": []
         |}
       """.stripMargin
-
-    assertFailure(
-      validate(config),
-      "array is too short"
-    )
+    validate(config)
   }
 
   test("Fail for missing fields in an expression") {

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/SchemaValidationSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/SchemaValidationSuite.scala
@@ -251,11 +251,8 @@ class SchemaValidationSuite extends FunSuite with TestAssertions with CwForwardi
     }
   }
 
-  test("checksToSkip cannot be empty") {
-    assertFailure(
-      validate(makeConfigString()(checksToSkip = "[]")),
-      "array is too short"
-    )
+  test("checksToSkip can be empty") {
+    validate(makeConfigString()(checksToSkip = "[]"))
   }
 
   test("checksToSkip entries cannot be empty") {


### PR DESCRIPTION
Adds an endpoint to update or remove cluster configurations
in ConfigBin for the given expressions.

Modified the cluster config schema to allow empty list
for `checksToSkip` field. This is convenient because Json
encoding creates this empty list.

Moved ConfigBinVersion to the shared library.