### PR TITLE
aggr: allow shard tags

### DIFF
--- a/atlas-aggregator/src/main/resources/application.conf
+++ b/atlas-aggregator/src/main/resources/application.conf
@@ -69,6 +69,8 @@ atlas.aggregator {
           "job",
           "node",
           "region",
+          "shard1",
+          "shard2",
           "stack",
           "subnet",
           "task",


### PR DESCRIPTION
Make it match settings from the publish cluster. See
Netflix/atlas#1127 for more details.