### PR TITLE
atlas-persistence: hash prefix and format key name

### DIFF
--- a/atlas-persistence/src/main/resources/log4j2.xml
+++ b/atlas-persistence/src/main/resources/log4j2.xml
@@ -12,7 +12,7 @@
         <Logger name="com.netflix.iep" level="info"/>
         <Logger name="com.netflix.spectator" level="info"/>
         <Logger name="com.netflix.atlas.persistence" level="debug"/>
-        <Logger name="software.amazon.awssdk" level="debug"/>
+        <Logger name="software.amazon.awssdk" level="info"/>
         <Root level="info">
             <AppenderRef ref="STDOUT"/>
         </Root>

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/RollingFileWriter.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/RollingFileWriter.scala
@@ -116,10 +116,11 @@ class AvroRollingFileWriter(
     }
   }
 
-  // Example file name: 2020051003.i-localhost.1.XkvU3A.tmp
+  // Example file name: 2020051003.i-localhost.0001.XkvU3A.tmp
   // The random string suffix is to avoid file name conflict when server restarts
   private def getNextTmpFilePath: String = {
-    s"$filePathPrefix.$getInstanceId.$nextFileSeqId.$getRandomStr${RollingFileWriter.TmpFileSuffix}"
+    val seqStr = "%04d".format(nextFileSeqId)
+    s"$filePathPrefix.$getInstanceId.$seqStr.$getRandomStr${RollingFileWriter.TmpFileSuffix}"
   }
 
   private def getInstanceId: String = {

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopySink.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopySink.scala
@@ -156,9 +156,7 @@ class S3CopySink(
       private def buildS3Key(fileName: String): String = {
         val hour = fileName.substring(0, HourlyRollingWriter.HourStringLen)
         val s3FileName = fileName.substring(HourlyRollingWriter.HourStringLen + 1)
-        //TODO not hash for now for easier data cleanup
-        //val hourPath = hash(s"$prefix/$hour")
-        val hourPath = s"$prefix/$hour"
+        val hourPath = hash(s"$prefix/$hour")
         s"$hourPath/$s3FileName"
       }
 


### PR DESCRIPTION
add hash prefix to s3 key for more even data distributeion; add padding for file sequence id for better sort alignment. 