### PR TITLE
atlas-stream: reject requests if total datasources exceed limit

### DIFF
--- a/atlas-stream/src/main/resources/application.conf
+++ b/atlas-stream/src/main/resources/application.conf
@@ -10,4 +10,5 @@ atlas.akka {
 atlas.stream {
   eval-service.queue-size = 10000
   max-datasources-per-session = 100
+  max-datasources-total = 2000
 }


### PR DESCRIPTION
Reject requests if total number of datasources exceeds limit to avoid atlas-stream from overload and produce incorrect results.