### PR TITLE
aggr: disable validation for registry

### DIFF
--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AggrConfig.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AggrConfig.scala
@@ -58,4 +58,9 @@ class AggrConfig(config: Config, registry: Registry) extends AtlasConfig {
     * for the aggregator.
     */
   override def maxNumberOfMeters(): Int = maxMeters
+
+  /**
+    * Set to null since this will get corrected before it gets to the registry.
+    */
+  override def validTagCharacters(): String = null
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
     val scala      = "2.13.2"
     val servo      = "0.13.0"
     val slf4j      = "1.7.30"
-    val spectator  = "0.109.0"
+    val spectator  = "0.111.0"
     val avroV      = "1.9.2"
 
     val crossScala = Seq(scala)


### PR DESCRIPTION
The charset will get checked and fixed while parsing the
payload so this secondary check is not necessary.