### PR TITLE
Add new line to SES notification log pattern

### DIFF
--- a/iep-ses-monitor/src/main/resources/log4j2.xml
+++ b/iep-ses-monitor/src/main/resources/log4j2.xml
@@ -9,7 +9,7 @@
 <Configuration status="warn">
     <Properties>
         <Property name="dfltPattern">%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %-5level [%t] %class: %msg%n</Property>
-        <Property name="notificationPattern">{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","notification":%m}</Property>
+        <Property name="notificationPattern">{"timestamp":"%d{yyyy-MM-dd'T'HH:mm:ss.SSS}","notification":%m}%n</Property>
     </Properties>
     <Appenders>
         <Console name="notifications" target="SYSTEM_OUT">


### PR DESCRIPTION
Log messages need to be separated by a new line.