### PR TITLE
stop cross building for scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: scala
 matrix:
   include:
   - jdk: openjdk8
-    scala: 2.12.10
-    env: BINTRAY_PUBLISH=true
-  - jdk: openjdk8
     scala: 2.13.1
     env: BINTRAY_PUBLISH=true
   - jdk: openjdk11

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
     val slf4j      = "1.7.30"
     val spectator  = "0.103.0"
 
-    val crossScala = Seq(scala, "2.12.10")
+    val crossScala = Seq(scala)
   }
 
   import Versions._


### PR DESCRIPTION
Internally all uses of these have moved to scala 2.13. To
reduce maintenance effort, drop 2.12 builds.