### PR TITLE
druid: fix `key,:has,:not` queries

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -362,7 +362,7 @@ object DruidDatabaseActor {
     val arrays = scala.collection.mutable.AnyRefMap.empty[Map[String, String], Array[Double]]
     val length = context.bufferSize
     data.foreach { d =>
-      val tags = d.event - "value"
+      val tags = d.tags
       val array = arrays.getOrElseUpdate(tags, ArrayHelper.fill(length, Double.NaN))
       val t = Instant.parse(d.timestamp).toEpochMilli
       val i = ((t - context.start) / context.step).toInt

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
@@ -193,6 +193,7 @@ class DruidClientSuite extends FunSuite with BeforeAndAfterAll {
 
   test("groupBy filter out null dimensions") {
     val datapoints = executeGroupByRequest
-    assert(datapoints.size === 5)
+    assert(datapoints.count(_.tags.isEmpty) === 1)
+    assert(datapoints.count(_.tags.nonEmpty) === 5)
   }
 }


### PR DESCRIPTION
Before these would be empty because druid would return the
event with a `"key": null` and it would get filtered out.
The filtering was added to avoid NPE with percentile queries.

This changes it to filter the keys with null values from the
set of tags rather than the overall datapoint. Checking with
a percentile query, this does not regress that behavior.