### PR TITLE
atlas-stream: add limit for max-datasources-per-session

### DIFF
--- a/atlas-stream/src/main/resources/application.conf
+++ b/atlas-stream/src/main/resources/application.conf
@@ -7,4 +7,7 @@ atlas.akka {
   ]
 }
 
-atlas.stream.eval-service.queue-size = 10000
+atlas.stream {
+  eval-service.queue-size = 10000
+  max-datasources-per-session = 100
+}

--- a/atlas-stream/src/main/scala/com/netflix/atlas/stream/EvalService.scala
+++ b/atlas-stream/src/main/scala/com/netflix/atlas/stream/EvalService.scala
@@ -45,7 +45,7 @@ import scala.util.Failure
 import scala.util.Success
 
 class EvalService @Inject()(
-  config: Config,
+  val config: Config,
   val registry: Registry,
   val evaluator: Evaluator,
   implicit val system: ActorSystem
@@ -57,7 +57,6 @@ class EvalService @Inject()(
   private val registrations = new ConcurrentHashMap[String, StreamInfo]
   private val numDataSourceDistSum = registry.distributionSummary("evalService.numDataSource")
   private val queueSize = config.getInt("atlas.stream.eval-service.queue-size")
-
   override def startImpl(): Unit = {
     logger.debug("Starting service")
 
@@ -203,7 +202,7 @@ object EvalService {
     }
 
     def complete(): Unit = {
-      logger.debug(s"queue complete for $id")
+      logger.info(s"queue complete for: $id")
       queue.complete()
     }
 

--- a/atlas-stream/src/test/scala/com/netflix/atlas/stream/EvalFlowSuite.scala
+++ b/atlas-stream/src/test/scala/com/netflix/atlas/stream/EvalFlowSuite.scala
@@ -36,6 +36,7 @@ class EvalFlowSuite extends AnyFunSuite {
   private val config = ConfigFactory.load
   private val registry = new NoopRegistry()
   private val validateNoop: DataSource => Unit = _ => ()
+
   private val dataSourceStr =
     """[{"id":"abc", "step": 10, "uri":"http://local-dev/api/v1/graph?q=name,a,:eq"}]"""
 
@@ -49,7 +50,7 @@ class EvalFlowSuite extends AnyFunSuite {
       }
     }
 
-    val evalFlow = EvalFlow.createEvalFlow(evalService, validateNoop)
+    val evalFlow = EvalFlow.createEvalFlow(evalService, DataSourceValidator(10, validateNoop))
 
     Source.single(dataSourceStr).via(evalFlow)
     val future = Source


### PR DESCRIPTION
Limit number of DataSources per session. 
Refactored DataSourceValidator to avoid passing extra parameters everywhere.