### PR TITLE
Add dependency on spectator-ext-aws2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -222,6 +222,7 @@ lazy val `iep-ses-monitor` = project
     Dependencies.log4jApi,
     Dependencies.log4jCore,
     Dependencies.log4jSlf4j,
+    Dependencies.spectatorAws2,
 
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaTestkit % "test",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,6 +84,7 @@ object Dependencies {
   val slf4jLog4j         = "org.slf4j" % "slf4j-log4j12" % slf4j
   val slf4jSimple        = "org.slf4j" % "slf4j-simple" % slf4j
   val spectatorApi       = "com.netflix.spectator" % "spectator-api" % spectator
+  val spectatorAws2      = "com.netflix.spectator" % "spectator-ext-aws2" % spectator
   val spectatorAtlas     = "com.netflix.spectator" % "spectator-reg-atlas" % spectator
   val spectatorLog4j     = "com.netflix.spectator" % "spectator-ext-log4j2" % spectator
   val spectatorM2        = "com.netflix.spectator" % "spectator-reg-metrics2" % spectator


### PR DESCRIPTION
`iep-ses-monitor` now uses the AWS v2 SDK. This will restore metrics for
the AWS calls it makes.