### PR TITLE
rename stream POST endpoint

### DIFF
--- a/atlas-stream/src/main/scala/com/netflix/atlas/stream/StreamApi.scala
+++ b/atlas-stream/src/main/scala/com/netflix/atlas/stream/StreamApi.scala
@@ -88,7 +88,7 @@ class StreamApi(
         }
       }
     } ~
-    endpointPath("stream") {
+    endpointPath("sse") {
       post {
         parseEntity(json[List[DataSource]]) { dsList =>
           val dsListWithDefaultStep = dsList.map { ds =>


### PR DESCRIPTION
Rename from `/stream` to `/sse`. The websocket usage for
`/stream` prevents the POST from being used. Since the
SSE output is useful for testing with curl, rename to make
it accessible.