### PR TITLE
rename root project to iep-apps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 
-lazy val root = project.in(file("."))
+lazy val `iep-apps` = project.in(file("."))
   .configure(BuildSettings.profile)
   .aggregate(
     `atlas-aggregator`,


### PR DESCRIPTION
rename root project to iep-apps to be more IDE friendly