### PR TITLE
Scaling policy lookup for expressions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -163,6 +163,7 @@ lazy val `iep-lwc-cloudwatch` = project
     Dependencies.iepGuice,
     Dependencies.iepModuleAtlas,
     Dependencies.iepModuleAws,
+    Dependencies.iepNflxEnv,
     Dependencies.log4jApi,
     Dependencies.log4jCore,
     Dependencies.log4jSlf4j,

--- a/iep-lwc-fwding-admin/src/main/resources/application.conf
+++ b/iep-lwc-fwding-admin/src/main/resources/application.conf
@@ -5,6 +5,14 @@ atlas.akka {
     "com.netflix.atlas.akka.HealthcheckApi",
     "com.netflix.iep.lwc.fwd.admin.Api"
   ]
+
+  actors = ${?atlas.akka.actors} [
+    {
+      name = "scalingPolicies"
+      class = "com.netflix.iep.lwc.fwd.admin.ScalingPolicies"
+    }
+  ]
+
 }
 
 blocking-dispatcher {
@@ -18,5 +26,13 @@ blocking-dispatcher {
 iep.lwc.fwding-admin {
   age-limit = 10m
   queue-size-limit = 10000
+  edda-cache-refresh-interval = 30m
   cw-expr-uri = "http://localhost:7102/api/v2/cloudwatch-forwarding/clusters/%s"
+
+  // The host name in the properties 'cw-alarms-uri', 'ec2-policies-uri' and 'titus-policies-uri'
+  // uses the following pattern to lookup the appropriate Edda deployment.
+  // "prefix-%s.%s.%s.suffix".format(account, region, env)
+  cw-alarms-uri = "http://localhost:7103/api/v2/aws/alarms;namespace=NFLX/EPIC;_expand:(alarmName,metricName,dimensions:(name,value))"
+  ec2-policies-uri = "http://localhost:7103/api/v2/aws/scalingPolicies;_expand:(policyName,alarms:(alarmName))"
+  titus-policies-uri = "http://localhost:7103/api/v3/netflix/titusscalingPolicies;_expand:(jobId,id,scalingPolicy:(targetPolicyDescriptor:(customizedMetricSpecification)))"
 }

--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/AppModule.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/AppModule.scala
@@ -29,6 +29,7 @@ class AppModule extends AbstractModule {
     bind(classOf[MarkerService]).to(classOf[MarkerServiceImpl])
     bind(classOf[Purger]).to(classOf[PurgerImpl])
     bind(classOf[ExpressionDetailsDao]).to(classOf[ExpressionDetailsDaoImpl])
+    bind(classOf[ScalingPoliciesDao]).to(classOf[ScalingPoliciesDaoImpl])
   }
 
   // Visibility of protected to avoid unused method warning from scala compiler

--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/Purger.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/Purger.scala
@@ -149,6 +149,12 @@ object PurgerImpl extends StrictLogging {
           result
       }
       .collect { case Success(r) => r }
+      .via(StreamOps.map { (r, mat) =>
+        if (r.status != StatusCodes.OK) {
+          r.discardEntityBytes()(mat)
+        }
+        r
+      })
       .filter(_.status == StatusCodes.OK)
       .flatMapConcat(r => r.entity.dataBytes)
       .map { d =>

--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/ScalingPolicies.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/ScalingPolicies.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc.fwd.admin
+import akka.NotUsed
+import akka.actor.Actor
+import akka.actor.Timers
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import com.netflix.iep.NetflixEnvironment._
+import com.netflix.iep.lwc.fwd.admin.ScalingPolicies._
+import com.netflix.iep.lwc.fwd.cw.FwdMetricInfo
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+
+import scala.concurrent.Future
+import scala.util.Failure
+
+class ScalingPolicies(config: Config, dao: ScalingPoliciesDao)
+    extends Actor
+    with Timers
+    with StrictLogging {
+
+  private implicit val mat = ActorMaterializer()
+  private implicit val ec = scala.concurrent.ExecutionContext.global
+
+  protected var scalingPolicies = Map.empty[EddaEndpoint, List[ScalingPolicy]]
+
+  private val cacheRefreshInterval =
+    config.getDuration("iep.lwc.fwding-admin.edda-cache-refresh-interval")
+
+  startPeriodicTimer()
+
+  override def receive: Receive = {
+    case GetScalingPolicy(metricInfo) => respond(getScalingPolicy(metricInfo))
+    case AddScalingPolicies(policies) => scalingPolicies = scalingPolicies ++ policies
+    case RefreshCache                 => respond(refreshCache)
+    case GetCache                     => sender() ! scalingPolicies
+    case message                      => throw new RuntimeException(s"Unknown message ${message}")
+  }
+
+  def startPeriodicTimer(): Unit = {
+    timers.startPeriodicTimer(NotUsed, RefreshCache, cacheRefreshInterval)
+  }
+
+  def respond[T](handleMessage: => Future[T]): Unit = {
+    val senderRef = sender()
+    val future = handleMessage.map { response =>
+      senderRef ! response
+    }
+
+    future.onComplete {
+      case Failure(e) => logger.error("Error processing message", e)
+      case _          =>
+    }
+  }
+
+  def getScalingPolicy(metricInfo: FwdMetricInfo): Future[Option[ScalingPolicy]] = {
+    getScalingPolicies(EddaEndpoint(metricInfo.account, metricInfo.region, env()))
+      .map(_.find(_.matchMetric(metricInfo)))
+  }
+
+  def getScalingPolicies(
+    eddaEndpoint: EddaEndpoint
+  ): Future[List[ScalingPolicy]] = {
+    scalingPolicies
+      .get(eddaEndpoint)
+      .map(Future(_))
+      .getOrElse {
+        Source
+          .single(eddaEndpoint)
+          .via(dao.getScalingPolicies())
+          .runWith(Sink.headOption)
+          .map { policies =>
+            policies
+              .map { p =>
+                self ! AddScalingPolicies(Map(eddaEndpoint -> p))
+                p
+              }
+              .getOrElse(throw new RuntimeException("Edda Error"))
+          }
+      }
+  }
+
+  def refreshCache(): Future[Unit] = {
+    val eddaEndpoints = scalingPolicies.keys.toList
+    Source(eddaEndpoints)
+      .flatMapConcat { eddaEndpoint =>
+        Source
+          .single(eddaEndpoint)
+          .via(dao.getScalingPolicies())
+          .map((eddaEndpoint, _))
+      }
+      .runWith(Sink.seq)
+      .map { allPolicies =>
+        if (allPolicies.size != eddaEndpoints.size) {
+          val failedEndpoints = eddaEndpoints.diff(
+            allPolicies
+              .map { case (e, _) => e }
+          )
+          logger.error(s"Failed to refresh Edda for endpoints: $failedEndpoints")
+        }
+        self ! AddScalingPolicies(allPolicies.toMap)
+      }
+  }
+}
+
+object ScalingPolicies {
+  case class GetScalingPolicy(metricInfo: FwdMetricInfo)
+  case object GetCache
+
+  private case class AddScalingPolicies(policies: Map[EddaEndpoint, List[ScalingPolicy]])
+  private[admin] case object RefreshCache
+}

--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/ScalingPoliciesDao.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/ScalingPoliciesDao.scala
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc.fwd.admin
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.coding.Gzip
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.Accept
+import akka.http.scaladsl.model.headers.HttpEncodings
+import akka.http.scaladsl.model.headers.`Accept-Encoding`
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Source
+import com.netflix.atlas.akka.AccessLogger
+import com.netflix.atlas.akka.StreamOps
+import com.netflix.atlas.json.Json
+import com.netflix.iep.lwc.fwd.cw.FwdMetricInfo
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+import javax.inject.Inject
+
+import scala.util.Failure
+import scala.util.Success
+
+trait ScalingPoliciesDao {
+  def getScalingPolicies(): Flow[EddaEndpoint, List[ScalingPolicy], NotUsed]
+}
+
+class ScalingPoliciesDaoImpl @Inject()(
+  config: Config,
+  implicit val system: ActorSystem
+) extends ScalingPoliciesDao
+    with StrictLogging {
+
+  private implicit val mat = ActorMaterializer()
+  private implicit val ec = scala.concurrent.ExecutionContext.global
+
+  private val ec2PoliciesUri = config.getString("iep.lwc.fwding-admin.ec2-policies-uri")
+  private val cwAlarmsUri = config.getString("iep.lwc.fwding-admin.cw-alarms-uri")
+  private val titusPoliciesUri = config.getString("iep.lwc.fwding-admin.titus-policies-uri")
+
+  protected val client = Http().superPool[AccessLogger]()
+
+  override def getScalingPolicies(): Flow[EddaEndpoint, List[ScalingPolicy], NotUsed] = {
+
+    Flow[EddaEndpoint]
+      .filter { eddaEndpoint =>
+        val valid = eddaEndpoint.account.nonEmpty &&
+        eddaEndpoint.region.nonEmpty &&
+        eddaEndpoint.env.nonEmpty
+
+        if (!valid) {
+          logger.error(s"Invalid EddaEndpoint $eddaEndpoint")
+        }
+
+        valid
+      }
+      .flatMapConcat { eddaEndpoint =>
+        Source
+          .single(eddaEndpoint)
+          .map(makeEddaUri(_, cwAlarmsUri))
+          .via(doGet())
+          .map(Json.decode[List[CwAlarm]](_))
+          .map((eddaEndpoint, _))
+      }
+      .flatMapConcat {
+        case (eddaEndpoint, alarms) =>
+          Source
+            .single(eddaEndpoint)
+            .map(makeEddaUri(_, ec2PoliciesUri))
+            .via(doGet())
+            .map(Json.decode[List[Ec2ScalingPolicy]](_))
+            .map(makeEc2ScalingPolicies(_, alarms))
+            .map((eddaEndpoint, alarms, _))
+      }
+      .flatMapConcat {
+        case (eddaEndpoint, alarms, ec2Policies) =>
+          Source
+            .single(eddaEndpoint)
+            .map(makeEddaUri(_, titusPoliciesUri))
+            .via(doGet())
+            .map(Json.decode[List[TitusScalingPolicy]](_))
+            .map(makeTitusScalingPolicies(_, alarms))
+            .map((ec2Policies, _))
+      }
+      .map {
+        case (ec2, titus) =>
+          ec2 ++ titus
+      }
+  }
+
+  def makeEc2ScalingPolicies(
+    ec2Policies: List[Ec2ScalingPolicy],
+    alarms: List[CwAlarm]
+  ): List[ScalingPolicy] = {
+
+    ec2Policies.flatMap { policy =>
+      val a = policy.alarms.flatMap { alarm =>
+        alarms.find(_.alarmName == alarm.alarmName)
+      }
+
+      a.map { alarm =>
+        ScalingPolicy(
+          policy.getPolicyId(),
+          ScalingPolicy.Ec2,
+          alarm.metricName,
+          alarm.dimensions
+        )
+      }
+    }
+
+  }
+
+  def makeTitusScalingPolicies(
+    titusPolicies: List[TitusScalingPolicy],
+    alarms: List[CwAlarm]
+  ): List[ScalingPolicy] = {
+
+    titusPolicies.flatMap { policy =>
+      if (policy.isTargetPolicy()) {
+        val spec = policy.getCustomMetricSpec()
+
+        Some(
+          ScalingPolicy(
+            policy.getPolicyId(),
+            ScalingPolicy.Titus,
+            spec.metricName,
+            spec.dimensions
+          )
+        )
+      } else {
+        val alarmName = s"${policy.jobId}/${policy.id.id}"
+        val a = alarms
+          .find(_.alarmName == alarmName)
+
+        a.map { alarm =>
+          ScalingPolicy(
+            policy.getPolicyId(),
+            ScalingPolicy.Titus,
+            alarm.metricName,
+            alarm.dimensions
+          )
+        }
+      }
+    }
+  }
+
+  def doGet(): Flow[Uri, String, NotUsed] = {
+    Flow[Uri]
+      .map(
+        uri =>
+          HttpRequest(HttpMethods.GET, uri).withHeaders(
+            `Accept-Encoding`(HttpEncodings.gzip),
+            Accept(MediaTypes.`application/json`)
+        )
+      )
+      .map(r => r -> AccessLogger.newClientLogger("edda", r))
+      .via(client)
+      .map {
+        case (result, accessLog) =>
+          accessLog.complete(result)
+
+          result match {
+            case Failure(e) => logger.error("Request to Edda failed", e)
+            case _          =>
+          }
+
+          result
+      }
+      .collect { case Success(r) => r }
+      .via(StreamOps.map { (r, mat) =>
+        if (r.status != StatusCodes.OK) {
+          r.discardEntityBytes()(mat)
+        }
+        r
+      })
+      .filter(_.status == StatusCodes.OK)
+      .map(Gzip.decodeMessage(_))
+      .mapAsync[String](1)(r => Unmarshal(r.entity).to[String])
+  }
+
+  def makeEddaUri(eddaEndpoint: EddaEndpoint, uriPattern: String): Uri = {
+    Uri(uriPattern.format(eddaEndpoint.account, eddaEndpoint.region, eddaEndpoint.env))
+  }
+}
+
+case class ScalingPolicy(
+  policyId: String,
+  policyType: String,
+  metricName: String,
+  dimensions: List[MetricDimension]
+) {
+
+  def matchMetric(metricInfo: FwdMetricInfo): Boolean = {
+    metricInfo.name == metricName && metricInfo.dimensions == dimensions
+      .map(d => (d.name, d.value))
+      .toMap
+  }
+}
+case class MetricDimension(name: String, value: String)
+
+object ScalingPolicy {
+  val Titus = "titus"
+  val Ec2 = "ec2"
+}
+
+case class EddaEndpoint(account: String, region: String, env: String)
+
+case class Ec2ScalingPolicy(policyName: String, alarms: List[CwAlarm]) {
+  def getPolicyId(): String = policyName
+}
+case class CwAlarm(alarmName: String, metricName: String, dimensions: List[MetricDimension])
+
+case class TitusScalingPolicy(jobId: String, id: Id, scalingPolicy: ScalingPolicyDetails) {
+  def getPolicyId(): String = id.id
+
+  def isTargetPolicy(): Boolean = {
+    scalingPolicy.targetPolicyDescriptor.isDefined
+  }
+
+  def getCustomMetricSpec(): CustomMetricSpec = {
+    scalingPolicy.targetPolicyDescriptor
+      .map(_.customizedMetricSpecification)
+      .getOrElse(throw new RuntimeException("targetPolicyDescriptor not found"))
+  }
+
+}
+case class Id(id: String)
+case class ScalingPolicyDetails(targetPolicyDescriptor: Option[TargetPolicyDescriptor])
+case class TargetPolicyDescriptor(customizedMetricSpecification: CustomMetricSpec)
+case class CustomMetricSpec(metricName: String, dimensions: List[MetricDimension])

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ExpressionDetailsDaoSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ExpressionDetailsDaoSuite.scala
@@ -64,7 +64,7 @@ class ExpressionDetailsDaoSuite extends FunSuite with BeforeAndAfter with Strict
         """
           | http://localhost/api/v1/graph?q=
           |  nf.app,foo_app1,:eq,
-          |  name,nodejs.cpuUsage,:eq,:and,
+          |  name,metric1,:eq,:and,
           |  :node-avg,
           |  (,nf.account,nf.asg,),:by
         """.stripMargin
@@ -72,7 +72,7 @@ class ExpressionDetailsDaoSuite extends FunSuite with BeforeAndAfter with Strict
           .replace("\n", ""),
         "$(nf.account)",
         Some("us-east-1"),
-        "nodejs.cpuUsage",
+        "metric1",
         List(
           ForwardingDimension(
             "AutoScalingGroup",
@@ -85,17 +85,17 @@ class ExpressionDetailsDaoSuite extends FunSuite with BeforeAndAfter with Strict
     val exprDetails = new ExpressionDetails(
       id,
       1551820461000L,
-      Some(
+      List(
         FwdMetricInfo(
           "us-east-1",
           "1234",
-          "nodejs.cpuUsage",
+          "metric1",
           Map("AutoScalingGroup" -> "asg1-v00")
         )
       ),
       None,
       Map.empty[String, Long],
-      None
+      List(ScalingPolicy("ec2Policy1", ScalingPolicy.Ec2, "metric1", Nil))
     )
 
     dao.save(exprDetails)
@@ -114,18 +114,18 @@ class ExpressionDetailsDaoSuite extends FunSuite with BeforeAndAfter with Strict
       new ExpressionDetails(
         id.copy(key = "config2"),
         reportTs,
-        None,
+        Nil,
         None,
         Map.empty[String, Long],
-        None
+        Nil
       ),
       new ExpressionDetails(
         id.copy(key = "config3"),
         reportTs,
-        None,
+        Nil,
         None,
         Map(NoDataFoundEvent -> reportTs),
-        None
+        Nil
       )
     )
 
@@ -152,13 +152,13 @@ class ExpressionDetailsSuite extends FunSuite with StrictLogging {
     val ed = new ExpressionDetails(
       ExpressionId("config1", ForwardingExpression("", "", None, "", Nil)),
       reportTs,
-      None,
+      Nil,
       None,
       Map(
         NoDataFoundEvent          -> reportTs,
         NoScalingPolicyFoundEvent -> timestampThen
       ),
-      None
+      Nil
     )
 
     val actual = ed.isPurgeEligible(timestampThen, 10.minutes.toMillis)
@@ -173,10 +173,10 @@ class ExpressionDetailsSuite extends FunSuite with StrictLogging {
     val ed = new ExpressionDetails(
       ExpressionId("config1", ForwardingExpression("", "", None, "", Nil)),
       reportTs,
-      None,
+      Nil,
       None,
       Map("foo" -> reportTs),
-      None
+      Nil
     )
 
     val actual = ed.isPurgeEligible(timestampThen, 10.minutes.toMillis)
@@ -191,10 +191,10 @@ class ExpressionDetailsSuite extends FunSuite with StrictLogging {
     val ed = new ExpressionDetails(
       ExpressionId("config1", ForwardingExpression("", "", None, "", Nil)),
       reportTs,
-      None,
+      Nil,
       None,
       Map.empty[String, Long],
-      None
+      Nil
     )
 
     val actual = ed.isPurgeEligible(timestampThen, 10.minutes.toMillis)

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/PurgerSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/PurgerSuite.scala
@@ -48,18 +48,18 @@ class PurgerSuite extends FunSuite {
       ExpressionDetails(
         ExpressionId("cluster1", ForwardingExpression("", "", None, "")),
         1552891811000L,
-        None,
+        Nil,
         None,
         Map(NoDataFoundEvent -> (1552891811000L - 11.minutes.toMillis)),
-        None
+        Nil
       ),
       ExpressionDetails(
         ExpressionId("cluster2", ForwardingExpression("", "", None, "")),
         1552891811000L,
-        None,
+        Nil,
         None,
         Map.empty[String, Long],
-        None
+        Nil
       )
     )
 
@@ -158,10 +158,10 @@ class PurgerSuite extends FunSuite {
       ExpressionDetails(
         ExpressionId("cluster1", expressions.find(_.atlasUri == "uri1").get),
         1552891811000L,
-        None,
+        Nil,
         None,
         Map(NoDataFoundEvent -> (now - 11.minutes.toMillis)),
-        None
+        Nil
       )
     )
 
@@ -218,10 +218,10 @@ class PurgerSuite extends FunSuite {
     val ed = ExpressionDetails(
       ExpressionId("", ForwardingExpression("", "", None, "", Nil)),
       1552891811000L,
-      None,
+      Nil,
       None,
       Map.empty[String, Long],
-      None
+      Nil
     )
 
     val future = Source

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ScalingPoliciesDaoSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ScalingPoliciesDaoSuite.scala
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc.fwd.admin
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model._
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import com.netflix.atlas.akka.AccessLogger
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuite
+
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+class ScalingPoliciesDaoSuite extends FunSuite {
+  val config = ConfigFactory.load()
+  private implicit val system = ActorSystem()
+  private implicit val mat = ActorMaterializer()
+
+  val ec2PoliciesUri = config.getString("iep.lwc.fwding-admin.ec2-policies-uri")
+  val cwAlarmsUri = config.getString("iep.lwc.fwding-admin.cw-alarms-uri")
+  val titusPoliciesUri = config.getString("iep.lwc.fwding-admin.titus-policies-uri")
+
+  test("Lookup all EC2 scaling policies") {
+    val data = Map(
+      Uri(ec2PoliciesUri) ->
+      """
+          |[
+          |  {
+          |    "alarms": [
+          |      {
+          |        "alarmName": "alarm1"
+          |      }
+          |    ],
+          |    "policyName": "ec2Policy1"
+          |  }
+          |]
+        """.stripMargin,
+      Uri(cwAlarmsUri) ->
+      """
+          |[
+          |  {
+          |    "alarmName": "alarm1",
+          |    "metricName": "metric1",
+          |    "dimensions": [
+          |      {
+          |        "value": "asg1",
+          |        "name": "AutoScalingGroupName"
+          |      }
+          |    ]
+          |  }
+          |]
+        """.stripMargin,
+      Uri(titusPoliciesUri) -> "[]"
+    )
+
+    val dao = new LocalScalingPoliciesDaoTestImpl(data, config, system)
+    val future = getScalingPolicies(dao, EddaEndpoint("123", "us-east-1", "test"))
+
+    val actual = Await.result(future, Duration.Inf)
+    val expected = List(
+      ScalingPolicy(
+        "ec2Policy1",
+        ScalingPolicy.Ec2,
+        "metric1",
+        List(MetricDimension("AutoScalingGroupName", "asg1"))
+      )
+    )
+    assert(actual === expected)
+  }
+
+  test("Lookup Titus scaling policies of type Target tracking") {
+    val data = Map(
+      Uri(ec2PoliciesUri) -> "[]",
+      Uri(cwAlarmsUri)    -> "[]",
+      Uri(titusPoliciesUri) ->
+      """
+          |[
+          |  {
+          |    "id": {
+          |      "id": "titusPolicy1"
+          |    },
+          |    "scalingPolicy": {
+          |      "targetPolicyDescriptor": {
+          |        "customizedMetricSpecification": {
+          |          "dimensions": [
+          |            {
+          |              "value": "asg1",
+          |              "name": "AutoScalingGroupName"
+          |            }
+          |          ],
+          |          "metricName": "metric1"
+          |        }
+          |      }
+          |    }
+          |  }
+          |]
+        """.stripMargin
+    )
+
+    val dao = new LocalScalingPoliciesDaoTestImpl(data, config, system)
+    val future = getScalingPolicies(dao, EddaEndpoint("123", "us-east-1", "test"))
+
+    val actual = Await.result(future, Duration.Inf)
+    val expected = List(
+      ScalingPolicy(
+        "titusPolicy1",
+        ScalingPolicy.Titus,
+        "metric1",
+        List(MetricDimension("AutoScalingGroupName", "asg1"))
+      )
+    )
+    assert(actual === expected)
+  }
+
+  test("Lookup Titus scaling policies of type Step scaling") {
+    val data = Map(
+      Uri(ec2PoliciesUri) -> "[]",
+      Uri(cwAlarmsUri) ->
+      """
+          |[
+          |  {
+          |    "alarmName": "job1/titusPolicy1",
+          |    "metricName": "metric1",
+          |    "dimensions": [
+          |      {
+          |        "value": "asg1",
+          |        "name": "AutoScalingGroupName"
+          |      }
+          |    ]
+          |  }
+          |]
+        """.stripMargin,
+      Uri(titusPoliciesUri) ->
+      """
+        |[
+        |  {
+        |    "jobId": "job1",
+        |    "id": {
+        |      "id": "titusPolicy1"
+        |    },
+        |    "scalingPolicy": {
+        |      "stepPolicyDescriptor": {}
+        |    }
+        |  }
+        |]
+      """.stripMargin
+    )
+
+    val dao = new LocalScalingPoliciesDaoTestImpl(data, config, system)
+    val future = getScalingPolicies(dao, EddaEndpoint("123", "us-east-1", "test"))
+
+    val actual = Await.result(future, Duration.Inf)
+    val expected = List(
+      ScalingPolicy(
+        "titusPolicy1",
+        ScalingPolicy.Titus,
+        "metric1",
+        List(MetricDimension("AutoScalingGroupName", "asg1"))
+      )
+    )
+    assert(actual === expected)
+  }
+
+  test("Fail when a downstream call fails") {
+    // No data for titusPoliciesUri should trigger a failure
+    val data = Map(
+      Uri(ec2PoliciesUri) -> "[]",
+      Uri(cwAlarmsUri)    -> "[]"
+    )
+
+    val dao = new LocalScalingPoliciesDaoTestImpl(data, config, system)
+    val future = getScalingPolicies(dao, EddaEndpoint("123", "us-east-1", "test"))
+
+    assertThrows[NoSuchElementException](Await.result(future, Duration.Inf))
+  }
+
+  test("Fail when status is not ok") {
+    val dao = new LocalScalingPoliciesDaoTestImpl(Map.empty[Uri, String], config, system) {
+      override def makeResponse(uri: Uri): Try[HttpResponse] = {
+        Success(HttpResponse(StatusCodes.InternalServerError))
+      }
+    }
+    val future = getScalingPolicies(dao, EddaEndpoint("123", "us-east-1", "test"))
+
+    assertThrows[NoSuchElementException](Await.result(future, Duration.Inf))
+  }
+
+  def getScalingPolicies(
+    dao: ScalingPoliciesDao,
+    eddaEndpoint: EddaEndpoint
+  ): Future[List[ScalingPolicy]] = {
+    Source
+      .single(EddaEndpoint("123", "us-east-1", "test"))
+      .via(dao.getScalingPolicies())
+      .runWith(Sink.head)
+  }
+}
+
+class LocalScalingPoliciesDaoTestImpl(
+  data: Map[Uri, String],
+  config: Config,
+  override implicit val system: ActorSystem
+) extends ScalingPoliciesDaoImpl(config, system) {
+  override protected val client = Flow[(HttpRequest, AccessLogger)]
+    .map {
+      case (request, accessLogger) =>
+        (
+          makeResponse(request.uri),
+          accessLogger
+        )
+    }
+
+  def makeResponse(uri: Uri): Try[HttpResponse] = {
+    data
+      .get(uri)
+      .map { body =>
+        Success(
+          HttpResponse(
+            StatusCodes.OK,
+            entity = HttpEntity(MediaTypes.`application/json`, body)
+          )
+        )
+      }
+      .getOrElse {
+        Failure(new RuntimeException("Error fetching data"))
+      }
+  }
+}

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ScalingPoliciesSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ScalingPoliciesSuite.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc.fwd.admin
+import akka.actor.ActorSystem
+import akka.actor.Props
+import akka.pattern.AskTimeoutException
+import akka.pattern.ask
+import akka.stream.scaladsl.Flow
+import akka.testkit.DefaultTimeout
+import akka.testkit.ImplicitSender
+import akka.testkit.TestKit
+import com.netflix.iep.lwc.fwd.admin.ScalingPolicies.GetCache
+import com.netflix.iep.lwc.fwd.admin.ScalingPolicies.GetScalingPolicy
+import com.netflix.iep.lwc.fwd.admin.ScalingPolicies.RefreshCache
+import com.netflix.iep.lwc.fwd.cw.FwdMetricInfo
+import com.typesafe.config.ConfigFactory
+import org.scalatest.FunSuiteLike
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class ScalingPoliciesSuite
+    extends TestKit(ActorSystem())
+    with FunSuiteLike
+    with DefaultTimeout
+    with ImplicitSender {
+
+  private val config = ConfigFactory.load()
+
+  test("Get cached Scaling policy") {
+    val ec2Policy1 = ScalingPolicy("ec2Policy1", ScalingPolicy.Ec2, "metric1", Nil)
+    val data = Map(EddaEndpoint("123", "us-east-1", "test") -> List(ec2Policy1))
+
+    val scalingPolicies = system.actorOf(
+      Props[ScalingPoliciesTestImpl](
+        new ScalingPoliciesTestImpl(
+          config,
+          new ScalingPoliciesDaoTestImpl(Map.empty[EddaEndpoint, List[ScalingPolicy]]),
+          data
+        )
+      )
+    )
+
+    val future = scalingPolicies ? GetScalingPolicy(
+      FwdMetricInfo("us-east-1", "123", "metric1", Map.empty[String, String])
+    )
+    val actual = Await.result(future.mapTo[Option[ScalingPolicy]], Duration.Inf)
+    val expected = Some(ec2Policy1)
+    assert(actual === expected)
+  }
+
+  test("Lookup Scaling policy") {
+    val ec2Policy1 = ScalingPolicy("ec2Policy1", ScalingPolicy.Ec2, "metric1", Nil)
+    val data = Map(EddaEndpoint("123", "us-east-1", "test") -> List(ec2Policy1))
+    val scalingPolicies = system.actorOf(
+      Props[ScalingPoliciesTestImpl](
+        new ScalingPoliciesTestImpl(
+          config,
+          new ScalingPoliciesDaoTestImpl(policies = data)
+        )
+      )
+    )
+
+    var future = scalingPolicies ? GetScalingPolicy(
+      FwdMetricInfo("us-east-1", "123", "metric1", Map.empty[String, String])
+    )
+    val actual = Await.result(future.mapTo[Option[ScalingPolicy]], Duration.Inf)
+
+    val expected = Some(ec2Policy1)
+    assert(actual === expected)
+
+    future = scalingPolicies ? GetCache
+    val cachedScalingPolicies =
+      Await.result(future.mapTo[Map[EddaEndpoint, List[ScalingPolicy]]], Duration.Inf)
+    assert(cachedScalingPolicies === data)
+  }
+
+  test("Timeout when dao fails to lookup Edda") {
+    val scalingPolicies = system.actorOf(
+      Props[ScalingPoliciesTestImpl](
+        new ScalingPoliciesTestImpl(
+          config,
+          () => {
+            Flow[EddaEndpoint]
+              .filter(_ => false)
+              .map(_ => List.empty[ScalingPolicy])
+          }
+        )
+      )
+    )
+    val future = scalingPolicies ? GetScalingPolicy(
+      FwdMetricInfo("us-east-1", "123", "metric1", Map.empty[String, String])
+    )
+
+    assertThrows[AskTimeoutException](
+      Await.result(future.mapTo[Option[ScalingPolicy]], Duration.Inf)
+    )
+  }
+
+  test("Refresh cache") {
+    val ec2Policy1 = ScalingPolicy("ec2Policy1", ScalingPolicy.Ec2, "metric1", Nil)
+    val ec2Policy2 = ScalingPolicy("ec2Policy2", ScalingPolicy.Ec2, "metric2", Nil)
+
+    val eddaEndpoint = EddaEndpoint("123", "us-east-1", "test")
+    val cache = Map(eddaEndpoint -> List(ec2Policy1))
+    val data = Map(eddaEndpoint  -> List(ec2Policy1, ec2Policy2))
+
+    val scalingPolicies = system.actorOf(
+      Props[ScalingPoliciesTestImpl](
+        new ScalingPoliciesTestImpl(
+          config,
+          new ScalingPoliciesDaoTestImpl(policies = data),
+          cache
+        )
+      )
+    )
+
+    var future = scalingPolicies ? RefreshCache
+    Await.ready(future, Duration.Inf)
+
+    future = scalingPolicies ? GetCache
+    val actual = Await.result(future.mapTo[Map[EddaEndpoint, List[ScalingPolicy]]], Duration.Inf)
+
+    assert(actual === data)
+  }
+
+  test("Dao failure during cache refresh") {
+    val ec2Policy1 = ScalingPolicy("ec2Policy1", ScalingPolicy.Ec2, "metric1", Nil)
+    val cache = Map(EddaEndpoint("123", "us-east-1", "test") -> List(ec2Policy1))
+
+    val scalingPolicies = system.actorOf(
+      Props[ScalingPoliciesTestImpl](
+        new ScalingPoliciesTestImpl(
+          config,
+          () => {
+            Flow[EddaEndpoint]
+              .filter(_ => false)
+              .map(_ => List.empty[ScalingPolicy])
+          },
+          cache
+        )
+      )
+    )
+
+    var future = scalingPolicies ? RefreshCache
+    Await.ready(future, Duration.Inf)
+
+    future = scalingPolicies ? GetCache
+    val actual = Await.result(future.mapTo[Map[EddaEndpoint, List[ScalingPolicy]]], Duration.Inf)
+    assert(actual === cache)
+  }
+
+}

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ScalingPoliciesTestImpl.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ScalingPoliciesTestImpl.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc.fwd.admin
+
+import akka.NotUsed
+import akka.stream.scaladsl.Flow
+import com.typesafe.config.Config
+
+class ScalingPoliciesTestImpl(
+  config: Config,
+  dao: ScalingPoliciesDao,
+  policies: Map[EddaEndpoint, List[ScalingPolicy]] = Map.empty[EddaEndpoint, List[ScalingPolicy]],
+) extends ScalingPolicies(config, dao) {
+  scalingPolicies = policies
+  override def startPeriodicTimer(): Unit = {}
+}
+
+class ScalingPoliciesDaoTestImpl(
+  policies: Map[EddaEndpoint, List[ScalingPolicy]]
+) extends ScalingPoliciesDao {
+  protected implicit val ec = scala.concurrent.ExecutionContext.global
+
+  override def getScalingPolicies(): Flow[EddaEndpoint, List[ScalingPolicy], NotUsed] = {
+    Flow[EddaEndpoint]
+      .map(policies(_))
+  }
+}


### PR DESCRIPTION
Query Edda to determine whether a scaling policy is
created in Ec2 or Titus for the metric that is forwarded
to CW.