### PR TITLE
atlas-persistence: parallelize file writing flow

### DIFF
--- a/atlas-persistence/src/main/resources/application.conf
+++ b/atlas-persistence/src/main/resources/application.conf
@@ -9,7 +9,8 @@ atlas {
 
   persistence {
     queue-size = 100000
-
+    // Number of parallel file writing workers
+    write-worker-size = 1
     local-file {
       data-dir = "./out"
       max-records = 100000

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/HourlyRollingWriter.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/HourlyRollingWriter.scala
@@ -30,9 +30,10 @@ import org.apache.avro.file.CodecFactory
   * RollingFileWriter.
   */
 class HourlyRollingWriter(
-  dataDir: String,
-  rollingConf: RollingConfig,
-  registry: Registry
+  val dataDir: String,
+  val rollingConf: RollingConfig,
+  val registry: Registry,
+  val workerId: Int
 ) extends StrictLogging {
 
   private val msOfOneHour = 3600000
@@ -74,7 +75,8 @@ class HourlyRollingWriter(
       rollingConf,
       hourStart,
       hourEnd,
-      registry
+      registry,
+      workerId
     )
     writer.initialize
     writer

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
@@ -108,7 +108,7 @@ class LocalFilePersistService @Inject()(
       Flow.fromGraph(GraphDSL.create() { implicit b =>
         val balancer = b.add(Balance[In](workerCount))
         val merge = b.add(Merge[Out](workerCount))
-        for (i <- 0 to workerCount - 1) {
+        for (i <- 0 until workerCount) {
           balancer ~> workerFlowFactory(i).async ~> merge
         }
         FlowShape(balancer.in, merge.out)

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
@@ -19,8 +19,12 @@ import akka.Done
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import akka.stream.FlowShape
+import akka.stream.scaladsl.Balance
 import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.GraphDSL
 import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Merge
 import akka.stream.scaladsl.RestartFlow
 import akka.stream.scaladsl.Sink
 import com.netflix.atlas.akka.StreamOps
@@ -51,7 +55,7 @@ class LocalFilePersistService @Inject()(
   implicit val mat = ActorMaterializer()
 
   private val queueSize = config.getInt("atlas.persistence.queue-size")
-
+  private val writeWorkerSize = config.getInt("atlas.persistence.write-worker-size")
   private val fileConfig = config.getConfig("atlas.persistence.local-file")
   private val dataDir = fileConfig.getString("data-dir")
 
@@ -71,14 +75,14 @@ class LocalFilePersistService @Inject()(
     logger.info("Starting service")
     val (q, f) = StreamOps
       .blockingQueue[Datapoint](registry, "LocalFilePersistService", queueSize)
-      .via(getRollingFileFlow)
+      .via(balancer(getRollingFileFlow(_), writeWorkerSize))
       .toMat(Sink.ignore)(Keep.both)
       .run
     queue = q
     flowComplete = f
   }
 
-  private def getRollingFileFlow(): Flow[Datapoint, NotUsed, NotUsed] = {
+  private def getRollingFileFlow(workerId: Int): Flow[Datapoint, NotUsed, NotUsed] = {
     import scala.concurrent.duration._
     RestartFlow.withBackoff(
       minBackoff = 1.second,
@@ -87,8 +91,28 @@ class LocalFilePersistService @Inject()(
       maxRestarts = -1
     ) { () =>
       Flow.fromGraph(
-        new RollingFileFlow(dataDir, rollingConf, registry)
+        new RollingFileFlow(dataDir, rollingConf, registry, workerId)
       )
+    }
+  }
+
+  def balancer[In, Out](
+    workerFlowFactory: Int => Flow[In, Out, NotUsed],
+    workerCount: Int
+  ): Flow[In, Out, NotUsed] = {
+    if (workerCount == 1) {
+      // Don't add overhead of balancer and sync boundary for single worker
+      workerFlowFactory(0)
+    } else {
+      import akka.stream.scaladsl.GraphDSL.Implicits._
+      Flow.fromGraph(GraphDSL.create() { implicit b =>
+        val balancer = b.add(Balance[In](workerCount))
+        val merge = b.add(Merge[Out](workerCount))
+        for (i <- 0 to workerCount - 1) {
+          balancer ~> workerFlowFactory(i).async ~> merge
+        }
+        FlowShape(balancer.in, merge.out)
+      })
     }
   }
 

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/RollingFileFlow.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/RollingFileFlow.scala
@@ -37,7 +37,8 @@ import scala.concurrent.duration._
 class RollingFileFlow(
   val dataDir: String,
   val rollingConf: RollingConfig,
-  val registry: Registry
+  val registry: Registry,
+  val id: Int
 ) extends GraphStage[FlowShape[Datapoint, NotUsed]]
     with StrictLogging {
 
@@ -52,10 +53,10 @@ class RollingFileFlow(
       private var hourlyWriter: HourlyRollingWriter = _
 
       override def preStart(): Unit = {
-        logger.info(s"creating sink directory: $dataDir")
+        logger.info(s"worker-$id: creating sink directory: $dataDir")
         Files.createDirectories(Paths.get(dataDir))
 
-        hourlyWriter = new HourlyRollingWriter(dataDir, rollingConf, registry)
+        hourlyWriter = new HourlyRollingWriter(dataDir, rollingConf, registry, id)
         hourlyWriter.initialize
         // This is to trigger rollover check when writer is idle for long time: e.g. in most cases
         // file writer will be idle while hour has ended but it is still waiting for late events

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/RollingFileWriter.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/RollingFileWriter.scala
@@ -40,7 +40,8 @@ class RollingFileWriter(
   val rollingConf: RollingConfig,
   val startTime: Long,
   val endTime: Long,
-  val registry: Registry
+  val registry: Registry,
+  val workerId: Int
 ) extends StrictLogging {
 
   // These "curr*" fields track status of the current file writer
@@ -168,11 +169,11 @@ class RollingFileWriter(
     "%04d".format((timestamp / 1000) % 3600)
   }
 
-  // Example file name: 2020051003.i-localhost.0001.XkvU3A.tmp
+  // Example file name: 2020051003.i-localhost.0.0001.XkvU3A.tmp
   // The random string suffix is to avoid file name conflict when server restarts
   private def getNextTmpFilePath: String = {
     val seqStr = "%04d".format(nextFileSeqId)
-    s"$filePathPrefix.$getInstanceId.$seqStr.$getRandomStr${RollingFileWriter.TmpFileSuffix}"
+    s"$filePathPrefix.$getInstanceId.$workerId.$seqStr.$getRandomStr${RollingFileWriter.TmpFileSuffix}"
   }
 
   private def getInstanceId: String = {

--- a/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/RollingFileWriterSuite.scala
+++ b/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/RollingFileWriterSuite.scala
@@ -62,7 +62,14 @@ class RollingFileWriterSuite extends AnyFunSuite with BeforeAndAfter with Before
       val hourStart = 3600000
       val hourEnd = 7200000
       val writer =
-        new RollingFileWriter(s"$outputDir/codec.$codec", rollingConf, hourStart, hourEnd, registry)
+        new RollingFileWriter(
+          s"$outputDir/codec.$codec",
+          rollingConf,
+          hourStart,
+          hourEnd,
+          registry,
+          0
+        )
       writer.initialize()
       createData(hourStart, 0, 1, 2).foreach(writer.write)
       writer.write(Datapoint(Map.empty, hourEnd, 3)) // out of range, should be ignored


### PR DESCRIPTION
Single thread seems to be one of the bottlenecks, allow parallelization to potentially increase throughput.