### PR TITLE
druid: Remove unneeded regex query when searching

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -263,7 +263,6 @@ object DruidClient {
     limit: Int = 1000
   ) {
     val queryType: String = "search"
-    val query: DruidQuery.type = DruidQuery
     // Use a union of the datasource(s) to send 1 query to Druid
     // The Druid broker will handle sending the query to each datasource
     // and merge the results before responding.
@@ -273,11 +272,6 @@ object DruidClient {
 
   case class UnionDatasource(dataSources: List[String]) {
     val `type`: String = "union"
-  }
-
-  case object DruidQuery {
-    val `type`: String = "regex"
-    val pattern: String = ".*"
   }
 
   case class SearchResult(


### PR DESCRIPTION
The addition of the regex query adds ~25% to the query time and is not needed to perform the query that we're trying to do (get all possible tag values)