### PR TITLE
atlas-persistence: save time range in the file name

### DIFF
--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/FileUtil.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/FileUtil.scala
@@ -17,8 +17,6 @@ package com.netflix.atlas.persistence
 
 import java.io.File
 import java.nio.file.Files
-import java.nio.file.Paths
-import java.nio.file.StandardCopyOption
 
 import com.netflix.atlas.core.util.Streams
 import com.typesafe.scalalogging.StrictLogging
@@ -52,19 +50,4 @@ object FileUtil extends StrictLogging {
     f.getName.endsWith(RollingFileWriter.TmpFileSuffix)
   }
 
-  // Mark a file as complete by removing tmp suffix, so it's ready for s3 copy
-  def markWriteComplete(f: File): Unit = {
-    try {
-      val filePath = f.getCanonicalPath
-      Files.move(
-        Paths.get(filePath),
-        Paths.get(filePath.substring(0, filePath.length - RollingFileWriter.TmpFileSuffix.length)),
-        // Atomic to avoid incorrect file list view during process of rename
-        StandardCopyOption.ATOMIC_MOVE
-      )
-    } catch {
-      case e: Exception =>
-        logger.error(s"Failed to mark file as complete by removing tmp suffix: $f", e)
-    }
-  }
 }

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
@@ -57,6 +57,7 @@ class LocalFilePersistService @Inject()(
   private val maxRecords = fileConfig.getLong("max-records")
   private val maxDurationMs = fileConfig.getDuration("max-duration").toMillis
   private val maxLateDurationMs = fileConfig.getDuration("max-late-duration").toMillis
+  private val rollingConf = RollingConfig(maxRecords, maxDurationMs, maxLateDurationMs)
 
   require(queueSize > 0)
   require(maxRecords > 0)
@@ -85,7 +86,7 @@ class LocalFilePersistService @Inject()(
       maxRestarts = -1
     ) { () =>
       Flow.fromGraph(
-        new RollingFileFlow(dataDir, maxRecords, maxDurationMs, maxLateDurationMs, registry)
+        new RollingFileFlow(dataDir, rollingConf, registry)
       )
     }
   }

--- a/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/RollingFileWriterSuite.scala
+++ b/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/RollingFileWriterSuite.scala
@@ -29,12 +29,13 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import scala.collection.mutable.ListBuffer
 
-class AvroRollingFileWriterSuite extends AnyFunSuite with BeforeAndAfter with BeforeAndAfterAll {
+class RollingFileWriterSuite extends AnyFunSuite with BeforeAndAfter with BeforeAndAfterAll {
 
   private val outputDir = "./target/unitTestAvroOutput"
   private val registry = new NoopRegistry
 
   before {
+    listFilesSorted(outputDir).foreach(_.delete()) // Clean up files if exits
     Files.createDirectories(Paths.get(outputDir))
   }
 
@@ -45,9 +46,14 @@ class AvroRollingFileWriterSuite extends AnyFunSuite with BeforeAndAfter with Be
 
   // Write 3 datapoints, first 2 is written in file 1, rollover, and 3rd one is written in file 2
   test("avro writer rollover by max records") {
-    val writer = new AvroRollingFileWriter(s"$outputDir/prefix", 2, 60000, registry)
+    val rollingConf = RollingConfig(2, 12000, 12000)
+    val hourStart = 3600000
+    val hourEnd = 7200000
+    val writer =
+      new RollingFileWriter(s"$outputDir/prefix", rollingConf, hourStart, hourEnd, registry)
     writer.initialize()
-    createData(0, 1, 2).foreach(writer.write)
+    createData(hourStart, 0, 1, 2).foreach(writer.write)
+    writer.write(Datapoint(Map.empty, hourEnd, 3)) // out of range, should be ignored
     writer.close()
 
     // Check num of files
@@ -56,6 +62,7 @@ class AvroRollingFileWriterSuite extends AnyFunSuite with BeforeAndAfter with Be
 
     // Check file 1 records
     val file1 = files.head
+    assert(file1.getName.endsWith(".0000-0001"))
     val dpArray1 = readAvro(file1)
     assert(dpArray1.size == 2)
     assert(dpArray1(0).getValue == 0)
@@ -65,25 +72,31 @@ class AvroRollingFileWriterSuite extends AnyFunSuite with BeforeAndAfter with Be
 
     // Check file 2 records
     val file2 = files.last
+    assert(file2.getName.endsWith(".0002-0002"))
     val dpArray2 = readAvro(file2)
     assert(dpArray2.size == 1)
     assert(dpArray2(0).getValue == 2)
     assert(dpArray2(0).getTags.get("node") == "2")
   }
 
-  private def createData(values: Double*): List[Datapoint] = {
+  private def createData(startTime: Long, values: Double*): List[Datapoint] = {
     values.toList.zipWithIndex.map {
       case (v, i) =>
         val tags = Map(
           "name" -> "cpu",
           "node" -> s"$i"
         )
-        Datapoint(tags, 12345, v, 60000)
+        Datapoint(tags, startTime + i * 1000, v, 60000)
     }
   }
 
   private def listFilesSorted(dir: String): List[File] = {
-    new File(dir).listFiles().filter(_.isFile).toList.sortBy(_.getName)
+    val d = new File(dir)
+    if (!d.exists()) {
+      Nil
+    } else {
+      new File(dir).listFiles().filter(_.isFile).toList.sortBy(_.getName)
+    }
   }
 
   private def readAvro(file: File): Array[AvroDatapoint] = {


### PR DESCRIPTION
Capture the actual time range seen for data points, and keep them as part of file name so that it can be filtered more precisely by big data jobs. Time range is the seconds of an hour, example: ".3500-3599".
Also some minor refactors to simplify code: remove RollingFileWriter trait for single implementation, add RollingConfig for easier parameter passing.