### PR TITLE
Use union datasource when querying for tags

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -254,7 +254,7 @@ object DruidClient {
 
   // http://druid.io/docs/latest/querying/searchquery.html
   case class SearchQuery(
-    dataSource: String,
+    private val dataSources: List[String],
     searchDimensions: List[DimensionSpec],
     intervals: List[String],
     filter: Option[DruidFilter] = None,
@@ -264,6 +264,15 @@ object DruidClient {
   ) {
     val queryType: String = "search"
     val query: DruidQuery.type = DruidQuery
+    // Use a union of the datasource(s) to send 1 query to Druid
+    // The Druid broker will handle sending the query to each datasource
+    // and merge the results before responding.
+    // https://druid.apache.org/docs/latest/querying/query-execution.html#union
+    val dataSource: UnionDatasource = UnionDatasource(dataSources)
+  }
+
+  case class UnionDatasource(dataSources: List[String]) {
+    val `type`: String = "union"
   }
 
   case object DruidQuery {

--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -175,16 +175,16 @@ class DruidDatabaseActor(config: Config) extends Actor with StrictLogging {
         //
         // The limit for number of returned values cannot be applied to the query sent to Druid
         // because it could truncate the results for multi-value dimensions.
-        val druidQueries = datasources.map { ds =>
-          val searchQuery = SearchQuery(
-            dataSource = ds.name,
-            searchDimensions = List(DefaultDimensionSpec(k, k)),
-            intervals = List(tagsQueryInterval),
-            filter = DruidFilter.forQuery(query),
-            limit = Int.MaxValue
-          )
-          client.search(searchQuery)
-        }
+        val searchQuery = SearchQuery(
+          dataSources = datasources.map { ds =>
+            ds.name
+          },
+          searchDimensions = List(DefaultDimensionSpec(k, k)),
+          intervals = List(tagsQueryInterval),
+          filter = DruidFilter.forQuery(query),
+          limit = Int.MaxValue
+        )
+        val druidQueries = List(client.search(searchQuery))
         Source(druidQueries)
           .flatMapMerge(Int.MaxValue, v => v)
           .map(_.flatMap(_.values))


### PR DESCRIPTION
This has the same effect overall, but results in fewer calls to the broker and slightly less overhead overall.
I'm unable to prove this make a material difference when testing locally.
The motivation is due to feedback that populating Lumen drop-downs is taking too long.