### PR TITLE
atlas-persistence: unflatten datapoint list

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -35,13 +35,13 @@ import akka.util.ByteString
 import com.fasterxml.jackson.core.JsonToken
 import com.netflix.atlas.akka.AccessLogger
 import com.netflix.atlas.akka.ByteStringInputStream
-import com.netflix.atlas.core.util.Streams
 import com.netflix.atlas.json.Json
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.util.Failure
 import scala.util.Success
+import scala.util.Using
 
 class DruidClient(
   config: Config,
@@ -148,7 +148,7 @@ class DruidClient(
   }
 
   private def parseResult(dimensions: List[String], data: ByteString): List[GroupByDatapoint] = {
-    Streams.scope(Json.newJsonParser(new ByteStringInputStream(data))) { parser =>
+    Using.resource(Json.newJsonParser(new ByteStringInputStream(data))) { parser =>
       import com.netflix.atlas.json.JsonParserHelper._
       val builder = List.newBuilder[GroupByDatapoint]
       foreachItem(parser) {

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/FileUtil.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/FileUtil.scala
@@ -18,10 +18,10 @@ package com.netflix.atlas.persistence
 import java.io.File
 import java.nio.file.Files
 
-import com.netflix.atlas.core.util.Streams
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.jdk.StreamConverters._
+import scala.util.Using
 
 object FileUtil extends StrictLogging {
 
@@ -36,7 +36,7 @@ object FileUtil extends StrictLogging {
 
   def listFiles(f: File): List[File] = {
     try {
-      Streams.scope(Files.list(f.toPath)) { dir =>
+      Using.resource(Files.list(f.toPath)) { dir =>
         dir.toScala(List).map(_.toFile)
       }
     } catch {

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/HourlyRollingWriter.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/HourlyRollingWriter.scala
@@ -62,7 +62,7 @@ class HourlyRollingWriter(
   }
 
   private def rollOverWriter(): Unit = {
-    if (prevWriter != null) prevWriter.close
+    if (prevWriter != null) prevWriter.close()
     prevWriter = currWriter
     currWriter = createWriter(System.currentTimeMillis())
   }
@@ -78,11 +78,15 @@ class HourlyRollingWriter(
       registry,
       workerId
     )
-    writer.initialize
+    writer.initialize()
     writer
   }
 
-  def write(dp: Datapoint): Unit = {
+  def write(dps: List[Datapoint]): Unit = {
+    dps.foreach(writeDp)
+  }
+
+  private def writeDp(dp: Datapoint): Unit = {
     val now = System.currentTimeMillis()
     checkHourRollover(now)
     checkPrevHourExpiration(now)
@@ -109,19 +113,19 @@ class HourlyRollingWriter(
     }
   }
 
-  private def checkHourRollover(now: Long) = {
+  private def checkHourRollover(now: Long): Unit = {
     if (now >= currWriter.endTime) {
       rollOverWriter()
     }
   }
 
   // Note: late arrival is only checked cross hour, not rolling time
-  private def checkPrevHourExpiration(now: Long) = {
+  private def checkPrevHourExpiration(now: Long): Unit = {
     if (prevWriter != null && (now > currWriter.startTime + rollingConf.maxLateDurationMs)) {
       logger.debug(
         s"stop writer for previous hour after maxLateDuration of ${rollingConf.maxLateDurationMs} ms"
       )
-      prevWriter.close
+      prevWriter.close()
       prevWriter = null
     }
   }
@@ -137,7 +141,7 @@ class HourlyRollingWriter(
 }
 
 object HourlyRollingWriter {
-  val HourFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH'00'")
+  val HourFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH'00'")
   val HourStringLen: Int = 15
 }
 

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
@@ -38,6 +38,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 import scala.concurrent.Await
+import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 
@@ -51,8 +52,8 @@ class LocalFilePersistService @Inject()(
   implicit val system: ActorSystem
 ) extends AbstractService
     with StrictLogging {
-  implicit val ec = scala.concurrent.ExecutionContext.global
-  implicit val mat = ActorMaterializer()
+  implicit val ec: ExecutionContextExecutor = scala.concurrent.ExecutionContext.global
+  implicit val mat: ActorMaterializer = ActorMaterializer()
 
   private val queueSize = config.getInt("atlas.persistence.queue-size")
   private val writeWorkerSize = config.getInt("atlas.persistence.write-worker-size")
@@ -68,21 +69,21 @@ class LocalFilePersistService @Inject()(
     fileConfig.getInt("avro-syncInterval")
   )
 
-  private var queue: SourceQueue[Datapoint] = _
+  private var queue: SourceQueue[List[Datapoint]] = _
   private var flowComplete: Future[Done] = _
 
   override def startImpl(): Unit = {
     logger.info("Starting service")
     val (q, f) = StreamOps
-      .blockingQueue[Datapoint](registry, "LocalFilePersistService", queueSize)
-      .via(balancer(getRollingFileFlow(_), writeWorkerSize))
+      .blockingQueue[List[Datapoint]](registry, "LocalFilePersistService", queueSize)
+      .via(balancer(getRollingFileFlow, writeWorkerSize))
       .toMat(Sink.ignore)(Keep.both)
       .run
     queue = q
     flowComplete = f
   }
 
-  private def getRollingFileFlow(workerId: Int): Flow[Datapoint, NotUsed, NotUsed] = {
+  private def getRollingFileFlow(workerId: Int): Flow[List[Datapoint], NotUsed, NotUsed] = {
     import scala.concurrent.duration._
     RestartFlow.withBackoff(
       minBackoff = 1.second,
@@ -108,7 +109,7 @@ class LocalFilePersistService @Inject()(
       Flow.fromGraph(GraphDSL.create() { implicit b =>
         val balancer = b.add(Balance[In](workerCount))
         val merge = b.add(Merge[Out](workerCount))
-        for (i <- 0 to workerCount - 1) {
+        for (i <- 0 until workerCount) {
           balancer ~> workerFlowFactory(i).async ~> merge
         }
         FlowShape(balancer.in, merge.out)
@@ -127,7 +128,7 @@ class LocalFilePersistService @Inject()(
     logger.info("Stopped service")
   }
 
-  def persist(dp: Datapoint): Unit = {
+  def persist(dp: List[Datapoint]): Unit = {
     queue.offer(dp)
   }
 }

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
@@ -108,7 +108,7 @@ class LocalFilePersistService @Inject()(
       Flow.fromGraph(GraphDSL.create() { implicit b =>
         val balancer = b.add(Balance[In](workerCount))
         val merge = b.add(Merge[Out](workerCount))
-        for (i <- 0 until workerCount) {
+        for (i <- 0 to workerCount - 1) {
           balancer ~> workerFlowFactory(i).async ~> merge
         }
         FlowShape(balancer.in, merge.out)

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
@@ -102,7 +102,7 @@ class LocalFilePersistService @Inject()(
     workerCount: Int
   ): Flow[In, Out, NotUsed] = {
     if (workerCount == 1) {
-      // Don't add overhead of balancer and sync boundary for single worker
+      // Don't add overhead of balancer and async boundary for single worker
       workerFlowFactory(0)
     } else {
       import akka.stream.scaladsl.GraphDSL.Implicits._

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopyService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopyService.scala
@@ -26,7 +26,6 @@ import akka.stream.KillSwitch
 import akka.stream.KillSwitches
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Source
-import com.netflix.atlas.core.util.Streams
 import com.netflix.iep.service.AbstractService
 import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
@@ -35,6 +34,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 import scala.concurrent.duration._
+import scala.util.Using
 
 @Singleton
 class S3CopyService @Inject()(
@@ -92,7 +92,7 @@ class S3CopyService @Inject()(
 
   private def hasMoreFiles: Boolean = {
     try {
-      Streams.scope(Files.list(Paths.get(dataDir))) { dir =>
+      Using.resource(Files.list(Paths.get(dataDir))) { dir =>
         dir.anyMatch(f => Files.isRegularFile(f))
       }
     } catch {

--- a/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/RollingFileWriterSuite.scala
+++ b/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/RollingFileWriterSuite.scala
@@ -56,7 +56,7 @@ class RollingFileWriterSuite extends AnyFunSuite with BeforeAndAfter with Before
   //testWriterWithCodec("zstandard")  // Seems similar to snappy
 
   // Write 3 datapoints, first 2 is written in file 1, rollover, and 3rd one is written in file 2
-  private def testWriterWithCodec(codec: String) {
+  private def testWriterWithCodec(codec: String): Unit = {
     test(s"avro writer rollover by max records - codec=$codec") {
       val rollingConf = RollingConfig(2, 12000, 12000, codec, 9, 64000)
       val hourStart = 3600000

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -6,7 +6,6 @@ object BuildSettings {
   val compilerFlags = Seq(
     "-deprecation",
     "-unchecked",
-    "-Xexperimental",
     "-Xlint:_,-infer-any",
     "-feature",
     "-target:jvm-1.8")


### PR DESCRIPTION
Currently data points from request is being add to queue one by one, this creates high sync contention for underlying BlockingQueue when data points per second reaches over 100K/s. With this change, only one data point list per request is passing through the queue, so it reduces sync contention significantly.
Also fixes some Scala warnings.