### PR TITLE
druid: improve dimension spec mapping

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -284,7 +284,8 @@ object DruidDatabaseActor {
   }
 
   def toDimensionSpec(key: String, query: Query): DimensionSpec = {
-    val matches = Query.cnfList(query)
+    val matches = Query
+      .cnfList(query)
       .map(toInClause)
       .collect {
         case q: KeyQuery if q.k == key => q


### PR DESCRIPTION
It will now work for clauses that look for a specific
value in addition to a null value. For example:

```
foo,bar,:eq,foo,:has,:not,:or
```