### PR TITLE
update aggregator to use debugRegistry

### DIFF
--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AppModule.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AppModule.scala
@@ -26,6 +26,7 @@ import com.netflix.iep.admin.guice.AdminModule
 import com.netflix.iep.service.AbstractService
 import com.netflix.iep.service.Service
 import com.netflix.spectator.api.Clock
+import com.netflix.spectator.api.Registry
 import com.netflix.spectator.atlas.AtlasConfig
 import com.netflix.spectator.atlas.AtlasRegistry
 import com.typesafe.config.Config
@@ -49,7 +50,7 @@ class AppModule extends AbstractModule {
 
 object AppModule {
 
-  class AggrConfig(config: Config) extends AtlasConfig {
+  class AggrConfig(config: Config, registry: Registry) extends AtlasConfig {
 
     override def get(k: String): String = {
       val prop = s"netflix.atlas.aggr.registry.$k"
@@ -61,6 +62,8 @@ object AppModule {
       tags.put("atlas.aggr", config.getString("netflix.iep.env.instance-id"))
       tags
     }
+
+    override def debugRegistry(): Registry = registry
   }
 
   @Singleton
@@ -75,9 +78,10 @@ object AppModule {
   }
 
   @Singleton
-  class AtlasRegistryProvider @Inject()(config: Config) extends Provider[AtlasRegistry] {
+  class AtlasRegistryProvider @Inject()(config: Config, registry: Registry)
+      extends Provider[AtlasRegistry] {
     override def get(): AtlasRegistry = {
-      val cfg = new AggrConfig(config)
+      val cfg = new AggrConfig(config, registry)
       new AtlasRegistry(Clock.SYSTEM, cfg)
     }
   }

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AppModuleSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AppModuleSuite.scala
@@ -16,12 +16,12 @@
 package com.netflix.atlas.aggregator
 
 import javax.inject.Singleton
-
 import com.google.inject.AbstractModule
 import com.google.inject.ConfigurationException
 import com.google.inject.Guice
 import com.google.inject.Provider
 import com.netflix.spectator.api.Clock
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.atlas.AtlasConfig
 import com.netflix.spectator.atlas.AtlasRegistry
@@ -34,21 +34,6 @@ class AppModuleSuite extends FunSuite {
   import AppModuleSuite._
 
   private val config = ConfigFactory.load()
-
-  test("aggr registry only") {
-    val injector = Guice.createInjector(new AppModule, new AbstractModule {
-      override def configure(): Unit = {
-        bind(classOf[Config]).toInstance(config)
-      }
-    })
-
-    val aggr = injector.getInstance(classOf[AtlasRegistry])
-    assert(aggr != null)
-
-    intercept[ConfigurationException] {
-      injector.getInstance(classOf[Registry])
-    }
-  }
 
   test("app and aggr registry") {
     val injector = Guice.createInjector(
@@ -70,7 +55,7 @@ class AppModuleSuite extends FunSuite {
     val config = ConfigFactory.parseString("""
         |netflix.atlas.aggr.registry.atlas.uri = "test"
       """.stripMargin)
-    val aggr = new AppModule.AggrConfig(config)
+    val aggr = new AppModule.AggrConfig(config, new NoopRegistry)
     assert(aggr.uri() === "test")
   }
 
@@ -78,7 +63,7 @@ class AppModuleSuite extends FunSuite {
     val config = ConfigFactory.parseString("""
         |netflix.atlas.aggr.registry.atlas.uri = "test"
       """.stripMargin)
-    val aggr = new AppModule.AggrConfig(config)
+    val aggr = new AppModule.AggrConfig(config, new NoopRegistry)
     assert(aggr.batchSize() === 10000)
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
     val scala      = "2.12.8"
     val servo      = "0.12.25"
     val slf4j      = "1.7.26"
-    val spectator  = "0.91.0"
+    val spectator  = "0.92.0-SNAPSHOT"
 
     val crossScala = Seq(scala)
   }


### PR DESCRIPTION
See Netflix/spectator#708. This will allow the aggr registry
metrics to be reported for the aggregator cluster instead of
getting forwarded to the target account.