### PR TITLE
persistence: add IPC metrics for AWS calls

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,8 @@ lazy val `atlas-persistence` = project
       Dependencies.log4jApi,
       Dependencies.log4jCore,
       Dependencies.log4jSlf4j,
-      Dependencies.snappy
+      Dependencies.snappy,
+      Dependencies.spectatorAws2
   ))
 
 lazy val `atlas-slotting` = project


### PR DESCRIPTION
Include spectator extension for AWS2 client so we get IPC
metrics.