### PR TITLE
aggr: adjust initial polling delay

### DIFF
--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AggrConfigSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AggrConfigSuite.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.aggregator
+
+import com.netflix.spectator.api.ManualClock
+import com.netflix.spectator.api.NoopRegistry
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funsuite.AnyFunSuite
+
+class AggrConfigSuite extends AnyFunSuite {
+
+  test("initial polling delay") {
+    val step = 60000L
+    val clock = new ManualClock()
+    val config = new AggrConfig(ConfigFactory.load(), new NoopRegistry)
+    (0L until step).foreach { t =>
+      clock.setWallTime(t)
+      val delay = config.initialPollingDelay(clock, step)
+      val stepOffset = (t + delay) % step
+      assert(stepOffset >= 6000)
+      assert(stepOffset <= 30000)
+    }
+  }
+}


### PR DESCRIPTION
Adjust the initial polling delay on the aggregator
to help spread out the requests to the downstream
clusters. It was initially aligned to the start to
maximize the amount of time to send the data. With
recent changes to run larger aggregator clusters
that have less data to send per node, this can
create a thundering herd for the connections.