### PR TITLE
atlas-persistence: make file rename atomic to fix early termination

### DIFF
--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/FileUtil.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/FileUtil.scala
@@ -18,6 +18,7 @@ package com.netflix.atlas.persistence
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
 
 import com.typesafe.scalalogging.StrictLogging
 
@@ -54,7 +55,9 @@ object FileUtil extends StrictLogging {
       val filePath = f.getCanonicalPath
       Files.move(
         Paths.get(filePath),
-        Paths.get(filePath.substring(0, filePath.length - RollingFileWriter.TmpFileSuffix.length))
+        Paths.get(filePath.substring(0, filePath.length - RollingFileWriter.TmpFileSuffix.length)),
+        // Atomic to avoid incorrect file list view during process of rename
+        StandardCopyOption.ATOMIC_MOVE
       )
     } catch {
       case e: Exception =>

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopyService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopyService.scala
@@ -46,7 +46,6 @@ class S3CopyService @Inject()(
 
   private val dataDir = config.getString("atlas.persistence.local-file.data-dir")
 
-  private implicit val ec = scala.concurrent.ExecutionContext.global
   private implicit val mat = ActorMaterializer()
 
   private var killSwitch: KillSwitch = _
@@ -85,6 +84,8 @@ class S3CopyService @Inject()(
   private def waitForCleanup(): Unit = {
     logger.info("Waiting for cleanup")
     val start = System.currentTimeMillis
+    // Wait a bit first as a best effort try in case atomic rename is not supported by FileSystem
+    Thread.sleep(5000)
     while (hasMoreFiles) {
       if (System.currentTimeMillis() > start + cleanupTimeoutMs) {
         logger.error("Cleanup timeout")

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopySink.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopySink.scala
@@ -58,7 +58,6 @@ class S3CopySink(
   private val in = Inlet[File]("S3CopySink.in")
   override val shape = SinkShape(in)
 
-  private implicit val ec = scala.concurrent.ExecutionContext.global
   private implicit val mat = ActorMaterializer()
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
@@ -111,11 +110,9 @@ class S3CopySink(
             logger.warn(s"Should process: temp file but inactive - $f")
             true
           } else {
-            logger.debug(s"Should NOT process: temp file - $f")
             false
           }
         } else {
-          logger.debug(s"Should process: regular file - $f")
           true
         }
       }


### PR DESCRIPTION
File rename was not atomic, it some times cause early termination of waiting during shutdown before all files are processed