### PR TITLE
restrict exprs for bridge to primary step

### DIFF
--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExprUpdateService.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExprUpdateService.scala
@@ -118,9 +118,14 @@ class ExprUpdateService @Inject()(
   }
 
   private def update(data: ByteString): Future[NotUsed] = {
+    import scala.collection.JavaConverters._
     Future {
       try {
-        val exprs = Json.decode[Subscriptions](data.toArray).getExpressions
+        val exprs = Json.decode[Subscriptions](data.toArray)
+          .getExpressions
+          .asScala
+          .filter(_.getFrequency == 60000) // Limit to primary publish step size
+          .asJava
         evaluator.sync(exprs)
         lastUpdateTime.set(registry.clock().wallTime())
       } catch {

--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExprUpdateService.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExprUpdateService.scala
@@ -121,7 +121,8 @@ class ExprUpdateService @Inject()(
     import scala.collection.JavaConverters._
     Future {
       try {
-        val exprs = Json.decode[Subscriptions](data.toArray)
+        val exprs = Json
+          .decode[Subscriptions](data.toArray)
           .getExpressions
           .asScala
           .filter(_.getFrequency == 60000) // Limit to primary publish step size

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExprUpdateServiceSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExprUpdateServiceSuite.scala
@@ -65,6 +65,11 @@ class ExprUpdateServiceSuite extends FunSuite with BeforeAndAfter {
         |      "id": "123",
         |      "expression": "name,cpu,:eq,:sum",
         |      "frequency": 60000
+        |    },
+        |    {
+        |      "id": "123",
+        |      "expression": "name,cpu,:eq,:sum",
+        |      "frequency": 5000
         |    }
         |  ]
         |}


### PR DESCRIPTION
The LWC bridge will now filter the expressions to only those
that match the primary step size for the corresponding Atlas
backend.