### PR TITLE
atlas-persistence: reject requests after queue closed

### DIFF
--- a/atlas-persistence/src/main/resources/application.conf
+++ b/atlas-persistence/src/main/resources/application.conf
@@ -8,7 +8,7 @@ atlas {
   }
 
   persistence {
-    queue-size = 100000
+    queue-size = 2000
     // Number of parallel file writing workers
     write-worker-size = 1
     local-file {

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
@@ -83,7 +83,7 @@ class LocalFilePersistService @Inject()(
     flowComplete = f
   }
 
-  override def isHealthy: Boolean =  {
+  override def isHealthy: Boolean = {
     super.isHealthy && queue != null && !queue.isDone
   }
 

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
@@ -83,6 +83,10 @@ class LocalFilePersistService @Inject()(
     flowComplete = f
   }
 
+  override def isHealthy: Boolean =  {
+    super.isHealthy && queue != null && !queue.isDone
+  }
+
   private def getRollingFileFlow(workerId: Int): Flow[List[Datapoint], NotUsed, NotUsed] = {
     import scala.concurrent.duration._
     RestartFlow.withBackoff(

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/PersistenceApi.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/PersistenceApi.scala
@@ -44,8 +44,12 @@ class PersistenceApi(localFileService: LocalFilePersistService) extends WebApi {
     parseEntity(customJson(p => PublishApi.decodeBatch(p))) {
       case Nil => complete(DiagnosticMessage.error(StatusCodes.BadRequest, "empty payload"))
       case dps: List[Datapoint] =>
-        localFileService.persist(dps)
-        complete(HttpResponse(StatusCodes.OK))
+        if (localFileService.isHealthy) {
+          localFileService.persist(dps)
+          complete(HttpResponse(StatusCodes.OK))
+        } else {
+          complete(DiagnosticMessage.error(StatusCodes.ServiceUnavailable, "service unhealthy"))
+        }
     }
   }
 }


### PR DESCRIPTION
During server or app shutdown, taking requests after queue closed causes data loss. Adding a check at Web API to reject requests after queue closed should fix this issue.