### PR TITLE
druid: Skip query if there are no datasources

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -176,7 +176,7 @@ class DruidDatabaseActor(config: Config) extends Actor with StrictLogging {
         //
         // The limit for number of returned values cannot be applied to the query sent to Druid
         // because it could truncate the results for multi-value dimensions.
-        if (!datasources.isEmpty) {
+        if (datasources.nonEmpty) {
           val searchQuery = SearchQuery(
             dataSources = datasources.map { ds =>
               ds.name


### PR DESCRIPTION
If no datasources match, then don't submit the query. Instead respond with none immediately.
This was my miss on an earlier PR - sorry 😬