### PR TITLE
include exprs in cloudwatch request failure log

### DIFF
--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
@@ -375,7 +375,9 @@ object ForwardingService extends StrictLogging {
             }
             .recover {
               case t: Throwable =>
-                logger.warn(s"cloudwatch request failed (region=$region, account=$account)", t)
+                val exprs = Json.encode(data.map(_.id))
+                val context = s"(region=$region, account=$account, exprs=$exprs)"
+                logger.warn(s"cloudwatch request failed $context", t)
                 data.map(_.copy(error = Some(t)))
             }
             .mapConcat(identity)


### PR DESCRIPTION
Helps for debugging which expressions were impacted and in
some cases tracking back to a bad expression that is causing
failures.