### PR TITLE
druid: improve behavior of has queries

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidFilter.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidFilter.scala
@@ -42,7 +42,7 @@ object DruidFilter {
       case Query.GreaterThanEqual(k, v) => js(k, ">=", v)
       case Query.LessThan(k, v)         => js(k, "<", v)
       case Query.LessThanEqual(k, v)    => js(k, "<=", v)
-      case Query.HasKey(k)              => JavaScript(k, "function(x) { return true; }")
+      case Query.HasKey(k)              => Not(Equal(k, "")) // druid: empty string is same as null
       case Query.Regex(k, v)            => Regex(k, s"^$v")
       case Query.RegexIgnoreCase(k, v)  => reic(k, v)
       case Query.And(q1, q2)            => And(List(toFilter(q1), toFilter(q2)))

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
@@ -270,4 +270,22 @@ class DruidDatabaseActorSuite extends FunSuite {
     assert(queries.map(_._1("name")).toSet === Set("m1", "m2", "m3"))
     assert(queries.map(_._1("nf.datasource")).toSet === Set("ds_1", "ds_2"))
   }
+
+  test("toDruidQueries: unknown dimensions") {
+    val expr = DataExpr.Sum(Query.HasKey("c"))
+    val queries = toDruidQueries(metadata, context, expr)
+
+    assert(queries.size === 2)
+    assert(queries.map(_._1("name")).toSet === Set("m1", "m3"))
+    assert(queries.map(_._1("nf.datasource")).toSet === Set("ds_2"))
+  }
+
+  test("toDruidQueries: unknown dimensions missing") {
+    val expr = DataExpr.Sum(Query.Not(Query.HasKey("c")))
+    val queries = toDruidQueries(metadata, context, expr)
+
+    assert(queries.size === 4)
+    assert(queries.map(_._1("name")).toSet === Set("m1", "m2", "m3"))
+    assert(queries.map(_._1("nf.datasource")).toSet === Set("ds_1", "ds_2"))
+  }
 }

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidFilterSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidFilterSuite.scala
@@ -95,7 +95,7 @@ class DruidFilterSuite extends FunSuite {
 
   test("forQuery - :has") {
     val actual = DruidFilter.forQuery(eval("country,:has"))
-    val expected = Some(DruidFilter.JavaScript("country", "function(x) { return true; }"))
+    val expected = Some(DruidFilter.Not(DruidFilter.Equal("country", "")))
     assert(actual === expected)
   }
 


### PR DESCRIPTION
Fixes the interpretation of has queries to more closely match
the expectations of the Atlas construct:

1. If the dimension is not present on a given datasource it
   will now be handled via a query simplification and never
   get sent to druid. This will allow queries that look for
   `not(has(k))` to work if `k` is not present.

2. When the dimension is present, a has query will now get
   written as `not(k == "")`. Druid treats empty strings and
   null values as being the same so this is matching for
   entries where the value for the key is not null. Before
   it would check for the key and have a javascript function
   that always returned true. That would match entries that
   were null which is not expected by the user.