### PR TITLE
stop all sessions on EvalService restart

### DIFF
--- a/atlas-stream/src/main/scala/com/netflix/atlas/stream/EvalService.scala
+++ b/atlas-stream/src/main/scala/com/netflix/atlas/stream/EvalService.scala
@@ -85,6 +85,14 @@ class EvalService @Inject()(
     cleanup()
   }
 
+  /**
+    * For now, not doing synchronization with `register`, considering below scenarios:
+    * 1. registered but not completed here, then cleared from Map
+    *    - EvalFlow gets an valid queue handle and setup successfully
+    *    - later updateDataSources will fail because streamInfo is null, and flow will fail
+    * 2. registered, completed here, and then cleared from Map
+    *   - whole EvalFlow complete due to completion of queue handle
+    */
   private def cleanup(): Unit = {
     registrations.values().forEach(streamInfo => streamInfo.handler.complete())
     registrations.clear()


### PR DESCRIPTION
Currently, when EvalService restarts for any error, it completes queues for all active sessions, and because EvalFlow pushes out a new Source continuously whenever previous one completes, and the initial heartbeat is always available immediately, which may cause super high cpu/network consumption at both client and server side.

The fix is to have EvalFlow only push out Source once and simply completeStage if it ever gets pulled again due to completion of previous source. This means all active session will be closed on EvalService restart, which I think should be the right thing to do.

Also add some comments about why not doing synchronization between `cleanup` and `register` on EvalService restart.