### PR TITLE
aggr: only use max size for string cache

### DIFF
--- a/atlas-aggregator/src/main/resources/application.conf
+++ b/atlas-aggregator/src/main/resources/application.conf
@@ -12,7 +12,6 @@ atlas.aggregator {
   cache {
     strings {
       max-size = 2000000
-      expires-after = 5m
     }
   }
 

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PayloadDecoder.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PayloadDecoder.scala
@@ -214,7 +214,6 @@ object PayloadDecoder {
   private val stringCache = Caffeine
     .newBuilder()
     .maximumSize(config.getInt("cache.strings.max-size"))
-    .expireAfterAccess(config.getDuration("cache.strings.expires-after"))
     .build[String, String]()
 
   /**


### PR DESCRIPTION
Remove the time check for the string cache. Some testing
shows that the `expireAfterAccess` significantly reduces
the throughput and adds little value for this use-case.