### PR TITLE
add aggr tag explicitly to counters

### DIFF
--- a/atlas-aggregator/src/test/resources/application.conf
+++ b/atlas-aggregator/src/test/resources/application.conf
@@ -1,0 +1,3 @@
+
+// Used for atlas.aggr tag in tests
+netflix.iep.env.instance-id = "i-123"

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
@@ -19,6 +19,7 @@ import java.time.Duration
 
 import com.fasterxml.jackson.core.JsonFactory
 import com.netflix.spectator.api.ManualClock
+import com.netflix.spectator.api.Tag
 import com.netflix.spectator.atlas.AtlasConfig
 import com.netflix.spectator.atlas.AtlasRegistry
 import org.scalatest.FunSuite
@@ -26,6 +27,8 @@ import org.scalatest.FunSuite
 class UpdateApiSuite extends FunSuite {
 
   private val factory = new JsonFactory()
+
+  private val aggrTag = Tag.of("atlas.aggr", "i-123")
 
   test("simple payload") {
     val clock = new ManualClock()
@@ -43,7 +46,8 @@ class UpdateApiSuite extends FunSuite {
       """.stripMargin)
     UpdateApi.processPayload(parser, registry)
     clock.setWallTime(62000)
-    assert(registry.counter(registry.createId("cpu")).actualCount() === 42.0)
+    val id = registry.createId("cpu").withTag(aggrTag)
+    assert(registry.counter(id).actualCount() === 42.0)
   }
 
   test("payload with additional tags") {
@@ -67,7 +71,7 @@ class UpdateApiSuite extends FunSuite {
     UpdateApi.processPayload(parser, registry)
     clock.setWallTime(62000)
     val id = registry.createId("cpu", "app", "www", "zone", "1e")
-    assert(registry.counter(id).actualCount() === 42.0)
+    assert(registry.counter(id.withTag(aggrTag)).actualCount() === 42.0)
   }
 
   test("payload with invalid characters") {
@@ -91,7 +95,7 @@ class UpdateApiSuite extends FunSuite {
     UpdateApi.processPayload(parser, registry)
     clock.setWallTime(62000)
     val id = registry.createId("cpu_user", "app", "www", "zone", "1e")
-    assert(registry.counter(id).actualCount() === 42.0)
+    assert(registry.counter(id.withTag(aggrTag)).actualCount() === 42.0)
   }
 }
 


### PR DESCRIPTION
Before this would get done for all metric with a commonTags
config. Now we can omit this from gauges as the max behavior
will choose the correct value. For now to avoid deduping this
tag is still needed on counters.