### PR TITLE
persistence: bucket files by start time to make range search easier

### DIFF
--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/FileUtil.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/FileUtil.scala
@@ -47,7 +47,10 @@ object FileUtil extends StrictLogging {
   }
 
   def isTmpFile(f: File): Boolean = {
-    f.getName.endsWith(RollingFileWriter.TmpFileSuffix)
+    isTmpFile(f.getName)
   }
 
+  def isTmpFile(s: String): Boolean = {
+    s.endsWith(RollingFileWriter.TmpFileSuffix)
+  }
 }

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopySink.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopySink.scala
@@ -187,12 +187,13 @@ class S3CopySink(
         logger.info(s"copyToS3 done: file=$file, key=$s3Key")
       }
 
-      // Example file name: 2020-05-10T0300.i-localhost.1.XkvU3A
+      // Example file name: 2020-05-10T0300.i-localhost.1.XkvU3A.1200-1320
       private def buildS3Key(fileName: String): String = {
         val hour = fileName.substring(0, HourlyRollingWriter.HourStringLen)
         val s3FileName = fileName.substring(HourlyRollingWriter.HourStringLen + 1)
         val hourPath = hash(s"$prefix/$hour")
-        s"$hourPath/$s3FileName"
+        val startMinute = S3CopySink.extractMinuteRange(fileName)
+        s"$hourPath/$startMinute/$s3FileName"
       }
 
       private def hash(path: String): String = {
@@ -203,6 +204,22 @@ class S3CopySink(
         val randomPrefix = hexBytes.take(3)
         s"$randomPrefix/$path"
       }
+    }
+  }
+}
+
+object S3CopySink {
+
+  // Extract start-end minute from file name: "xyz.1200-1320" => "20-21"
+  // Use the special range "61-61" for tmp files.
+  def extractMinuteRange(fileName: String): String = {
+    if (FileUtil.isTmpFile(fileName)) {
+      "61-61"
+    } else {
+      val len = fileName.length
+      val startMinute = fileName.substring(len - 9, len - 5).toInt / 60
+      val endMinute = fileName.substring(len - 4).toInt / 60
+      "%02d".format(startMinute) + "-" + "%02d".format(endMinute)
     }
   }
 }

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopySink.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopySink.scala
@@ -210,8 +210,11 @@ class S3CopySink(
 
 object S3CopySink {
 
-  // Extract start-end minute from file name: "xyz.1200-1320" => "20-21"
-  // Use the special range "61-61" for tmp files.
+  /**
+    * Extract start and end minute from file name's suffix, which is start and end seconds of hour.
+    * For example a file name "xyz.1200-1320" would be extracted as "20-22".
+    * Use the special range "61-61" for tmp files because they don't have time range suffix.
+    */
   def extractMinuteRange(fileName: String): String = {
     if (FileUtil.isTmpFile(fileName)) {
       "61-61"

--- a/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/S3CopySinkSuite.scala
+++ b/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/S3CopySinkSuite.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014-2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.persistence
+
+import org.scalatest.BeforeAndAfter
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+
+class S3CopySinkSuite extends AnyFunSuite with BeforeAndAfter with BeforeAndAfterAll {
+  test("extractMinuteRange") {
+    assert(S3CopySink.extractMinuteRange("abc.tmp") === "61-61")
+    assert(S3CopySink.extractMinuteRange("abc.1200-1300") === "20-21")
+    assert(S3CopySink.extractMinuteRange("abc.0000-0123") === "00-02")
+  }
+}


### PR DESCRIPTION
Put files with the same start/end minute into a sub folder in s3. 
This makes file matching by range easier for downstream data processing pipeline. In theory it can create up to 1830(60+59+...+1) folders for an hour, but in reality I'd expect actual number to be much smaller because data points are mostly in order and range for a file is small, e.g. assume max range per file is 3 min, max num of folders <= 3*60.