### PR TITLE
rollup nf.node for percentile counters

### DIFF
--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/UpdateApi.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/UpdateApi.scala
@@ -104,7 +104,7 @@ object UpdateApi extends StrictLogging {
       // TODO: validate num tags and lengths
       val op = nextInt(parser)
       val value = nextDouble(parser)
-      val id = createId(registry, tags)
+      val id = createId(registry, rollup(tags))
       op match {
         case ADD =>
           // Add the aggr tag to avoid values getting deduped on the backend
@@ -142,6 +142,17 @@ object UpdateApi extends StrictLogging {
       i += 1
     }
     tags.result
+  }
+
+  /**
+    * Handle any automatic rollups on the id. For now it just removes the node dimension for
+    * ids with percentiles.
+    */
+  private def rollup(tags: TagMap): TagMap = {
+    if (tags.contains("percentile"))
+      (tags - "nf.node" - "nf.task").asInstanceOf[TagMap]
+    else
+      tags
   }
 
   private def createId(registry: AtlasRegistry, tags: TagMap): Id = {


### PR DESCRIPTION
For the counters used to compute the percentile approximations,
automatically rollup nf.node and nf.task if present. These
should always get rolled up as soon as possible.