### PR TITLE
lwc bridge: add metric for payload size

### DIFF
--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExprUpdateServiceSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExprUpdateServiceSuite.scala
@@ -40,7 +40,7 @@ class ExprUpdateServiceSuite extends AnyFunSuite with BeforeAndAfter {
   private val registry = new DefaultRegistry(clock)
   private val evaluator = new ExpressionsEvaluator(config)
 
-  private val service = new ExprUpdateService(config, registry, evaluator)
+  private val service = new ExprUpdateService(config, registry, evaluator, system)
 
   private def update(response: HttpResponse): Unit = {
     val future = Source


### PR DESCRIPTION
Adds a metric to track the raw payload size for the set
of expressions to sync from lwcapi. Also converts the
number of expressions metric to a matching distribution
summary.

Minor cleanup: 1) inject actor system, and 2) avoid
creating a copy of the response as a byte array to parse
the data.