### PR TITLE
Migrate to iep.aws2.AtlasClientFactory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -218,7 +218,7 @@ lazy val `iep-ses-monitor` = project
     Dependencies.alpakkaSqs,
     Dependencies.iepGuice,
     Dependencies.iepModuleAtlas,
-    Dependencies.iepModuleAws,
+    Dependencies.iepModuleAws2,
     Dependencies.log4jApi,
     Dependencies.log4jCore,
     Dependencies.log4jSlf4j,

--- a/iep-ses-monitor/src/main/scala/com/netflix/iep/ses/AppModule.scala
+++ b/iep-ses-monitor/src/main/scala/com/netflix/iep/ses/AppModule.scala
@@ -17,6 +17,7 @@ package com.netflix.iep.ses
 
 import com.google.inject.AbstractModule
 import com.google.inject.Provides
+import com.google.inject.Singleton
 import com.google.inject.multibindings.Multibinder
 import com.netflix.iep.aws2.AwsClientFactory
 import com.netflix.iep.service.Service
@@ -28,6 +29,7 @@ class AppModule extends AbstractModule {
     serviceBinder.addBinding().to(classOf[SesMonitoringService])
   }
 
+  @Singleton
   @Provides
   def provideAwsSqsAsyncClient(factory: AwsClientFactory): SqsAsyncClient = {
     factory.newInstance(classOf[SqsAsyncClient])

--- a/iep-ses-monitor/src/main/scala/com/netflix/iep/ses/AppModule.scala
+++ b/iep-ses-monitor/src/main/scala/com/netflix/iep/ses/AppModule.scala
@@ -18,10 +18,8 @@ package com.netflix.iep.ses
 import com.google.inject.AbstractModule
 import com.google.inject.Provides
 import com.google.inject.multibindings.Multibinder
-import com.netflix.iep.NetflixEnvironment
+import com.netflix.iep.aws2.AwsClientFactory
 import com.netflix.iep.service.Service
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
-import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 
 class AppModule extends AbstractModule {
@@ -31,12 +29,8 @@ class AppModule extends AbstractModule {
   }
 
   @Provides
-  def provideAwsSqsAsyncClient(): SqsAsyncClient = {
-    SqsAsyncClient
-      .builder()
-      .region(Region.of(NetflixEnvironment.region()))
-      .credentialsProvider(DefaultCredentialsProvider.create())
-      .build()
+  def provideAwsSqsAsyncClient(factory: AwsClientFactory): SqsAsyncClient = {
+    factory.newInstance(classOf[SqsAsyncClient])
   }
 
   @Provides

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,6 +52,7 @@ object Dependencies {
   val iepModuleArchaius2 = "com.netflix.iep" % "iep-module-archaius2" % iep
   val iepModuleAtlas     = "com.netflix.iep" % "iep-module-atlas" % iep
   val iepModuleAws       = "com.netflix.iep" % "iep-module-aws" % iep
+  val iepModuleAws2      = "com.netflix.iep" % "iep-module-aws2" % iep
   val iepModuleAwsMetrics= "com.netflix.iep" % "iep-module-awsmetrics" % iep
   val iepModuleEureka    = "com.netflix.iep" % "iep-module-eureka" % iep
   val iepModuleJmx       = "com.netflix.iep" % "iep-module-jmxport" % iep


### PR DESCRIPTION
No async client was available in the factory for the AWS 1.x SDK and,
since the SES Monitor usage was a one-off, I didn't add it. Now that
alpakka-sqs uses the AWS 2.x SDK and there is a client factory for that
available, I'm moving the SES Monitor to leverage it.