### PR TITLE
atlas-persistence: enable data compression

### DIFF
--- a/atlas-persistence/src/main/resources/application.conf
+++ b/atlas-persistence/src/main/resources/application.conf
@@ -15,6 +15,10 @@ atlas {
       max-records = 100000
       max-duration = 5m
       max-late-duration = 5m
+      // Compression codec, can be: null, deflate, bzip2 or snappy
+      avro-codec = "null"
+      // avro buffer size(before compress), default is 64k, suggested values are between 2K and 2M
+      avro-syncInterval = 64000
     }
 
     s3 {

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/HourlyRollingWriter.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/HourlyRollingWriter.scala
@@ -138,4 +138,14 @@ object HourlyRollingWriter {
   val HourStringLen: Int = 15
 }
 
-case class RollingConfig(maxRecords: Long, maxDurationMs: Long, maxLateDurationMs: Long)
+case class RollingConfig(
+  maxRecords: Long,
+  maxDurationMs: Long,
+  maxLateDurationMs: Long,
+  codec: String,
+  syncInterval: Int
+) {
+  require(maxRecords > 0)
+  require(maxDurationMs > 0)
+  require(maxLateDurationMs > 0)
+}

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
@@ -54,14 +54,13 @@ class LocalFilePersistService @Inject()(
 
   private val fileConfig = config.getConfig("atlas.persistence.local-file")
   private val dataDir = fileConfig.getString("data-dir")
-  private val maxRecords = fileConfig.getLong("max-records")
-  private val maxDurationMs = fileConfig.getDuration("max-duration").toMillis
-  private val maxLateDurationMs = fileConfig.getDuration("max-late-duration").toMillis
-  private val rollingConf = RollingConfig(maxRecords, maxDurationMs, maxLateDurationMs)
-
-  require(queueSize > 0)
-  require(maxRecords > 0)
-  require(maxDurationMs > 0)
+  private val rollingConf = RollingConfig(
+    fileConfig.getLong("max-records"),
+    fileConfig.getDuration("max-duration").toMillis,
+    fileConfig.getDuration("max-late-duration").toMillis,
+    fileConfig.getString("avro-codec"),
+    fileConfig.getInt("avro-syncInterval")
+  )
 
   private var queue: SourceQueue[Datapoint] = _
   private var flowComplete: Future[Done] = _

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/RollingFileWriter.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/RollingFileWriter.scala
@@ -23,6 +23,7 @@ import java.nio.file.StandardCopyOption
 import com.netflix.atlas.core.model.Datapoint
 import com.netflix.spectator.api.Registry
 import com.typesafe.scalalogging.StrictLogging
+import org.apache.avro.file.CodecFactory
 import org.apache.avro.file.DataFileWriter
 import org.apache.avro.specific.SpecificDatumWriter
 
@@ -74,6 +75,10 @@ class RollingFileWriter(
     val dataFileWriter = new DataFileWriter[AvroDatapoint](
       new SpecificDatumWriter[AvroDatapoint](classOf[AvroDatapoint])
     )
+
+    dataFileWriter.setCodec(CodecFactory.fromString(rollingConf.codec))
+    dataFileWriter.setSyncInterval(rollingConf.syncInterval)
+
     // Possible to use API that takes OutputStream to track file size if needed
     dataFileWriter.create(AvroDatapoint.getClassSchema, new File(newFile))
 

--- a/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/AvroTest.scala
+++ b/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/AvroTest.scala
@@ -41,10 +41,11 @@ object AvroTest {
     while (dataFileReader.hasNext) {
       dataFileReader.next()
       count += 1
+      if (count < 4) {
+        println(s"    blockSize  = ${dataFileReader.getBlockSize}")
+      }
     }
 
-    println(s"    blockCount = ${dataFileReader.getBlockCount}")
-    println(s"    blockSize  = ${dataFileReader.getBlockSize}")
     println(s"    numRecords = $count")
 
     dataFileReader.close()

--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,8 @@ lazy val `atlas-persistence` = project
       Dependencies.iepGuice,
       Dependencies.log4jApi,
       Dependencies.log4jCore,
-      Dependencies.log4jSlf4j
+      Dependencies.log4jSlf4j,
+      Dependencies.snappy
   ))
 
 lazy val `atlas-slotting` = project

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,6 +74,7 @@ object Dependencies {
   val slf4jApi           = "org.slf4j" % "slf4j-api" % slf4j
   val slf4jLog4j         = "org.slf4j" % "slf4j-log4j12" % slf4j
   val slf4jSimple        = "org.slf4j" % "slf4j-simple" % slf4j
+  val snappy             = "org.xerial.snappy" % "snappy-java" % "1.1.7.6"
   val spectatorApi       = "com.netflix.spectator" % "spectator-api" % spectator
   val spectatorAws2      = "com.netflix.spectator" % "spectator-ext-aws2" % spectator
   val spectatorAtlas     = "com.netflix.spectator" % "spectator-reg-atlas" % spectator


### PR DESCRIPTION
Enable data compression to reduce output file size.