### PR TITLE
druid: filter out datapoints with null values

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -285,6 +285,7 @@ object DruidClient {
   }
 
   case class GroupByDatapoint(timestamp: String, event: Map[String, String]) {
+
     /**
       * Checks that all values in the event are non-null. Druid treats empty strings and
       * null values as being the same. Some older threads suggest server side filtering

--- a/atlas-druid/src/test/resources/groupByResponse.json
+++ b/atlas-druid/src/test/resources/groupByResponse.json
@@ -1,0 +1,50 @@
+[
+  {
+    "version": "v1",
+    "timestamp": "2019-03-28T15:25:00.000Z",
+    "event": {
+      "value": 0,
+      "percentile": null
+    }
+  },
+  {
+    "version": "v1",
+    "timestamp": "2019-03-28T15:25:00.000Z",
+    "event": {
+      "value": 0,
+      "percentile": "T0000"
+    }
+  },
+  {
+    "version": "v1",
+    "timestamp": "2019-03-28T15:25:00.000Z",
+    "event": {
+      "value": 0,
+      "percentile": "T0002"
+    }
+  },
+  {
+    "version": "v1",
+    "timestamp": "2019-03-28T15:25:00.000Z",
+    "event": {
+      "value": 1,
+      "percentile": "T002A"
+    }
+  },
+  {
+    "version": "v1",
+    "timestamp": "2019-03-28T15:25:00.000Z",
+    "event": {
+      "value": 1,
+      "percentile": "T002B"
+    }
+  },
+  {
+    "version": "v1",
+    "timestamp": "2019-03-28T15:25:00.000Z",
+    "event": {
+      "value": 1,
+      "percentile": "T002C"
+    }
+  }
+]

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
@@ -179,4 +179,20 @@ class DruidClientSuite extends FunSuite with BeforeAndAfterAll {
     )
     assert(aggregators.keySet === expected)
   }
+
+  private def executeGroupByRequest: List[GroupByDatapoint] = {
+    import com.netflix.atlas.core.util.Streams._
+    val file = "groupByResponse.json"
+    val payload = scope(resource(file))(byteArray)
+    val response = HttpResponse(StatusCodes.OK, entity = payload)
+    val client = newClient(Success(response))
+    val query = GroupByQuery("test", Nil, Nil, Nil)
+    val future = client.groupBy(query).runWith(Sink.head)
+    Await.result(future, Duration.Inf)
+  }
+
+  test("groupBy filter out null dimensions") {
+    val datapoints = executeGroupByRequest
+    assert(datapoints.size === 5)
+  }
 }


### PR DESCRIPTION
Druid treats null and empty string as being the same. If
dimensions returned as part of the event map from a group
by request have a null value, then filter them out to avoid
NPE during request processing in Atlas. For the Atlas storage
null values are not allowed and cannot be part of the response.