### PR TITLE
druid: Filter null metrics

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -464,7 +464,7 @@ object DruidDatabaseActor {
 
           // Add to the filter to remove rows that don't include the metric we're aggregating.
           // This reduces what needs to be merged and passed back to the broker, improving query performance.
-          val metricValueFilter = Query.Not(Query.Equal(name, "0"))
+          val metricValueFilter = Query.Not(Query.Equal(name, "0")).and(Query.HasKey(name))
           val finalQueryWithFilter = finalQuery.and(metricValueFilter)
 
           val groupByQuery = GroupByQuery(


### PR DESCRIPTION
When we introduce new metric names, the value of that metric in older segments is null. When doing a group-by query, these segments without the metric will still perform aggregations. Filtering out nulls means the historical nodes can quickly remove rows that won't contribute