### PR TITLE
remove common tags from aggr registry

### DIFF
--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AppModule.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AppModule.scala
@@ -57,12 +57,6 @@ object AppModule {
       if (config.hasPath(prop)) config.getString(prop) else null
     }
 
-    override def commonTags(): java.util.Map[String, String] = {
-      val tags = new java.util.HashMap[String, String]()
-      tags.put("atlas.aggr", config.getString("netflix.iep.env.instance-id"))
-      tags
-    }
-
     override def debugRegistry(): Registry = registry
   }
 


### PR DESCRIPTION
These will get applied more narrowly now as it is only
needed for counters and not gauges.