### PR TITLE
aggr: configurable rollup policy

### DIFF
--- a/atlas-aggregator/src/main/resources/application.conf
+++ b/atlas-aggregator/src/main/resources/application.conf
@@ -15,6 +15,13 @@ atlas.aggregator {
     }
   }
 
+  rollup-policy = [
+    {
+      query = "percentile,:has"
+      rollup = ["nf.node", "nf.task"]
+    }
+  ]
+
   // Determines whether or not to include the aggregator node as a tag on counters.
   // If false it will use atlas.dstype=sum instead.
   include-aggr-tag = false


### PR DESCRIPTION
Adds support for a configurable rollup policy on the
aggregator. The format is the same as the rollup policies
that can be used with the AtlasRegistry.