### PR TITLE
atlas-persistence: make services singleton to make shutdown hook work

### DIFF
--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
@@ -29,7 +29,9 @@ import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class LocalFilePersistService @Inject()(
   val config: Config,
   val registry: Registry,

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopyService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopyService.scala
@@ -31,10 +31,12 @@ import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 import javax.inject.Inject
+import javax.inject.Singleton
 
 import scala.concurrent.duration._
 import scala.jdk.StreamConverters._
 
+@Singleton
 class S3CopyService @Inject()(
   val config: Config,
   val registry: Registry,


### PR DESCRIPTION
Make services singleton so that their stopImpl will be called during shutdown