### PR TITLE
Sort API Output

### DIFF
--- a/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/DynamoOps.scala
+++ b/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/DynamoOps.scala
@@ -144,6 +144,8 @@ trait DynamoOps extends StrictLogging {
     desiredWrite: Long,
     dynamodbErrors: Counter
   ): Unit = {
+    logger.info(s"init dynamodb table $tableName in ${NetflixEnvironment.region()}")
+
     var continue = true
 
     while (continue) {

--- a/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/Grouping.scala
+++ b/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/Grouping.scala
@@ -62,7 +62,10 @@ case class SlottedAsgDetails(
   minSize: Int,
   instances: List[SlottedInstanceDetails],
 ) {
-  require(instances.size <= desiredCapacity, "instances.size > desiredCapacity")
+  require(
+    instances.size <= desiredCapacity,
+    s"instances.size (${instances.size}) > desiredCapacity ($desiredCapacity)"
+  )
 }
 
 case class SlottedInstanceDetails(

--- a/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/SlottingCache.scala
+++ b/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/SlottingCache.scala
@@ -17,9 +17,11 @@ package com.netflix.atlas.slotting
 
 import javax.inject.Singleton
 
+import scala.collection.immutable.SortedMap
+
 @Singleton
 class SlottingCache() {
 
   @volatile
-  var asgs = Map.empty[String, SlottedAsgDetails]
+  var asgs: SortedMap[String, SlottedAsgDetails] = SortedMap.empty[String, SlottedAsgDetails]
 }

--- a/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/SlottingService.scala
+++ b/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/SlottingService.scala
@@ -37,6 +37,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 import scala.collection.JavaConverters._
+import scala.collection.immutable.SortedMap
 
 @Singleton
 class SlottingService @Inject()(
@@ -202,7 +203,7 @@ class SlottingService @Inject()(
     .monitorValue(new AtomicLong(clock.wallTime()), Functions.AGE)
 
   private def updateCacheTask(): Unit = {
-    var updatedAsgs = Map.empty[String, SlottedAsgDetails]
+    var updatedAsgs = SortedMap.empty[String, SlottedAsgDetails]
 
     val table = dynamodb.getTable(tableName)
     val iter = table.scan(activeItemsScanSpec()).iterator

--- a/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/GroupingSuite.scala
+++ b/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/GroupingSuite.scala
@@ -148,7 +148,7 @@ class GroupingSuite extends FunSuite with Grouping {
       )
     }
 
-    assert(caught.getMessage === "requirement failed: instances.size > desiredCapacity")
+    assert(caught.getMessage === "requirement failed: instances.size (3) > desiredCapacity (2)")
   }
 
   test("assign slots") {

--- a/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/SlottingApiSuite.scala
+++ b/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/SlottingApiSuite.scala
@@ -27,6 +27,7 @@ import com.netflix.atlas.akka.RequestHandler
 import com.netflix.atlas.json.Json
 import org.scalatest.FunSuite
 
+import scala.collection.immutable.SortedMap
 import scala.concurrent.duration._
 import scala.io.Source
 
@@ -128,7 +129,7 @@ class SlottingApiSuite extends FunSuite with ScalatestRouteTest {
   }
 
   test("load cache") {
-    slottingCache.asgs = Map(
+    slottingCache.asgs = SortedMap(
       "atlas_app-main-all-v001" -> loadSlottedAsgDetails("/atlas_app-main-all-v001.json")
     )
 


### PR DESCRIPTION
- Switch the cache to use a SortedMap, so the output will be sorted by ASG name
- Log the DynamoDB table being used at startup
- Add details to the message when SlottedAsgDetails fails the requirement
