### PR TITLE
atlas-persistence: ensure S3CopyService is shutdown last

### DIFF
--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
@@ -35,6 +35,9 @@ import javax.inject.Singleton
 class LocalFilePersistService @Inject()(
   val config: Config,
   val registry: Registry,
+  // S3CopyService is actually NOT used by this service, it is here just to guarantee that the
+  // shutdown callback (stopImpl) of this service is invoked before S3CopyService's
+  val s3CopyService: S3CopyService,
   implicit val system: ActorSystem
 ) extends AbstractService
     with StrictLogging {


### PR DESCRIPTION
atlas-persistence: ensure S3CopyService is shutdown after LocalFilePersistService