### PR TITLE
set initial delay to start of interval

### DIFF
--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AggrConfig.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AggrConfig.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.aggregator
 
+import com.netflix.spectator.api.Clock
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.atlas.AtlasConfig
 import com.typesafe.config.Config
@@ -27,4 +28,13 @@ class AggrConfig(config: Config, registry: Registry) extends AtlasConfig {
   }
 
   override def debugRegistry(): Registry = registry
+
+  override def initialPollingDelay(clock: Clock, stepSize: Long): Long = {
+    val now = clock.wallTime()
+    val stepBoundary = now / stepSize * stepSize
+
+    // Buffer by 10% of the step interval
+    val firstTime = stepBoundary + stepSize / 10
+    if (firstTime > now) firstTime - now else firstTime + stepSize - now
+  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
     val scala      = "2.13.1"
     val servo      = "0.12.28"
     val slf4j      = "1.7.28"
-    val spectator  = "0.98.0"
+    val spectator  = "0.99.1"
 
     val crossScala = Seq(scala, "2.12.10")
   }


### PR DESCRIPTION
Gives the aggregator more time to send data when handling
many metrics.