### PR TITLE
fix invalid characters while parsing

### DIFF
--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
@@ -67,6 +67,30 @@ class UpdateApiSuite extends FunSuite {
     val id = registry.createId("cpu", "app", "www", "zone", "1e")
     assert(registry.counter(id).actualCount() === 42.0)
   }
+
+  test("payload with invalid characters") {
+    val clock = new ManualClock()
+    val registry = new AtlasRegistry(clock, UpdateApiSuite.config)
+    val parser = factory.createParser("""
+        |[
+        |  6,
+        |  "name",
+        |  "cpu user",
+        |  "app",
+        |  "www",
+        |  "zone",
+        |  "1e",
+        |  3,
+        |  0, 1, 2, 3, 4, 5,
+        |  0,
+        |  42.0
+        |]
+      """.stripMargin)
+    UpdateApi.processPayload(parser, registry)
+    clock.setWallTime(62000)
+    val id = registry.createId("cpu_user", "app", "www", "zone", "1e")
+    assert(registry.counter(id).actualCount() === 42.0)
+  }
 }
 
 object UpdateApiSuite {


### PR DESCRIPTION
Updates the aggregator to fix invalid characters in the
strings while the data is being parsed. This has a few
advantages:

1. Reduces cost for serializing later when publishing.
2. Dedupes the strings as they are coming in to reduce
   the overall memory footprint.