### PR TITLE
stream: use flow rather than processor

### DIFF
--- a/atlas-stream/src/main/scala/com/netflix/atlas/stream/StreamApi.scala
+++ b/atlas-stream/src/main/scala/com/netflix/atlas/stream/StreamApi.scala
@@ -159,11 +159,10 @@ class StreamApi(
       .repeat(heartbeat)
       .throttle(1, 5.seconds, 1, ThrottleMode.Shaping)
 
-    //repeat and throttle to keep the source alive, actual rate of stream is decided by step
+    // Use tick to keep the source alive, actual rate of stream is decided by step
     val src = Source
-      .repeat(dataSources)
-      .throttle(1, 5.seconds, 1, ThrottleMode.Shaping)
-      .via(Flow.fromProcessor(() => evaluator.createStreamsProcessor))
+      .tick(0.seconds, 1.minute, dataSources)
+      .via(evaluator.createStreamsFlow)
       .map { messageEnvelope =>
         prefix ++ ByteString(Json.encode[MessageEnvelope](messageEnvelope)) ++ suffix
       }


### PR DESCRIPTION
Avoid conversion to generic processor as it isn't needed
here and adds overhead. Also change to using tick rather
than repeat and throttle.