### PR TITLE
druid: extract tags from simplified query

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -391,17 +391,20 @@ object DruidDatabaseActor {
         m -> ds.datasource.dimensions
       }
     }
-
-    val commonTags = exactTags(query)
-
     val intervals = List(toInterval(context))
+
     metrics.flatMap {
       case (m, ds) =>
         val name = m("name")
         val datasource = m("nf.datasource")
+
+        // Common tags should be extracted for the simplified query rather than the raw
+        // query. The simplified query may have additional exact matches due to simplified
+        // OR clauses that need to be maintained for correct processing in the eval step.
+        val simpleQuery = simplify(query, ds)
+        val commonTags = exactTags(simpleQuery)
         val tags = commonTags ++ m
 
-        val simpleQuery = simplify(query, ds)
         if (simpleQuery == Query.False) {
           None
         } else {

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
@@ -288,4 +288,10 @@ class DruidDatabaseActorSuite extends FunSuite {
     assert(queries.map(_._1("name")).toSet === Set("m1", "m2", "m3"))
     assert(queries.map(_._1("nf.datasource")).toSet === Set("ds_1", "ds_2"))
   }
+
+  test("toDruidQueries: or with one missing dimension") {
+    val expr = DataExpr.Sum(Query.Or(Query.Equal("a", "1"), Query.Equal("d", "2")))
+    val queries = toDruidQueries(metadata, context, expr)
+    assert(queries.forall(_._1.contains("a")))
+  }
 }


### PR DESCRIPTION
For some OR clauses this is needed to preserve the tag
information for the eval step. Otherwise the data would
get filtered out and result in an empty graph.