### PR TITLE
add option for aggregator to use dstype sum

### DIFF
--- a/atlas-aggregator/src/main/resources/application.conf
+++ b/atlas-aggregator/src/main/resources/application.conf
@@ -16,6 +16,10 @@ atlas.aggregator {
     }
   }
 
+  // Determines whether or not to include the aggregator node as a tag on counters.
+  // If false it will use atlas.dstype=sum instead.
+  include-aggr-tag = false
+
   allowed-characters = "-._A-Za-z0-9^~"
 
   validation {

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PayloadDecoder.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PayloadDecoder.scala
@@ -186,9 +186,14 @@ object PayloadDecoder {
   private val ADD = 0
   private val MAX = 10
 
-  private val aggrTag = Tag.of("atlas.aggr", NetflixEnvironment.instanceId())
-
   private val config = ConfigManager.get().getConfig("atlas.aggregator")
+
+  private val aggrTag = {
+    if (config.getBoolean("include-aggr-tag"))
+      Tag.of("atlas.aggr", NetflixEnvironment.instanceId())
+    else
+      Tag.of(TagKey.dsType, "sum")
+  }
 
   private val maxUserTags = config.getInt("validation.max-user-tags")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
     val scala      = "2.13.2"
     val servo      = "0.13.0"
     val slf4j      = "1.7.30"
-    val spectator  = "0.107.0"
+    val spectator  = "0.109.0"
     val avroV      = "1.9.2"
 
     val crossScala = Seq(scala)


### PR DESCRIPTION
Adds a configuration option that determines how counters
will get tagged. It will either add an aggregator tag to
avoid deduping on the backend or use `atlas.dstype=sum`
to allow the backend to sum the values.