### PR TITLE
aws-sdk-java-v2 2.10.56

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -214,7 +214,7 @@ lazy val `iep-ses-monitor` = project
   .configure(BuildSettings.profile)
   .settings(libraryDependencies ++= Seq(
     Dependencies.atlasModuleAkka,
-    Dependencies.awsSQS,
+    Dependencies.aws2SQS,
     Dependencies.alpakkaSqs,
     Dependencies.iepGuice,
     Dependencies.iepModuleAtlas,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,8 @@ object Dependencies {
     val akkaHttpV  = "10.1.11"
     val atlas      = "1.7.0-rc.3"
     val aws        = "1.11.702"
-    val iep        = "2.1.8"
+    val aws2       = "2.10.56"
+    val iep        = "2.1.9"
     val guice      = "4.1.0"
     val log4j      = "2.13.0"
     val scala      = "2.13.1"
@@ -40,6 +41,7 @@ object Dependencies {
   val awsEC2             = "com.amazonaws" % "aws-java-sdk-ec2" % aws
   val awsSQS             = "com.amazonaws" % "aws-java-sdk-sqs" % aws
   val awsSTS             = "com.amazonaws" % "aws-java-sdk-sts" % aws
+  val aws2SQS            = "software.amazon.awssdk" % "sqs" % aws2
   val frigga             = "com.netflix.frigga" % "frigga" % "0.20.0"
   val guiceCore          = "com.google.inject" % "guice" % guice
   val guiceMulti         = "com.google.inject.extensions" % "guice-multibindings" % guice


### PR DESCRIPTION
Pick up fix for DNS resolution with netty client. Also
fixes the explicit SQS dependency for the SES monitor
to use the V2 SDK instead of V1.

https://github.com/aws/aws-sdk-java-v2/blob/master/CHANGELOG.md#21056-2020-01-24