### PR TITLE
enable response caching for slotting service

### DIFF
--- a/atlas-slotting/src/main/resources/application.conf
+++ b/atlas-slotting/src/main/resources/application.conf
@@ -40,3 +40,8 @@ slotting {
   cutoff-interval = 7 d
   janitor-interval = 24 h
 }
+
+akka.http.caching.lfu-cache {
+  time-to-live = 10s
+  time-to-idle = 10s
+}

--- a/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/SlottingApiSuite.scala
+++ b/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/SlottingApiSuite.scala
@@ -37,8 +37,8 @@ class SlottingApiSuite extends FunSuite with ScalatestRouteTest {
   implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.second)
 
   val slottingCache = new SlottingCache()
-  val endpoint = new SlottingApi(slottingCache)
-  val routes: Route = RequestHandler.standardOptions(endpoint.routes)
+  val endpoint = new SlottingApi(system, slottingCache)
+  val routes: Route = RequestHandler.standardOptions(endpoint.innerRoutes)
 
   private def assertResponse(response: HttpResponse, expectedStatus: StatusCode): Unit = {
     assert(response.status === expectedStatus)

--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ lazy val `atlas-druid` = project
 lazy val `atlas-slotting` = project
   .configure(BuildSettings.profile)
   .settings(libraryDependencies ++= Seq(
+      Dependencies.akkaHttpCaching,
       Dependencies.atlasModuleAkka,
       Dependencies.awsAutoScaling,
       Dependencies.awsDynamoDB,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,6 +23,7 @@ object Dependencies {
   import Versions._
 
   val akkaActor          = "com.typesafe.akka" %% "akka-actor" % akka
+  val akkaHttpCaching    = "com.typesafe.akka" %% "akka-http-caching" % akkaHttpV
   val akkaHttpCore       = "com.typesafe.akka" %% "akka-http-core" % akkaHttpV
   val akkaHttpTestkit    = "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV
   val akkaSlf4j          = "com.typesafe.akka" %% "akka-slf4j" % akka


### PR DESCRIPTION
This service is polled heavily by many nodes and the responses
are typically the same. The most expensive aspects currently
are compressing the payloads followed by converting the objects
to JSON. This change should considerably reduce both.