### PR TITLE
archaius: add explicit config binding

### DIFF
--- a/iep-archaius/src/main/scala/com/netflix/iep/archaius/Main.scala
+++ b/iep-archaius/src/main/scala/com/netflix/iep/archaius/Main.scala
@@ -16,57 +16,24 @@
 package com.netflix.iep.archaius
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.google.inject.AbstractModule
-import com.google.inject.Module
 import com.google.inject.Provides
 import com.google.inject.multibindings.Multibinder
 import com.netflix.iep.aws.AwsClientFactory
+import com.netflix.iep.config.ConfigManager
 import com.netflix.iep.guice.BaseModule
-import com.netflix.iep.guice.GuiceHelper
 import com.netflix.iep.service.Service
-import com.netflix.iep.service.ServiceManager
-import com.netflix.spectator.api.NoopRegistry
-import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
-import org.slf4j.LoggerFactory
 
 object Main {
 
-  private val logger = LoggerFactory.getLogger(getClass)
-
-  private def getBaseModules: java.util.List[Module] = {
-    val modules = GuiceHelper.getModulesUsingServiceLoader
-    if (!sys.env.contains("NETFLIX_ENVIRONMENT")) {
-      // If we are running in a local environment provide simple versions of registry
-      // and config bindings. These bindings are normally provided by the final package
-      // config for the app in the production setup.
-      modules.add(new AbstractModule {
-        override def configure(): Unit = {
-          bind(classOf[Registry]).toInstance(new NoopRegistry)
-          bind(classOf[Config]).toInstance(ConfigFactory.load())
-        }
-      })
-    }
-    modules
-  }
-
   def main(args: Array[String]): Unit = {
-    try {
-      val modules = getBaseModules
-      modules.add(new ServerModule)
-      val guice = new GuiceHelper
-      guice.start(modules)
-      guice.getInjector.getInstance(classOf[ServiceManager])
-      guice.addShutdownHook()
-    } catch {
-      // Send exceptions to main log file instead of wherever STDERR is sent for the process
-      case t: Throwable => logger.error("fatal error on startup", t)
-    }
+    com.netflix.iep.guice.Main.run(args, new ServerModule)
   }
 
   class ServerModule extends BaseModule {
     override def configure(): Unit = {
+      bind(classOf[Config]).toInstance(ConfigManager.get())
+
       val serviceBinder = Multibinder.newSetBinder(binder(), classOf[Service])
       serviceBinder.addBinding().toConstructor(getConstructor(classOf[DynamoService]))
       bind(classOf[DynamoService])


### PR DESCRIPTION
Simplify main and add an explicit config binding. Since
this is the dynamic properties source, it uses static
settings and that doesn't vary for internal deployments.