### PR TITLE
druid: Add filter clause for non-zero metric value

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -462,17 +462,12 @@ object DruidDatabaseActor {
           val metricValueFilter = Query.Not(Query.Equal(name, "0"))
           val finalQueryWithFilter = finalQuery.and(metricValueFilter)
 
-          // Filter out datapoints that are zero on the server side to reduce the payload
-          // sizes and improve query performance.
-          val havingSpec = HavingSpec("value", 0.0)
-
           val groupByQuery = GroupByQuery(
             dataSource = datasource,
             dimensions = dimensions,
             intervals = intervals,
             aggregations = List(toAggregation(name, expr)),
             filter = DruidFilter.forQuery(finalQueryWithFilter),
-            having = Some(havingSpec),
             granularity = Granularity.millis(context.step)
           )
           val druidQuery =


### PR DESCRIPTION
Adding a filter on the metric value itself has a huge effect on query performance when there are sparce metrics.
Sparse metrics: Where a row has only 1 metric value defined, the others are null (or 0)
Sparse metrics combined with dimensions used across metrics, such as percentile, mean that we aggregate a lot of zeros, as well as grouping-by dimension values that may not be present in the final resultset.
Omitting these rows early with a filter significantly helps query performance in these situations.