### PR TITLE
druid: Avoid using javascript filter

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidFilter.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidFilter.scala
@@ -44,7 +44,7 @@ object DruidFilter {
       case Query.LessThanEqual(k, v)    => js(k, "<=", v)
       case Query.HasKey(k)              => Not(Equal(k, "")) // druid: empty string is same as null
       case Query.Regex(k, v)            => Regex(k, s"^$v")
-      case Query.RegexIgnoreCase(k, v)  => reic(k, v)
+      case Query.RegexIgnoreCase(k, v)  => Regex(k, s"(?i)^$v")
       case Query.And(q1, q2)            => And(List(toFilter(q1), toFilter(q2)))
       case Query.Or(q1, q2)             => Or(List(toFilter(q1), toFilter(q2)))
       case Query.Not(q)                 => Not(toFilter(q))
@@ -68,10 +68,6 @@ object DruidFilter {
   private def js(k: String, op: String, v: String): JavaScript = {
     val sanitizedV = sanitize(v)
     JavaScript(k, s"function(x) { return x $op '$sanitizedV'; }")
-  }
-
-  private def reic(k: String, p: String): JavaScript = {
-    JavaScript(k, s"""function(x) { var re = /^$p/i; return re.test(x); }""")
   }
 
   case class Equal(dimension: String, value: String) extends DruidFilter {

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidFilterSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidFilterSuite.scala
@@ -89,7 +89,7 @@ class DruidFilterSuite extends AnyFunSuite {
     DruidFilter.forQuery(eval("country,US,:reic"))
     val actual = DruidFilter.forQuery(eval("country,US,:reic"))
     val expected =
-      Some(DruidFilter.JavaScript("country", "function(x) { var re = /^US/i; return re.test(x); }"))
+      Some(DruidFilter.Regex("country", "(?i)^US"))
     assert(actual === expected)
   }
 


### PR DESCRIPTION
Use regex filter with lowercase extraction function and lowercase the regex query. Extraction functions are applied to the value prior to applying the filter, but the matched value is returned unchanged.