### PR TITLE
lwc-bridge: more efficient expression removal

### DIFF
--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExprUpdateService.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExprUpdateService.scala
@@ -15,7 +15,6 @@
  */
 package com.netflix.iep.lwc
 
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import akka.NotUsed
 import akka.actor.ActorSystem

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/BridgeApiSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/BridgeApiSuite.scala
@@ -31,7 +31,7 @@ class BridgeApiSuite extends AnyFunSuite with ScalatestRouteTest with BeforeAndA
   private implicit val routeTestTimeout = RouteTestTimeout(5.second)
 
   private val config = ConfigFactory.load()
-  private val evaluator = new ExpressionsEvaluator(config)
+  private val evaluator = new ExpressionsEvaluator(config, new NoopRegistry)
   private val endpoint = new BridgeApi(config, new NoopRegistry, evaluator, system)
   private val routes = RequestHandler.standardOptions(endpoint.routes)
 

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExprUpdateServiceSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExprUpdateServiceSuite.scala
@@ -38,7 +38,7 @@ class ExprUpdateServiceSuite extends AnyFunSuite with BeforeAndAfter {
   private val config = ConfigFactory.load()
   private val clock = new ManualClock()
   private val registry = new DefaultRegistry(clock)
-  private val evaluator = new ExpressionsEvaluator(config)
+  private val evaluator = new ExpressionsEvaluator(config, registry)
 
   private val service = new ExprUpdateService(config, registry, evaluator, system)
 

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/StatsApiSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/StatsApiSuite.scala
@@ -22,8 +22,8 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.netflix.atlas.akka.RequestHandler
-import com.netflix.atlas.core.model.Datapoint
 import com.netflix.atlas.json.Json
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.atlas.impl.Subscription
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfter
@@ -37,7 +37,7 @@ class StatsApiSuite extends AnyFunSuite with ScalatestRouteTest with BeforeAndAf
   private implicit val routeTestTimeout = RouteTestTimeout(5.second)
 
   private val config = ConfigFactory.load()
-  private val evaluator = new ExpressionsEvaluator(config)
+  private val evaluator = new ExpressionsEvaluator(config, new NoopRegistry)
   private val endpoint = new StatsApi(evaluator)
   private val routes = RequestHandler.standardOptions(endpoint.routes)
 


### PR DESCRIPTION
If there are a lot of expressions in the index, then
removals can be quite slow. For that case of removing
many expressions it will now just recreate the index
instead. Also adds counters to track the number of
expressions added and removed.