### PR TITLE
Timeout for s3 call and retry by listing file

### DIFF
--- a/atlas-persistence/src/main/resources/application.conf
+++ b/atlas-persistence/src/main/resources/application.conf
@@ -25,6 +25,7 @@ atlas {
       // A ".tmp" file not modified for this duration will be marked as complete (renamed), and it
       // MUST be longer than local-file.max-duration to avoid conflict
       max-inactive-duration = 7m
+      client-timeout = 2m
     }
   }
 }

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopyService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopyService.scala
@@ -35,7 +35,6 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 import scala.concurrent.duration._
-import scala.jdk.StreamConverters._
 
 @Singleton
 class S3CopyService @Inject()(

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopyService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopyService.scala
@@ -50,12 +50,9 @@ class S3CopyService @Inject()(
 
   private var killSwitch: KillSwitch = _
   private val s3Config = config.getConfig("atlas.persistence.s3")
-  private val bucket = s3Config.getString("bucket")
-  private val region = s3Config.getString("region")
-  private val prefix = s3Config.getString("prefix")
+
   private val cleanupTimeoutMs = s3Config.getDuration("cleanup-timeout").toMillis
   private val maxInactiveMs = s3Config.getDuration("max-inactive-duration").toMillis
-
   private val maxFileDurationMs =
     config.getDuration("atlas.persistence.local-file.max-duration").toMillis
 
@@ -70,8 +67,7 @@ class S3CopyService @Inject()(
       .tick(1.second, 5.seconds, NotUsed)
       .viaMat(KillSwitches.single)(Keep.right)
       .flatMapMerge(Int.MaxValue, _ => Source(FileUtil.listFiles(new File(dataDir))))
-      // S3CopySink handles flow restart for each file so no need to use RestartSink here
-      .toMat(new S3CopySink(bucket, region, prefix, maxInactiveMs, registry, system))(Keep.left)
+      .toMat(new S3CopySink(s3Config, registry, system))(Keep.left)
       .run()
   }
 


### PR DESCRIPTION
It seems like the s3 async client call never finishes occasionally (a few files after 2 days), with current flow, those file never get a chance to be re-processed in such cases. So setting a timeout from our end, release from dedup map when timeout and let file listing trigger the re-process.