### PR TITLE
Purge the forwarded metrics admin record that are no longer reported

### DIFF
--- a/iep-lwc-cloudwatch-model/src/main/scala/com/netflix/iep/lwc/fwd/cw/Report.scala
+++ b/iep-lwc-cloudwatch-model/src/main/scala/com/netflix/iep/lwc/fwd/cw/Report.scala
@@ -20,11 +20,23 @@ case class Report(
   id: ExpressionId,
   metric: Option[FwdMetricInfo],
   error: Option[Throwable]
-)
+) {
+
+  def metricWithTimestamp(): Option[FwdMetricInfo] = {
+    metric.map(_.copy(timestamp = Some(timestamp)))
+  }
+}
 
 case class FwdMetricInfo(
   region: String,
   account: String,
   name: String,
-  dimensions: Map[String, String]
-)
+  dimensions: Map[String, String],
+  timestamp: Option[Long] = None
+) {
+
+  def equalsIgnoreTimestamp(that: FwdMetricInfo): Boolean = {
+    this.copy(timestamp = None) == that.copy(timestamp = None)
+  }
+
+}

--- a/iep-lwc-fwding-admin/src/main/resources/application.conf
+++ b/iep-lwc-fwding-admin/src/main/resources/application.conf
@@ -27,7 +27,12 @@ iep.lwc.fwding-admin {
   age-limit = 10m
   queue-size-limit = 10000
   edda-cache-refresh-interval = 30m
+  fwd-metric-info-purge-limit = 5d
   cw-expr-uri = "http://localhost:7102/api/v2/cloudwatch-forwarding/clusters/%s"
+
+  accountEnvMapping = {
+    123 = local
+  }
 
   // The host name in the properties 'cw-alarms-uri', 'ec2-policies-uri' and 'titus-policies-uri'
   // uses the following pattern to lookup the appropriate Edda deployment.

--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/Timer.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/Timer.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc.fwd.admin
+
+import java.util.concurrent.TimeUnit
+
+import com.netflix.spectator.api.Clock
+import com.netflix.spectator.api.Registry
+
+object Timer {
+
+  def measure[T](
+    f: => T,
+    name: String,
+    clock: Clock,
+    record: (String, List[String], Long) => Unit
+  ): T = {
+    var tags = List.empty[String]
+    val start = clock.monotonicTime()
+    try {
+      f
+    } catch {
+      case e: Exception =>
+        tags = List("exception", e.getClass.getSimpleName)
+        throw e
+    } finally {
+      record(name, tags, clock.monotonicTime() - start)
+    }
+  }
+
+  def record[T](f: => T, name: String, registry: Registry): T = {
+    measure(
+      f,
+      name,
+      registry.clock(),
+      (n: String, t: List[String], d: Long) =>
+        registry.timer(n, t: _*).record(d, TimeUnit.NANOSECONDS)
+    )
+  }
+
+}

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ExpressionDetailsDaoSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ExpressionDetailsDaoSuite.scala
@@ -22,6 +22,7 @@ import com.netflix.iep.lwc.fwd.cw.ExpressionId
 import com.netflix.iep.lwc.fwd.cw.ForwardingDimension
 import com.netflix.iep.lwc.fwd.cw.ForwardingExpression
 import com.netflix.iep.lwc.fwd.cw.FwdMetricInfo
+import com.netflix.spectator.api.NoopRegistry
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
 import org.scalatest.BeforeAndAfter
@@ -31,7 +32,11 @@ import scala.concurrent.duration._
 
 class ExpressionDetailsDaoSuite extends FunSuite with BeforeAndAfter with StrictLogging {
 
-  val dao = new ExpressionDetailsDaoImpl(ConfigFactory.load(), makeDynamoDBClient())
+  val dao = new ExpressionDetailsDaoImpl(
+    ConfigFactory.load(),
+    makeDynamoDBClient(),
+    new NoopRegistry()
+  )
 
   def makeDynamoDBClient(): AmazonDynamoDB = {
     AmazonDynamoDBClientBuilder

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/MarkerServiceExprDetailsSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/MarkerServiceExprDetailsSuite.scala
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc.fwd.admin
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+import com.netflix.iep.lwc.fwd.cw.ExpressionId
+import com.netflix.iep.lwc.fwd.cw.ForwardingExpression
+import com.netflix.iep.lwc.fwd.cw.FwdMetricInfo
+import com.netflix.iep.lwc.fwd.cw.Report
+import org.scalatest.FunSuite
+
+import scala.concurrent.duration._
+
+class MarkerServiceExprDetailsSuite extends FunSuite {
+
+  import ExpressionDetails._
+  import MarkerServiceImpl._
+
+  private val fwdMetricInfoPurgeLimitMillis = (5.days).toMillis
+
+  private val now = Instant.ofEpochSecond(1551820461L)
+
+  private val metricInfo = FwdMetricInfo("us-east-1", "123", "cpuUsage", Map.empty[String, String])
+  private val report = Report(
+    now.toEpochMilli,
+    ExpressionId(
+      "c1",
+      ForwardingExpression("name,cpuUsage,:eq", "123", None, "cpuUsage")
+    ),
+    Some(metricInfo),
+    None
+  )
+
+  private val scalingPolicy = ScalingPolicy("1", ScalingPolicy.Ec2, "cpuUsage", Nil)
+  private val scalingPolicyStatus = ScalingPolicyStatus(false, Some(scalingPolicy))
+
+  private val prevExprDetails = ExpressionDetails(
+    report.id,
+    now.minusSeconds(10).toEpochMilli,
+    report.metricWithTimestamp().toList,
+    report.error,
+    Map.empty[String, Long],
+    List(scalingPolicy)
+  )
+
+  test("Make ExpressionDetails") {
+
+    val expected = ExpressionDetails(
+      ExpressionId("c1", ForwardingExpression("name,cpuUsage,:eq", "123", None, "cpuUsage")),
+      now.toEpochMilli,
+      List(
+        FwdMetricInfo(
+          "us-east-1",
+          "123",
+          "cpuUsage",
+          Map.empty[String, String],
+          Some(now.toEpochMilli)
+        )
+      ),
+      None,
+      Map.empty[String, Long],
+      List(ScalingPolicy("1", ScalingPolicy.Ec2, "cpuUsage", List.empty[MetricDimension]))
+    )
+
+    val actual = toExprDetails(
+      report,
+      scalingPolicyStatus,
+      Some(prevExprDetails),
+      fwdMetricInfoPurgeLimitMillis,
+      now.toEpochMilli
+    )
+
+    assert(actual === expected)
+  }
+
+  test("NoDataFoundEvent: Report[data=yes]") {
+    val actual = toNoDataFoundEvent(report, None)
+    assert(actual.isEmpty)
+  }
+
+  test("NoDataFoundEvent: Report[data=no] Saved[None]") {
+    val expected = Map(NoDataFoundEvent -> report.timestamp)
+    val actual = toNoDataFoundEvent(report.copy(metric = None), None)
+
+    assert(actual === expected)
+  }
+
+  test("NoDataFoundEvent: Report[data=no] Saved[data=yes]") {
+    val expected = Map(NoDataFoundEvent -> report.timestamp)
+    val actual = toNoDataFoundEvent(report.copy(metric = None), Some(prevExprDetails))
+
+    assert(actual === expected)
+  }
+
+  test("NoDataFoundEvent: Report[data=no] Saved[data=no]") {
+    val expected = Map(NoDataFoundEvent -> prevExprDetails.timestamp)
+    val actual = toNoDataFoundEvent(
+      report.copy(metric = None),
+      Some(prevExprDetails.copy(events = Map(NoDataFoundEvent -> prevExprDetails.timestamp)))
+    )
+
+    assert(actual === expected)
+  }
+
+  test("NoScalingPolicyFoundEvent: Report[sp=unknown]") {
+    val actual = toNoScalingPolicyFoundEvent(report, ScalingPolicyStatus(true, None), None)
+    assert(actual.isEmpty)
+  }
+
+  test("NoScalingPolicyFoundEvent: Report[sp=yes]") {
+    val actual = toNoScalingPolicyFoundEvent(report, scalingPolicyStatus, None)
+    assert(actual.isEmpty)
+  }
+
+  test("NoScalingPolicyFoundEvent: Report[sp=no] Saved[None]") {
+    val actual = toNoScalingPolicyFoundEvent(report, ScalingPolicyStatus(false, None), None)
+    val expected = Map(NoScalingPolicyFoundEvent -> report.timestamp)
+
+    assert(actual === expected)
+  }
+
+  test("NoScalingPolicyFoundEvent: Report[sp=no] Saved[sp=yes]") {
+    val actual =
+      toNoScalingPolicyFoundEvent(
+        report,
+        ScalingPolicyStatus(false, None),
+        Some(prevExprDetails)
+      )
+    val expected = Map(NoScalingPolicyFoundEvent -> report.timestamp)
+
+    assert(actual === expected)
+  }
+
+  test("NoScalingPolicyFoundEvent: Report[sp=no] Saved[sp=no]") {
+    val actual =
+      toNoScalingPolicyFoundEvent(
+        report,
+        ScalingPolicyStatus(false, None),
+        Some(
+          prevExprDetails.copy(
+            events = Map(NoScalingPolicyFoundEvent -> prevExprDetails.timestamp)
+          )
+        )
+      )
+    val expected = Map(NoScalingPolicyFoundEvent -> prevExprDetails.timestamp)
+
+    assert(actual === expected)
+  }
+
+  test("Make Forwarded Metrics: Report[data=yes] Saved[None]") {
+    val expected = List(metricInfo.copy(timestamp = Some(report.timestamp)))
+    val actual = toForwardedMetrics(
+      report,
+      None,
+      fwdMetricInfoPurgeLimitMillis,
+      now.toEpochMilli
+    )
+
+    assert(actual === expected)
+  }
+
+  test("Make Forwarded Metrics: Report[data=yes] Saved[data=yes]") {
+    val metric1 = metricInfo.copy(
+      dimensions = Map("nf.asg" -> "1"),
+      timestamp = Some(report.timestamp)
+    )
+    val metric2 = metricInfo.copy(
+      dimensions = Map("nf.asg" -> "2"),
+      timestamp = Some(report.timestamp)
+    )
+
+    val expected = List(metric1, metric2)
+    val actual = toForwardedMetrics(
+      report.copy(metric = Some(metric1)),
+      Some(prevExprDetails.copy(forwardedMetrics = List(metric1, metric2))),
+      fwdMetricInfoPurgeLimitMillis,
+      now.toEpochMilli
+    )
+
+    assert(actual === expected)
+  }
+
+  test("Make Forwarded Metrics: Purge old data") {
+    val metric1 = metricInfo.copy(
+      dimensions = Map("nf.asg" -> "1"),
+      timestamp = Some(now.toEpochMilli)
+    )
+
+    val metric2 = metricInfo.copy(
+      dimensions = Map("nf.asg" -> "2"),
+      timestamp = Some(now.toEpochMilli)
+    )
+
+    val metric3 = metricInfo.copy(
+      dimensions = Map("nf.asg" -> "3"),
+      timestamp = Some(now.minus(6, ChronoUnit.DAYS).toEpochMilli)
+    )
+
+    val savedMetrics = List(metric1, metric2, metric3)
+
+    val expected = List(metric1, metric2)
+    val actual = toForwardedMetrics(
+      report.copy(metric = Some(metric1)),
+      Some(prevExprDetails.copy(forwardedMetrics = savedMetrics)),
+      fwdMetricInfoPurgeLimitMillis,
+      now.toEpochMilli
+    )
+
+    assert(actual === expected)
+  }
+
+  test("Make Forwarded Metrics: Report[data=no] Saved[None]") {
+    val actual = toForwardedMetrics(
+      report.copy(metric = None),
+      None,
+      fwdMetricInfoPurgeLimitMillis,
+      now.toEpochMilli
+    )
+
+    assert(actual.isEmpty)
+  }
+
+  test("Make Scaling Policies: Report[sp=yes] Saved[None]") {
+    val expected = List(scalingPolicy)
+    val actual = toScalingPolicies(
+      Some(scalingPolicy),
+      None,
+      List(metricInfo)
+    )
+
+    assert(actual === expected)
+  }
+
+  test("Make Scaling Policies: Report[sp=yes] Saved[sp=yes]") {
+    val metric1 = metricInfo.copy(
+      dimensions = Map("nf.asg" -> "1"),
+      timestamp = Some(now.toEpochMilli)
+    )
+
+    val metric2 = metricInfo.copy(
+      dimensions = Map("nf.asg" -> "2"),
+      timestamp = Some(now.toEpochMilli)
+    )
+
+    val policy1 = scalingPolicy.copy(dimensions = List(MetricDimension("nf.asg", "1")))
+    val policy2 = scalingPolicy.copy(dimensions = List(MetricDimension("nf.asg", "2")))
+
+    val expected = List(policy1, policy2)
+    val actual = toScalingPolicies(
+      Some(policy1),
+      Some(prevExprDetails.copy(scalingPolicies = List(policy2))),
+      List(metric1, metric2)
+    )
+
+    assert(actual === expected)
+  }
+
+  test("Make Scaling Policies: Purge old data") {
+    val metric1 = metricInfo.copy(
+      dimensions = Map("nf.asg" -> "1"),
+      timestamp = Some(now.toEpochMilli)
+    )
+
+    val policy1 = scalingPolicy.copy(dimensions = List(MetricDimension("nf.asg", "1")))
+    val policy2 = scalingPolicy.copy(dimensions = List(MetricDimension("nf.asg", "2")))
+
+    val expected = List(policy1)
+    val actual = toScalingPolicies(
+      Some(policy1),
+      Some(prevExprDetails.copy(scalingPolicies = List(policy2))),
+      List(metric1)
+    )
+
+    assert(actual === expected)
+  }
+}

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/TimerSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/TimerSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc.fwd.admin
+
+import com.netflix.iep.lwc.fwd.admin.Timer._
+import com.netflix.spectator.api.ManualClock
+import org.scalatest.FunSuiteLike
+
+class TimerSuite extends FunSuiteLike {
+  test("Measure time for calls that succeed") {
+    val clock = new ManualClock()
+    clock.setMonotonicTime(1)
+
+    def work(): String = {
+      clock.setMonotonicTime(2)
+      "done"
+    }
+
+    val timer = new TestTimer()
+
+    val result = measure(work, "workTimer", clock, timer.record)
+    assert(result == "done")
+
+    assert(timer.name == "workTimer")
+    assert(timer.tags.isEmpty)
+    assert(timer.duration == 1)
+  }
+
+  test("Measure time for calls that fail") {
+    val clock = new ManualClock()
+    clock.setMonotonicTime(1)
+
+    def work(): String = {
+      clock.setMonotonicTime(2)
+      throw new RuntimeException("failed")
+    }
+
+    val timer = new TestTimer()
+
+    assertThrows[RuntimeException](
+      measure(work, "workTimer", clock, timer.record)
+    )
+    assert(timer.name == "workTimer")
+    assert(timer.tags === List("exception", "RuntimeException"))
+    assert(timer.duration == 1)
+
+  }
+}
+
+class TestTimer(var name: String = "", var tags: List[String] = Nil, var duration: Long = -1) {
+
+  def record(name: String, tags: List[String], duration: Long): Unit = {
+    this.name = name
+    this.tags = tags
+    this.duration = duration
+  }
+}


### PR DESCRIPTION
Save the report timestamp for every forwarded metric and use it
to remove the entry when the metric is no longer reported.

This is useful to keep the list size bounded for the forwarded metrics
and scaling policies in a 'ExpressionDetails' admin record.

When one expression is used to forward metrics for many asgs,
the admin record should be updated when the asgs are removed and
not forwarding any data.