### PR TITLE
validate datapoints coming into the aggregator

### DIFF
--- a/atlas-aggregator/src/main/resources/application.conf
+++ b/atlas-aggregator/src/main/resources/application.conf
@@ -6,3 +6,77 @@ atlas.akka {
     "com.netflix.atlas.aggregator.UpdateApi"
   ]
 }
+
+atlas.aggregator {
+
+  cache {
+    strings {
+      max-size = 2000000
+      expires-after = 5m
+    }
+    ids {
+      max-size = 5000000
+      expires-after = 5m
+    }
+  }
+
+  allowed-characters = "-._A-Za-z0-9^~"
+
+  validation {
+
+    // Maximum number of user tags
+    max-user-tags = 20
+
+    // Validation rules for tags, should only include simple TagRule instances
+    rules = [
+      {
+        class = "com.netflix.atlas.core.validation.KeyLengthRule"
+        min-length = 2
+        max-length = 60
+      },
+      {
+        class = "com.netflix.atlas.core.validation.NameValueLengthRule"
+        name {
+          min-length = 2
+          max-length = 255
+        }
+        others {
+          min-length = 1
+          max-length = 120
+        }
+      },
+      {
+        class = "com.netflix.atlas.core.validation.ReservedKeyRule"
+        prefix = "atlas."
+        allowed-keys = [
+          "aggr",
+          "dstype",
+          "offset",
+          "legacy"
+        ]
+      },
+      {
+        class = "com.netflix.atlas.core.validation.ReservedKeyRule"
+        prefix = "nf."
+        allowed-keys = [
+          "account",
+          "ami",
+          "app",
+          "asg",
+          "cluster",
+          "country",
+          "country.rollup",
+          "job",
+          "node",
+          "region",
+          "stack",
+          "subnet",
+          "task",
+          "vmtype",
+          "vpc",
+          "zone"
+        ]
+      }
+    ]
+  }
+}

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/FailureMessage.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/FailureMessage.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.aggregator
+
+import com.netflix.atlas.akka.DiagnosticMessage
+import com.netflix.atlas.core.validation.ValidationResult
+import com.netflix.atlas.json.JsonSupport
+
+/**
+  * Message returned to the user if some of the datapoints sent fail validation rules.
+  *
+  * @param `type`
+  *     Indicates whether the payload was an entirely or just partially impacted. If
+  *     all datapoints failed, then it will return an error.
+  * @param errorCount
+  *     The number of failed datapoints in the payload.
+  * @param message
+  *     Sampled set of failure messages to help the user debug.
+  */
+case class FailureMessage(`type`: String, errorCount: Int, message: List[String])
+    extends JsonSupport {
+
+  def typeName: String = `type`
+}
+
+object FailureMessage {
+
+  def error(message: List[ValidationResult], n: Int): FailureMessage = {
+    val failures = message.collect { case ValidationResult.Fail(_, reason) => reason }
+    new FailureMessage(DiagnosticMessage.Error, n, failures.take(5))
+  }
+
+  def partial(message: List[ValidationResult], n: Int): FailureMessage = {
+    val failures = message.collect { case ValidationResult.Fail(_, reason) => reason }
+    new FailureMessage("partial", n, failures.take(5))
+  }
+}

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
@@ -15,7 +15,15 @@
  */
 package com.netflix.atlas.aggregator
 
+import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.StatusCode
+import akka.http.scaladsl.model.StatusCodes
 import com.fasterxml.jackson.core.JsonFactory
+import com.netflix.atlas.aggregator.UpdateApi.TagMap
+import com.netflix.atlas.akka.ByteStringInputStream
+import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.atlas.core.util.Strings
+import com.netflix.atlas.json.Json
 import com.netflix.spectator.api.Clock
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.ManualClock
@@ -48,7 +56,7 @@ class UpdateApiSuite extends FunSuite {
         |  42.0
         |]
       """.stripMargin)
-    UpdateApi.processPayload(parser, service)
+    assert(UpdateApi.processPayload(parser, service).status === StatusCodes.OK)
     clock.setWallTime(62000)
     val id = Id.create("cpu").withTag(aggrTag)
     assert(service.lookup(id).counter(id).actualCount() === 42.0)
@@ -72,7 +80,7 @@ class UpdateApiSuite extends FunSuite {
         |  42.0
         |]
       """.stripMargin)
-    UpdateApi.processPayload(parser, service)
+    assert(UpdateApi.processPayload(parser, service).status === StatusCodes.OK)
     clock.setWallTime(62000)
     val id = Id
       .create("cpu")
