### PR TITLE
DynamoDB Capacity Updates

### DIFF
--- a/atlas-slotting/src/main/resources/application.conf
+++ b/atlas-slotting/src/main/resources/application.conf
@@ -19,8 +19,16 @@ aws {
 
   dynamodb {
     table-name = "atlas_slotting-"${netflix.iep.env.stack}
-    read-capacity = 15
-    write-capacity = 15
+
+    read-capacity {
+      default = 15
+      # add $env.$region scoped values here
+    }
+
+    write-capacity {
+      default = 15
+      # add $env.$region scoped values here
+    }
   }
 }
 

--- a/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/DynamoOps.scala
+++ b/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/DynamoOps.scala
@@ -101,39 +101,37 @@ trait DynamoOps extends StrictLogging {
       .withValueMap(valueMap)
   }
 
-  def updateTimestampItemSpec(name: String, oldData: ByteBuffer): UpdateItemSpec = {
+  def updateTimestampItemSpec(name: String, oldTimestamp: Long): UpdateItemSpec = {
     val nameMap = new NameMap()
-      .`with`("#d", Data)
       .`with`("#a", Active)
       .`with`("#t", Timestamp)
 
     val valueMap = new ValueMap()
-      .withBinary(":v1", Util.toByteArray(oldData))
+      .withLong(":v1", oldTimestamp)
       .withBoolean(":v2", true)
       .withLong(":v3", System.currentTimeMillis)
 
     new UpdateItemSpec()
       .withPrimaryKey(Name, name)
-      .withConditionExpression("#d = :v1")
+      .withConditionExpression("#t = :v1")
       .withUpdateExpression("set #a = :v2, #t = :v3")
       .withNameMap(nameMap)
       .withValueMap(valueMap)
   }
 
-  def deactivateAsgItemSpec(name: String, oldData: ByteBuffer): UpdateItemSpec = {
+  def deactivateAsgItemSpec(name: String): UpdateItemSpec = {
     val nameMap = new NameMap()
-      .`with`("#d", Data)
       .`with`("#a", Active)
       .`with`("#t", Timestamp)
 
     val valueMap = new ValueMap()
-      .withBinary(":v1", Util.toByteArray(oldData))
+      .withBoolean(":v1", true)
       .withBoolean(":v2", false)
       .withLong(":v3", System.currentTimeMillis)
 
     new UpdateItemSpec()
       .withPrimaryKey(Name, name)
-      .withConditionExpression("#d = :v1")
+      .withConditionExpression("#a = :v1")
       .withUpdateExpression("set #a = :v2, #t = :v3")
       .withNameMap(nameMap)
       .withValueMap(valueMap)

--- a/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/Util.scala
+++ b/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/Util.scala
@@ -19,11 +19,23 @@ import java.nio.ByteBuffer
 import java.time.Duration
 import java.util.concurrent.ScheduledFuture
 
+import com.netflix.iep.NetflixEnvironment
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.impl.Scheduler
+import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 
 object Util extends StrictLogging {
+
+  def getLongOrDefault(config: Config, basePath: String): Long = {
+    val env = NetflixEnvironment.accountEnv()
+    val region = NetflixEnvironment.region()
+
+    if (config.hasPath(s"$basePath.$env.$region"))
+      config.getLong(s"$basePath.$env.$region")
+    else
+      config.getLong(s"$basePath.default")
+  }
 
   def compress(s: String): ByteBuffer = {
     ByteBuffer.wrap(Gzip.compressString(s))

--- a/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/DynamoOpsSuite.scala
+++ b/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/DynamoOpsSuite.scala
@@ -66,18 +66,16 @@ class DynamoOpsSuite extends FunSuite with DynamoOps {
   }
 
   test("update timestamp spec") {
-    val oldData = mkByteBuffer("""{"name": "atlas_app-main-all-v001", "desiredCapacity": 3}""")
-    val updateSpec = updateTimestampItemSpec("atlas_app-main-all-v001", oldData)
-    assert(updateSpec.getConditionExpression === "#d = :v1")
+    val updateSpec = updateTimestampItemSpec("atlas_app-main-all-v001", 1556568270713L)
+    assert(updateSpec.getConditionExpression === "#t = :v1")
     assert(updateSpec.getUpdateExpression === s"set #a = :v2, #t = :v3")
-    assert(updateSpec.getNameMap.toString === s"{#d=data, #a=$Active, #t=$Timestamp}")
+    assert(updateSpec.getNameMap.toString === s"{#a=$Active, #t=$Timestamp}")
   }
 
   test("deactivate asg spec") {
-    val oldData = mkByteBuffer("""{"name": "atlas_app-main-all-v001", "desiredCapacity": 3}""")
-    val updateSpec = deactivateAsgItemSpec("atlas_app-main-all-v001", oldData)
-    assert(updateSpec.getConditionExpression === "#d = :v1")
+    val updateSpec = deactivateAsgItemSpec("atlas_app-main-all-v001")
+    assert(updateSpec.getConditionExpression === "#a = :v1")
     assert(updateSpec.getUpdateExpression === s"set #a = :v2, #t = :v3")
-    assert(updateSpec.getNameMap.toString === s"{#d=data, #a=$Active, #t=$Timestamp}")
+    assert(updateSpec.getNameMap.toString === s"{#a=$Active, #t=$Timestamp}")
   }
 }


### PR DESCRIPTION
The required DynamoDB capacity can differ based on account and region,
depending on the number and size of ASGs being tracked. This change
provides the ability to specify the desired read and write capacity per
account and region, with a default value as the fallback.

The timestamp update and deactivate ASG methods do not change the data
payload in DynamoDB, so the condition expressions have been updated to
check the data that is changing. the data payloads can be up to 400KB in
size, while a Boolean and a Long are just a few bytes. this should help
save some DynamoDB write capacity. keeping the conditional checks in
place will provide stability for the items, when there are multiple
writers during a deployment.