### PR TITLE
atlas-persistence: use generic avro type to avoid overhead

### DIFF
--- a/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/AvroTest.scala
+++ b/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/AvroTest.scala
@@ -20,7 +20,8 @@ import java.nio.file.Files
 import java.nio.file.Paths
 
 import org.apache.avro.file.DataFileReader
-import org.apache.avro.specific.SpecificDatumReader
+import org.apache.avro.generic.GenericDatumReader
+import org.apache.avro.generic.GenericRecord
 
 // Read metadata for all avro files in given directory
 object AvroTest {
@@ -36,14 +37,14 @@ object AvroTest {
   private def readFile(file: File): Unit = {
     println(s"##### Reading file: $file")
     var count = 0
-    val userDatumReader = new SpecificDatumReader[AvroDatapoint](classOf[AvroDatapoint])
-    val dataFileReader = new DataFileReader[AvroDatapoint](file, userDatumReader)
+    val genericDatumReader = new GenericDatumReader[GenericRecord](RollingFileWriter.AvroSchema)
+    val dataFileReader = new DataFileReader[GenericRecord](file, genericDatumReader)
     while (dataFileReader.hasNext) {
-      dataFileReader.next()
-      count += 1
+      val record = dataFileReader.next()
       if (count < 4) {
-        println(s"    blockSize  = ${dataFileReader.getBlockSize}")
+        println(s"blockSize = ${dataFileReader.getBlockSize} | record = $record")
       }
+      count += 1
     }
 
     println(s"    numRecords = $count")

--- a/build.sbt
+++ b/build.sbt
@@ -51,8 +51,6 @@ lazy val `atlas-druid` = project
 lazy val `atlas-persistence` = project
   .configure(BuildSettings.profile)
   .settings(
-    avroStringType := "String",
-    avroFieldVisibility := "private",
     libraryDependencies ++= Seq(
       Dependencies.atlasModuleAkka,
       Dependencies.atlasModuleWebApi,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,8 +8,3 @@ addSbtPlugin("org.scalameta"             % "sbt-scalafmt"         % "2.3.1")
 
 // Convenient helpers, not required
 addSbtPlugin("com.timushev.sbt"          % "sbt-updates"          % "0.5.0")
-
-// Avro Java source code generation from schema
-addSbtPlugin("com.cavorite" % "sbt-avro" % "2.0.0").settings
-// avro-compiler version should match actual avro version
-libraryDependencies += "org.apache.avro" % "avro-compiler" % "1.9.2"


### PR DESCRIPTION
Switch to avro's GenericRecord APIs to avoid overhead. 
Currently a specifc java class is generated for Datapoint and its instances are used for writing to avro file, but that creates quite some overhead because it creates every new instance by reflection(Class.forName), and eventually come down to the same path of generic type and writer.
It also simplify project setup since we don't need the extra step of code gen and schema compilation stuff.
