### PR TITLE
druid: fix matching of not clauses

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -497,11 +497,9 @@ object DruidDatabaseActor {
   /**
     * Simplify the query by keeping only clauses that have exact matches.
     */
-  private def simplifyExact(query: Query): Query = {
+  private[druid] def simplifyExact(query: Query): Query = {
     val simpleQuery = query match {
       case Query.And(q1, q2) => Query.And(simplifyExact(q1), simplifyExact(q2))
-      case Query.Or(q1, q2)  => Query.Or(simplifyExact(q1), simplifyExact(q2))
-      case Query.Not(q)      => Query.Not(simplifyExact(q))
       case q: Query.Equal    => q
       case _: Query          => Query.True
     }


### PR DESCRIPTION
The change in #170 would cause not queries to get simplified
to false and incorrectly match nothing. The exact matching
criteria has been updated to match the behavior of exactKeys.