### PR TITLE
druid: add limit for data size

### DIFF
--- a/atlas-druid/src/main/resources/application.conf
+++ b/atlas-druid/src/main/resources/application.conf
@@ -6,6 +6,10 @@ atlas {
     //uri = "http://localhost:7103/druid/v2"
 
     tags-interval = 6h
+
+    // Maximum size for intermediate data response. If it is exceeded, then the
+    // processing will be fail early.
+    max-data-size = 2g
   }
 
   akka {

--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -27,7 +27,6 @@ import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.TransferEncodings
 import akka.http.scaladsl.model.headers._
 import akka.stream.Materializer
 import akka.stream.scaladsl.Flow
@@ -41,7 +40,6 @@ import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 
 import java.io.InputStream
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip.GZIPInputStream
 import scala.util.Failure
 import scala.util.Success


### PR DESCRIPTION
Add simple check on intermediate data size to avoid
GC issues on some responses that have a really high
cardinality.