@@ -99,7 +107,7 @@ class UpdateApiSuite extends FunSuite {
         |  42.0
         |]
       """.stripMargin)
-    UpdateApi.processPayload(parser, service)
+    assert(UpdateApi.processPayload(parser, service).status === StatusCodes.OK)
     clock.setWallTime(62000)
     val id = Id
       .create("cpu_user")
@@ -127,12 +135,104 @@ class UpdateApiSuite extends FunSuite {
         |  42.0
         |]
       """.stripMargin)
-    UpdateApi.processPayload(parser, service)
+    assert(UpdateApi.processPayload(parser, service).status === StatusCodes.OK)
     clock.setWallTime(62000)
     val id = Id
       .create("latency")
       .withTag(aggrTag)
       .withTag("percentile", "T0000")
     assert(service.lookup(id).counter(id).actualCount() === 42.0)
+  }
+
+  private def createPayload(ts: List[TagMap], op: Int, value: Double): String = {
+    val data = List.newBuilder[Any]
+    data += ts.map(_.size * 2).sum
+    ts.foreach { tags =>
+      tags.foreach { t =>
+        data += t._1
+        data += t._2
+      }
+    }
+    var offset = 0
+    ts.foreach { tags =>
+      data += tags.size
+      (0 until tags.size * 2).foreach { i =>
+        data += offset + i
+      }
+      data += op
+      data += value
+      offset += tags.size * 2
+    }
+    Json.encode(data)
+  }
+
+  private def validationTest(tags: TagMap, expectedStatus: StatusCode): FailureMessage = {
+    validationTest(List(tags), expectedStatus)
+  }
+
+  private def validationTest(ts: List[TagMap], expectedStatus: StatusCode): FailureMessage = {
+    val clock = new ManualClock()
+    val service = createAggrService(clock)
+    val parser = factory.createParser(createPayload(ts, 0, 1.0))
+    val response = UpdateApi.processPayload(parser, service)
+    assert(response.status === expectedStatus)
+    assert(response.entity.isStrict())
+    val strict = response.entity.asInstanceOf[HttpEntity.Strict]
+    Json.decode[FailureMessage](new ByteStringInputStream(strict.data))
+  }
+
+  test("validation: ok") {
+    val tags = SmallHashMap("name" -> "foo")
+    validationTest(tags, StatusCodes.OK)
+  }
+
+  test("validation: missing name") {
+    val tags = SmallHashMap("foo" -> "bar")
+    val msg = validationTest(tags, StatusCodes.BadRequest)
+    assert(msg.errorCount === 1)
+    assert(msg.message === List("missing 'name': Set(foo)"))
+  }
+
+  test("validation: too many user tags") {
+    val tags = Map("name" -> "foo") ++ (0 until 20)
+        .map(v => Strings.zeroPad(v, 5))
+        .map(v => v -> v)
+    val msg = validationTest(SmallHashMap(tags), StatusCodes.BadRequest)
+    assert(msg.errorCount === 1)
+    assert(msg.message === List("too many user tags: 21 > 20"))
+  }
+
+  test("validation: user tags, ignore restricted") {
+    val tags = Map("name" -> "foo", "nf.app" -> "www") ++ (0 until 19)
+        .map(v => Strings.zeroPad(v, 5))
+        .map(v => v -> v)
+    val msg = validationTest(SmallHashMap(tags), StatusCodes.OK)
+    assert(msg.errorCount === 0)
+  }
+
+  test("validation: tag rule") {
+    val tags = SmallHashMap("name" -> "test", "nf.foo" -> "bar")
+    val msg = validationTest(tags, StatusCodes.BadRequest)
+    assert(msg.errorCount === 1)
+    assert(msg.message === List("invalid key for reserved prefix 'nf.': nf.foo"))
+  }
+
+  test("validation: partial failure") {
+    val ts = List(
+      SmallHashMap("name" -> "test", "nf.foo" -> "bar"),
+      SmallHashMap("name" -> "test", "nf.app" -> "bar")
+    )
+    val msg = validationTest(ts, StatusCodes.Accepted)
+    assert(msg.errorCount === 1)
+    assert(msg.message === List("invalid key for reserved prefix 'nf.': nf.foo"))
+  }
+
+  test("validation: truncate if there are too many errors") {
+    val ts = (0 until 20).toList.map { i =>
+      SmallHashMap("name" -> i.toString, "nf.foo" -> "bar")
+    }
+    val msg = validationTest(ts, StatusCodes.BadRequest)
+    assert(msg.errorCount === 20)
+    assert(msg.message.size === 5)
   }
 }


### PR DESCRIPTION
The `/update` endpoint on the aggregator will now validate
the datapoints and indicate any issues in the response. This
can be used by thin clients to inform the user of problems.

The rules are mostly the same as those used for the publish
endpoint of the backend. Valid characters are not checked
because they will get fixed on this path by the registry.