### PR TITLE
druid: simplify default analysis types

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -145,7 +145,7 @@ object DruidClient {
     intervals: List[String] = null,
     toInclude: Option[ToInclude] = None,
     merge: Boolean = true,
-    analysisTypes: List[String] = List("cardinality", "size", "aggregators"),
+    analysisTypes: List[String] = List("aggregators"),
     lenientAggregatorMerge: Boolean = false
   ) {
     val queryType: String = "segmentMetadata"


### PR DESCRIPTION
Removes the `cardinality` and `size` analysis types from
the default list for segment metadata. These types can
cause a lot of overhead for the query.