### PR TITLE
include tags in validation responses

### DIFF
--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
@@ -189,7 +189,7 @@ class UpdateApiSuite extends AnyFunSuite {
     val tags = SmallHashMap("foo" -> "bar")
     val msg = validationTest(tags, StatusCodes.BadRequest)
     assert(msg.errorCount === 1)
-    assert(msg.message === List("missing 'name': Set(foo)"))
+    assert(msg.message === List("missing 'name': Set(foo) (tags={\"foo\":\"bar\"})"))
   }
 
   test("validation: too many user tags") {
@@ -198,7 +198,7 @@ class UpdateApiSuite extends AnyFunSuite {
         .map(v => v -> v)
     val msg = validationTest(SmallHashMap(tags), StatusCodes.BadRequest)
     assert(msg.errorCount === 1)
-    assert(msg.message === List("too many user tags: 21 > 20"))
+    assert(msg.message.head.startsWith("too many user tags: 21 > 20 (tags={"))
   }
 
   test("validation: user tags, ignore restricted") {
@@ -213,7 +213,11 @@ class UpdateApiSuite extends AnyFunSuite {
     val tags = SmallHashMap("name" -> "test", "nf.foo" -> "bar")
     val msg = validationTest(tags, StatusCodes.BadRequest)
     assert(msg.errorCount === 1)
-    assert(msg.message === List("invalid key for reserved prefix 'nf.': nf.foo"))
+    assert(
+      msg.message === List(
+          "invalid key for reserved prefix 'nf.': nf.foo (tags={\"nf.foo\":\"bar\"})"
+        )
+    )
   }
 
   test("validation: partial failure") {
@@ -223,7 +227,11 @@ class UpdateApiSuite extends AnyFunSuite {
     )
     val msg = validationTest(ts, StatusCodes.Accepted)
     assert(msg.errorCount === 1)
-    assert(msg.message === List("invalid key for reserved prefix 'nf.': nf.foo"))
+    assert(
+      msg.message === List(
+          "invalid key for reserved prefix 'nf.': nf.foo (tags={\"nf.foo\":\"bar\"})"
+        )
+    )
   }
 
   test("validation: truncate if there are too many errors") {

--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/LwcPublishActor.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/LwcPublishActor.scala
@@ -131,7 +131,7 @@ class LwcPublishActor(config: Config, registry: Registry, evaluator: Expressions
   private def updateStats(failures: List[ValidationResult]): Unit = {
     failures.foreach {
       case ValidationResult.Pass => // Ignored
-      case ValidationResult.Fail(error, _) =>
+      case ValidationResult.Fail(error, _, _) =>
         registry.counter(numInvalidId.withTag("error", error)).increment()
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   object Versions {
     val akka       = "2.5.31"
     val akkaHttpV  = "10.1.11"
-    val atlas      = "1.7.0-SNAPSHOT"
+    val atlas      = "1.7.0-rc.10"
     val aws        = "1.11.847"
     val aws2       = "2.14.4"
     val iep        = "2.6.0"


### PR DESCRIPTION
For more information see Netflix/atlas#1203. It might be
possible to reduce some of the duplication with PublishApi,
but need to ensure it doesn't cause problems and that can
be done at a later time if needed. Currently aggregator
does some of the validation as parsing to reduce the overhead.