### PR TITLE
add cloudwatch poller app

### DIFF
--- a/atlas-cloudwatch/src/main/resources/META-INF/services/com.google.inject.Module
+++ b/atlas-cloudwatch/src/main/resources/META-INF/services/com.google.inject.Module
@@ -1,0 +1,1 @@
+com.netflix.atlas.guice.CloudWatchModule

--- a/atlas-cloudwatch/src/main/resources/alb.conf
+++ b/atlas-cloudwatch/src/main/resources/alb.conf
@@ -1,0 +1,247 @@
+
+atlas {
+  cloudwatch {
+
+    // Metrics for the overall load balancer
+    // http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html
+    alb = {
+      namespace = "AWS/ApplicationELB"
+      period = 1m
+      end-period-offset = 2
+
+      dimensions = [
+        "LoadBalancer"
+      ]
+
+      metrics = [
+        {
+          name = "ProcessedBytes"
+          alias = "aws.alb.processedBytes"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ActiveConnectionCount"
+          alias = "aws.alb.activeConnectionCount"
+          conversion = "sum"
+        },
+        {
+          name = "ELBAuthError"
+          alias = "aws.alb.authRequest"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "result"
+              value = "error"
+            }
+          ]
+        },
+        {
+          name = "ELBAuthFailure"
+          alias = "aws.alb.authRequest"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "result"
+              value = "failure"
+            }
+          ]
+        },
+        {
+          name = "ELBAuthSuccess"
+          alias = "aws.alb.authRequest"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "result"
+              value = "success"
+            }
+          ]
+        },
+        {
+          name = "ELBAuthLatency"
+          alias = "aws.alb.authLatency"
+          conversion = "timer"
+        },
+        {
+          name = "NewConnectionCount"
+          alias = "aws.alb.newConnections"
+          conversion = "sum,rate"
+        },
+        {
+          name = "RejectedConnectionCount"
+          alias = "aws.alb.rejectedConnections"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ConsumedLCUs"
+          alias = "aws.alb.consumedLCUs"
+          conversion = "sum"
+        }
+      ]
+    }
+
+    // Metrics for the overall load balancer by zone
+    // http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html
+    alb-zone = {
+      namespace = "AWS/ApplicationELB"
+      period = 1m
+      end-period-offset = 2
+
+      dimensions = [
+        "LoadBalancer",
+        "AvailabilityZone"
+      ]
+
+      metrics = [
+        {
+          name = "HTTPCode_ELB_4XX_Count"
+          alias = "aws.alb.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "4xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_ELB_5XX_Count"
+          alias = "aws.alb.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "5xx"
+            }
+          ]
+        },
+        {
+          name = "ClientTLSNegotiationErrorCount"
+          alias = "aws.alb.clientErrors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "error"
+              value = "TLSNegotiation"
+            }
+          ]
+        }
+      ]
+    }
+
+    // Metrics available by target group
+    // http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html
+    alb-tg-zone = {
+      namespace = "AWS/ApplicationELB"
+      period = 1m
+      end-period-offset = 2
+
+      dimensions = [
+        "LoadBalancer",
+        "TargetGroup",
+        "AvailabilityZone"
+      ]
+
+      metrics = [
+        {
+          name = "RequestCount"
+          alias = "aws.alb.requests"
+          conversion = "sum,rate"
+        },
+        {
+          name = "HTTPCode_Target_2XX_Count"
+          alias = "aws.alb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "2xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_Target_3XX_Count"
+          alias = "aws.alb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "3xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_Target_4XX_Count"
+          alias = "aws.alb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "4xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_Target_5XX_Count"
+          alias = "aws.alb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "5xx"
+            }
+          ]
+        },
+        {
+          name = "TargetConnectionErrorCount"
+          alias = "aws.alb.targetErrors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "error"
+              value = "Connection"
+            }
+          ]
+        },
+        {
+          name = "TargetTLSNegotiationErrorCount"
+          alias = "aws.alb.targetErrors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "error"
+              value = "TLSNegotiation"
+            }
+          ]
+        },
+        {
+          name = "HealthyHostCount"
+          alias = "aws.alb.hostCount"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "healthy"
+            }
+          ]
+        },
+        {
+          name = "UnHealthyHostCount"
+          alias = "aws.alb.hostCount"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "unhealthy"
+            }
+          ]
+        },
+        {
+          name = "TargetResponseTime"
+          alias = "aws.alb.targetLatency"
+          conversion = "timer"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/api-gateway.conf
+++ b/atlas-cloudwatch/src/main/resources/api-gateway.conf
@@ -1,0 +1,51 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-dashboard.html
+    api-gateway = {
+      namespace = "ApiGateway"
+      period = 1m
+
+      dimensions = [
+        "ApiName",
+        "Label"
+      ]
+
+      metrics = [
+        {
+          name = "Count"
+          alias = "aws.apigateway.requests"
+          conversion = "sum,rate"
+        },
+        {
+          name = "4XXError"
+          alias = "aws.apigateway.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "4xx"
+            }
+          ]
+        },
+        {
+          name = "5XXError"
+          alias = "aws.apigateway.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "5xx"
+            }
+          ]
+        },
+        {
+          name = "Latency"
+          alias = "aws.apigateway.latency"
+          conversion = "timer-millis"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/billing.conf
+++ b/atlas-cloudwatch/src/main/resources/billing.conf
@@ -1,0 +1,27 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/monitor_estimated_charges_with_cloudwatch.html
+    billing = {
+      namespace = "AWS/Billing"
+      period = 6h
+      end-period-offset = 1
+      period-count = 2
+
+      dimensions = [
+        "LinkedAccount",
+        "ServiceName",
+        "Currency"
+      ]
+
+      metrics = [
+        {
+          name = "EstimatedCharges"
+          alias = "aws.billing.estimatedMonthlyCharge"
+          conversion = "sum"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/dx.conf
+++ b/atlas-cloudwatch/src/main/resources/dx.conf
@@ -1,0 +1,170 @@
+
+atlas {
+  cloudwatch {
+
+    // https://docs.aws.amazon.com/directconnect/latest/UserGuide/monitoring-cloudwatch.html
+    dx-connection = {
+      namespace = "AWS/DX"
+      period = 1m
+      end-period-offset = 4
+      period-count = 6
+
+      dimensions = [
+        "ConnectionId"
+      ]
+
+      metrics = [
+        {
+          name = "ConnectionState"
+          alias = "aws.dx.connectionState"
+          conversion = "max"
+        },
+        {
+          name = "ConnectErrorCount"
+          alias = "aws.dx.connectErrorCount"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ConnectionBpsEgress"
+          alias = "aws.dx.connectionBytes"
+          conversion = "sum",
+          tags = [
+            {
+              key = "id"
+              value = "egress"
+            }
+          ]
+        },
+        {
+          name = "ConnectionBpsIngress"
+          alias = "aws.dx.connectionBytes"
+          conversion = "sum",
+          tags = [
+            {
+              key = "id"
+              value = "ingress"
+            }
+          ]
+        },
+        {
+          name = "ConnectionPpsEgress"
+          alias = "aws.dx.connectionPackets"
+          conversion = "sum",
+          tags = [
+            {
+              key = "id"
+              value = "egress"
+            }
+          ]
+        },
+        {
+          name = "ConnectionPpsIngress"
+          alias = "aws.dx.connectionPackets"
+          conversion = "sum",
+          tags = [
+            {
+              key = "id"
+              value = "ingress"
+            }
+          ]
+        },
+      ]
+    }
+
+    dx-connection-light-level = {
+      namespace = "AWS/DX"
+      period = 5m
+      end-period-offset = 1
+      period-count = 6
+
+      dimensions = [
+        "ConnectionId",
+        "OpticalLaneNumber"
+      ]
+
+      metrics = [
+        {
+          name = "ConnectionLightLevelTx"
+          alias = "aws.dx.connectionLightLevel"
+          conversion = "max",
+          tags = [
+            {
+              key = "id"
+              value = "egress"
+            }
+          ]
+        },
+        {
+          name = "ConnectionLightLevelRx"
+          alias = "aws.dx.connectionLightLevel"
+          conversion = "max",
+          tags = [
+            {
+              key = "id"
+              value = "ingress"
+            }
+          ]
+        }
+      ]
+    }
+
+    dx-virtual-interface = {
+      namespace = "AWS/DX"
+      period = 1m
+      end-period-offset = 4
+      period-count = 6
+
+      dimensions = [
+        "ConnectionId",
+        "VirtualInterfaceId"
+      ]
+
+      metrics = [
+        {
+          name = "VirtualInterfaceBpsEgress"
+          alias = "aws.dx.virtualInterfaceBytes"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "egress"
+            }
+          ]
+        },
+        {
+          name = "VirtualInterfaceBpsIngress"
+          alias = "aws.dx.virtualInterfaceBytes"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "ingress"
+            }
+          ]
+        },
+        {
+          name = "VirtualInterfacePpsEgress"
+          alias = "aws.dx.virtualInterfacePackets"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "egress"
+            }
+          ]
+        },
+        {
+          name = "VirtualInterfacePpsIngress"
+          alias = "aws.dx.virtualInterfacePackets"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "ingress"
+            }
+          ]
+        },
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/dynamodb.conf
+++ b/atlas-cloudwatch/src/main/resources/dynamodb.conf
@@ -1,0 +1,159 @@
+
+atlas {
+  cloudwatch {
+
+    // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/metrics-dimensions.html
+    dynamodb-table-1m = {
+      namespace = "AWS/DynamoDB"
+      period = 1m
+
+      dimensions = [
+        "TableName"
+      ]
+
+      metrics = [
+        {
+          name = "ConditionalCheckFailedRequests"
+          alias = "aws.dynamodb.conditionalCheckFailed"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ConsumedReadCapacityUnits"
+          alias = "aws.dynamodb.consumedCapacity"
+          conversion = "dist-summary"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "ConsumedWriteCapacityUnits"
+          alias = "aws.dynamodb.consumedCapacity"
+          conversion = "dist-summary"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "ReadThrottleEvents"
+          alias = "aws.dynamodb.throttleEvents"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteThrottleEvents"
+          alias = "aws.dynamodb.throttleEvents"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        }
+      ]
+    }
+
+    dynamodb-table-5m = {
+      namespace = "AWS/DynamoDB"
+      period = 5m
+      end-period-offset = 1
+      period-count = 4
+
+      dimensions = [
+        "TableName"
+      ]
+
+      metrics = [
+        {
+          name = "ProvisionedReadCapacityUnits"
+          alias = "aws.dynamodb.provisionedCapacity"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "ProvisionedWriteCapacityUnits"
+          alias = "aws.dynamodb.provisionedCapacity"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        }
+      ]
+    }
+
+    dynamodb-table-ops = {
+      namespace = "AWS/DynamoDB"
+      period = 1m
+
+      dimensions = [
+        "TableName",
+        "Operation"
+      ]
+
+      metrics = [
+        {
+          name = "SuccessfulRequestLatency"
+          alias = "aws.dynamodb.requestLatency"
+          conversion = "timer"
+        },
+        {
+          name = "ReturnedItemCount"
+          alias = "aws.dynamodb.returnedItems"
+          conversion = "dist-summary"
+        },
+        {
+          name = "SystemErrors"
+          alias = "aws.dynamodb.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "system"
+            }
+          ]
+        },
+        {
+          name = "ThrottledRequests"
+          alias = "aws.dynamodb.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "throttled"
+            }
+          ]
+        },
+        {
+          name = "UserErrors"
+          alias = "aws.dynamodb.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "user"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/ec2.conf
+++ b/atlas-cloudwatch/src/main/resources/ec2.conf
@@ -1,0 +1,267 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/ec2-metricscollected.html
+    ec2 = {
+      namespace = "AWS/EC2"
+      period = 5m
+      end-period-offset = 1
+      period-count = 4
+      timeout = 20m
+
+      dimensions = [
+        "AutoScalingGroupName"
+      ]
+
+      metrics = [
+        {
+          name = "CPUUtilization"
+          alias = "aws.ec2.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "NetworkIn"
+          alias = "aws.ec2.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "NetworkOut"
+          alias = "aws.ec2.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "NetworkPacketsIn"
+          alias = "aws.ec2.networkPackets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "NetworkPacketsOut"
+          alias = "aws.ec2.networkPackets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "DiskReadBytes"
+          alias = "aws.ec2.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "DiskWriteBytes"
+          alias = "aws.ec2.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "DiskReadOps"
+          alias = "aws.ec2.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "DiskWriteOps"
+          alias = "aws.ec2.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "StatusCheckFailed_Instance"
+          alias = "aws.ec2.badInstances"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "instance"
+            }
+          ]
+        },
+        {
+          name = "StatusCheckFailed_System"
+          alias = "aws.ec2.badInstances"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "system"
+            }
+          ]
+        },
+      ]
+    }
+
+    ec2-instance = ${atlas.cloudwatch.ec2} {
+      dimensions = [
+        "InstanceId"
+      ]
+    }
+
+    // Only needed for transition period
+    // http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/ec2-metricscollected.html
+    // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-transition-to-version-2
+    ec2-imdsv2 = {
+      namespace = "AWS/EC2"
+      period = 5m
+      end-period-offset = 1
+      period-count = 4
+      timeout = 20m
+
+      dimensions = [
+        "AutoScalingGroupName"
+      ]
+
+      metrics = [
+        {
+          name = "MetadataNoToken"
+          alias = "aws.ec2.metadataNoTokenRequests"
+          conversion = "sum,rate"
+        }
+      ]
+    }
+
+    // http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-instances.html#t2-instances-monitoring-cpu-credits
+    ec2-credit = {
+      namespace = "AWS/EC2"
+      period = 5m
+      end-period-offset = 1
+      period-count = 4
+      timeout = 20m
+
+      dimensions = [
+        "AutoScalingGroupName"
+      ]
+
+      metrics = [
+        {
+          name = "CPUCreditUsage"
+          alias = "aws.ec2.cpuCreditUsage"
+          conversion = "sum"
+        },
+        {
+          name = "CPUCreditBalance"
+          alias = "aws.ec2.cpuCreditBalance"
+          conversion = "sum"
+        },
+      ]
+    }
+
+    // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/monitor.html
+    ec2-api = {
+      namespace = "AWS/EC2/API"
+      period = 1m
+      end-period-offset = 1
+      period-count = 4
+      timeout = 20m
+
+      dimensions = [
+        "Action"
+      ]
+
+      metrics = [
+        {
+          name = "ClientErrors"
+          alias = "aws.ec2.apiCalls"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "result"
+              value = "failure"
+            },
+            {
+              key = "id"
+              value = "ClientErrors"
+            },
+          ]
+        },
+        {
+          name = "RequestLimitExceeded"
+          alias = "aws.ec2.apiCalls"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "result"
+              value = "failure"
+            },
+            {
+              key = "id"
+              value = "RequestLimitExceeded"
+            },
+          ]
+        },
+        {
+          name = "ServerErrors"
+          alias = "aws.ec2.apiCalls"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "result"
+              value = "failure"
+            },
+            {
+              key = "id"
+              value = "ServerErrors"
+            },
+          ]
+        },
+        {
+          name = "SuccessfulCalls"
+          alias = "aws.ec2.apiCalls"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "result"
+              value = "success"
+            },
+            {
+              key = "id"
+              value = "SuccessfulCalls"
+            },
+          ]
+        },
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/efs.conf
+++ b/atlas-cloudwatch/src/main/resources/efs.conf
@@ -1,0 +1,76 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/efs-metricscollected.html
+    efs = {
+      namespace = "AWS/EFS"
+      period = 1m
+
+      dimensions = [
+        "FileSystemId"
+      ]
+
+      metrics = [
+        {
+          name = "DataReadIOBytes"
+          alias = "aws.efs.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "DataWriteIOBytes"
+          alias = "aws.efs.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "MetadataIOBytes"
+          alias = "aws.efs.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "metadata"
+            }
+          ]
+        },
+        {
+          name = "PermittedThroughput"
+          alias = "aws.efs.permittedThroughput"
+          conversion = "max"
+          tags = []
+        },
+        {
+          name = "BurstCreditBalance"
+          alias = "aws.efs.burstCreditBalance"
+          conversion = "max"
+          tags = []
+        },
+        {
+          name = "PercentIOLimit"
+          alias = "aws.efs.percentIOLimit"
+          conversion = "max"
+          tags = []
+        },
+        {
+          name = "ClientConnections"
+          alias = "aws.efs.clientConnections"
+          conversion = "sum"
+          tags = []
+        },
+
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/elasticache.conf
+++ b/atlas-cloudwatch/src/main/resources/elasticache.conf
@@ -1,0 +1,535 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheMetrics.html
+    elasticache = {
+      namespace = "AWS/ElastiCache"
+      period = 1m
+
+      dimensions = [
+        "CacheClusterId",
+        "CacheNodeId"
+      ]
+
+      metrics = [
+        // http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheMetrics.HostLevel.html
+        {
+          name = "CPUUtilization"
+          alias = "aws.elasticache.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "FreeableMemory"
+          alias = "aws.elasticache.memoryFree"
+          conversion = "max"
+        },
+        {
+          name = "NetworkBytesIn"
+          alias = "aws.elasticache.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "NetworkBytesOut"
+          alias = "aws.elasticache.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "SwapUsage"
+          alias = "aws.elasticache.swapUsage"
+          conversion = "max"
+        },
+
+        // Both memcache and redis
+        {
+          name = "Evictions"
+          alias = "aws.elasticache.itemsRemoved"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "evicted"
+            }
+          ]
+        },
+        {
+          name = "Reclaimed"
+          alias = "aws.elasticache.itemsRemoved"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "reclaimed"
+            }
+          ]
+        },
+        {
+          name = "CurrConnections"
+          alias = "aws.elasticache.numConnections"
+          conversion = "max"
+        },
+        {
+          name = "CurrItems"
+          alias = "aws.elasticache.numItems"
+          conversion = "max"
+        },
+        {
+          name = "NewConnections"
+          alias = "aws.elasticache.connections"
+          conversion = "sum,rate"
+        },
+
+
+        // http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheMetrics.Memcached.html
+        {
+          name = "NewItems"
+          alias = "aws.elasticache.items"
+          conversion = "sum,rate"
+        },
+        {
+          name = "BytesUsedForCacheItems"
+          alias = "aws.elasticache.memoryUsed"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "cacheItems"
+            }
+          ]
+        },
+        {
+          name = "BytesUsedForHash"
+          alias = "aws.elasticache.memoryUsed"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "hashTables"
+            }
+          ]
+        },
+        {
+          name = "SlabsMoved"
+          alias = "aws.elasticache.slabsMoved"
+          conversion = "sum"
+        },
+        {
+          name = "DecrHits"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "decr"
+            },
+            {
+              key = "status"
+              value = "hit"
+            }
+          ]
+        },
+        {
+          name = "DecrMisses"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "decr"
+            },
+            {
+              key = "status"
+              value = "miss"
+            }
+          ]
+        },
+        {
+          name = "IncrHits"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "incr"
+            },
+            {
+              key = "status"
+              value = "hit"
+            }
+          ]
+        },
+        {
+          name = "IncrMisses"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "incr"
+            },
+            {
+              key = "status"
+              value = "miss"
+            }
+          ]
+        },
+        {
+          name = "DeleteHits"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "delete"
+            },
+            {
+              key = "status"
+              value = "hit"
+            }
+          ]
+        },
+        {
+          name = "DeleteMisses"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "delete"
+            },
+            {
+              key = "status"
+              value = "miss"
+            }
+          ]
+        },
+        {
+          name = "GetHits"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "get"
+            },
+            {
+              key = "status"
+              value = "hit"
+            }
+          ]
+        },
+        {
+          name = "GetMisses"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "get"
+            },
+            {
+              key = "status"
+              value = "miss"
+            }
+          ]
+        },
+        {
+          name = "TouchHits"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "touch"
+            },
+            {
+              key = "status"
+              value = "hit"
+            }
+          ]
+        },
+        {
+          name = "TouchMisses"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "touch"
+            },
+            {
+              key = "status"
+              value = "miss"
+            }
+          ]
+        },
+        {
+          name = "CasHits"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "cas"
+            },
+            {
+              key = "status"
+              value = "hit"
+            }
+          ]
+        },
+        {
+          name = "CasMisses"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "cas"
+            },
+            {
+              key = "status"
+              value = "miss"
+            }
+          ]
+        },
+        {
+          name = "CasBadval"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "cas"
+            },
+            {
+              key = "status"
+              value = "badval"
+            }
+          ]
+        },
+        {
+          name = "CmdGet"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "get"
+            }
+          ]
+        },
+        {
+          name = "CmdSet"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "set"
+            }
+          ]
+        },
+        {
+          name = "CmdFlush"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "flush"
+            }
+          ]
+        },
+        {
+          name = "CmdConfigGet"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "configGet"
+            }
+          ]
+        },
+        {
+          name = "CmdConfigSet"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "configSet"
+            }
+          ]
+        },
+        {
+          name = "CmdTouch"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "touch"
+            }
+          ]
+        },
+
+        // http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheMetrics.Redis.html
+        {
+          name = "CacheHits"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "hit"
+            }
+          ]
+        },
+        {
+          name = "CacheMisses"
+          alias = "aws.elasticache.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "miss"
+            }
+          ]
+        },
+        {
+          name = "ReplicationBytes"
+          alias = "aws.elasticache.replicationThroughput"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ReplicationLag"
+          alias = "aws.elasticache.replicationLag"
+          conversion = "max"
+        },
+        {
+          name = "SaveInProgress"
+          alias = "aws.elasticache.saveInProgress"
+          conversion = "max"
+        },
+        {
+          name = "BytesUsedForCache"
+          alias = "aws.elasticache.memoryUsed"
+          conversion = "max"
+        },
+        {
+          name = "HyperLogLogBasedCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "hyperLogLogBased"
+            }
+          ]
+        },
+        {
+          name = "GetTypeCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "getType"
+            }
+          ]
+        },
+        {
+          name = "HashBasedCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "hashBased"
+            }
+          ]
+        },
+        {
+          name = "KeyBasedCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "keyBased"
+            }
+          ]
+        },
+        {
+          name = "ListBasedCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "listBased"
+            }
+          ]
+        },
+        {
+          name = "SetBasedCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "setBased"
+            }
+          ]
+        },
+        {
+          name = "SetTypeCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "setType"
+            }
+          ]
+        },
+        {
+          name = "SortedSetBasedCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "sortedSetBased"
+            }
+          ]
+        },
+        {
+          name = "StringBasedCmds"
+          alias = "aws.elasticache.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "stringBased"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/elb.conf
+++ b/atlas-cloudwatch/src/main/resources/elb.conf
@@ -1,0 +1,155 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/elb-cloudwatch-metrics.html
+    elb = {
+      namespace = "AWS/ELB"
+      period = 1m
+
+      dimensions = [
+        "LoadBalancerName",
+        "AvailabilityZone"
+      ]
+
+      metrics = [
+        {
+          name = "RequestCount"
+          alias = "aws.elb.requests"
+          conversion = "sum,rate"
+        },
+        {
+          name = "HTTPCode_ELB_4XX"
+          alias = "aws.elb.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "4xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_ELB_5XX"
+          alias = "aws.elb.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "5xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_Backend_2XX"
+          alias = "aws.elb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "2xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_Backend_3XX"
+          alias = "aws.elb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "3xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_Backend_4XX"
+          alias = "aws.elb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "4xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_Backend_5XX"
+          alias = "aws.elb.backendResponses"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "5xx"
+            }
+          ]
+        },
+        {
+          name = "BackendConnectionErrors"
+          alias = "aws.elb.backendErrors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "error"
+              value = "connection"
+            }
+          ]
+        },
+        {
+          name = "HealthyHostCount"
+          alias = "aws.elb.hostCount"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "healthy"
+            }
+          ]
+        },
+        {
+          name = "UnHealthyHostCount"
+          alias = "aws.elb.hostCount"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "unhealthy"
+            }
+          ]
+        },
+        {
+          name = "Latency"
+          alias = "aws.elb.latency"
+          conversion = "timer"
+        },
+        {
+          name = "SurgeQueueLength"
+          alias = "aws.elb.surgeQueueLength"
+          conversion = "max"
+        },
+        {
+          name = "SpilloverCount"
+          alias = "aws.elb.spillover"
+          conversion = "sum,rate"
+        }
+      ]
+    }
+
+    elb-bytes = {
+      namespace = "AWS/ELB"
+      period = 1m
+
+      dimensions = [
+        "LoadBalancerName"
+      ]
+
+      metrics = [
+        {
+          name = "EstimatedProcessedBytes"
+          alias = "aws.elb.processedBytes"
+          conversion = "sum,rate"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/es.conf
+++ b/atlas-cloudwatch/src/main/resources/es.conf
@@ -1,0 +1,177 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/es-metricscollected.html
+    es = {
+      namespace = "AWS/ES"
+      period = 5m
+      end-period-offset = 1
+      period-count = 4
+
+      dimensions = [
+        "ClientId",
+        "DomainName"
+      ]
+
+      metrics = [
+        {
+          name = "Nodes"
+          alias = "aws.es.clusterSize"
+          conversion = "max"
+        },
+        {
+          name = "SearchableDocuments"
+          alias = "aws.es.indexSize"
+          conversion = "max"
+          tags = [
+            {
+              key = "status"
+              value = "searchable"
+            }
+          ]
+        },
+        {
+          name = "DeletedDocuments"
+          alias = "aws.es.indexSize"
+          conversion = "max"
+          tags = [
+            {
+              key = "status"
+              value = "deleted"
+            }
+          ]
+        },
+        {
+          name = "DiskQueueDepth"
+          alias = "aws.es.diskQueueDepth"
+          conversion = "max"
+        },
+        {
+          name = "ReadLatency"
+          alias = "aws.es.ioLatency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteLatency"
+          alias = "aws.es.ioLatency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "ReadThroughput"
+          alias = "aws.es.ioThroughput"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteThroughput"
+          alias = "aws.es.ioThroughput"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "ReadIOPS"
+          alias = "aws.es.iops"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteIOPS"
+          alias = "aws.es.iops"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "FreeStorageSpace"
+          alias = "aws.es.freeStorageSpace"
+          conversion = "min"
+        },
+        {
+          name = "JVMMemoryPressure"
+          alias = "aws.es.jvmMemoryPressure"
+          conversion = "max"
+        },
+        {
+          name = "MasterJVMMemoryPressure"
+          alias = "aws.esmaster.jvmMemoryPressure"
+          conversion = "max"
+        },
+        {
+          name = "CPUUtilization"
+          alias = "aws.es.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "MasterCPUUtilization"
+          alias = "aws.esmaster.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "ClusterStatus.green"
+          alias = "aws.es.clusterStatus"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "green"
+            }
+          ]
+        },
+        {
+          name = "ClusterStatus.yellow"
+          alias = "aws.es.clusterStatus"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "yellow"
+            }
+          ]
+        },
+        {
+          name = "ClusterStatus.red"
+          alias = "aws.es.clusterStatus"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "red"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/events.conf
+++ b/atlas-cloudwatch/src/main/resources/events.conf
@@ -1,0 +1,43 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cwe-metricscollected.html
+    events = {
+      namespace = "AWS/Events"
+      period = 1m
+
+      dimensions = [
+        "RuleName"
+      ]
+
+      metrics = [
+        {
+          name = "DeadLetterInvocations"
+          alias = "aws.events.deadLetterInvocations"
+          conversion = "sum,rate"
+        },
+        {
+          name = "Invocations"
+          alias = "aws.events.invocations"
+          conversion = "sum,rate"
+        },
+        {
+          name = "FailedInvocations"
+          alias = "aws.events.failedInvocations"
+          conversion = "sum,rate"
+        },
+        {
+          name = "TriggeredRules"
+          alias = "aws.events.rulesTriggered"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ThrottledRules"
+          alias = "aws.events.rulesThrottled"
+          conversion = "sum,rate"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/iot.conf
+++ b/atlas-cloudwatch/src/main/resources/iot.conf
@@ -1,0 +1,387 @@
+
+atlas {
+  cloudwatch {
+
+    // https://docs.aws.amazon.com/iot/latest/developerguide/metrics_dimensions.html
+    iot-base = {
+      namespace = "AWS/IoT"
+      period = 1m
+
+      dimensions = [
+        //"RuleName"
+      ]
+
+      metrics = [
+        {
+          name = "RulesExecuted"
+          alias = "aws.iot.rulesExecuted"
+          conversion = "sum,rate"
+        }
+      ]
+    }
+
+    // Rule metrics
+    iot-rule = {
+      namespace = "AWS/IoT"
+      period = 1m
+
+      dimensions = [
+        "RuleName"
+      ]
+
+      metrics = [
+        {
+          name = "TopicMatch"
+          alias = "aws.iot.topicMatches"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ParseError"
+          alias = "aws.iot.ruleErrors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "error"
+              value = "ParseError"
+            }
+          ]
+        },
+        {
+          name = "RuleMessageThrottled"
+          alias = "aws.iot.ruleErrors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "error"
+              value = "RuleMessageThrottled"
+            }
+          ]
+        },
+        {
+          name = "RuleNotFound"
+          alias = "aws.iot.ruleErrors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "error"
+              value = "RuleNotFound"
+            }
+          ]
+        }
+      ]
+    }
+
+    // Rule action metrics
+    iot-rule-action = {
+      namespace = "AWS/IoT"
+      period = 1m
+
+      dimensions = [
+        "RuleName",
+        "ActionType"
+      ]
+
+      metrics = [
+        {
+          name = "Success"
+          alias = "aws.iot.actionInvocations"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Success"
+            }
+          ]
+        },
+        {
+          name = "Failure"
+          alias = "aws.iot.actionInvocations"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Failure"
+            }
+          ]
+        }
+      ]
+    }
+
+    // Message broker metrics
+    iot-message-broker = {
+      namespace = "AWS/IoT"
+      period = 1m
+
+      dimensions = [
+        "Protocol"
+      ]
+
+      metrics = [
+        {
+          name = "Connect.AuthError"
+          alias = "aws.iot.connectionRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "AuthError"
+            }
+          ]
+        },
+        {
+          name = "Connect.ClientError"
+          alias = "aws.iot.connectionRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ClientError"
+            }
+          ]
+        },
+        {
+          name = "Connect.ClientIDThrottle"
+          alias = "aws.iot.connectionRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ClientIDThrottle"
+            }
+          ]
+        },
+        {
+          name = "Connect.ServerError"
+          alias = "aws.iot.connectionRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ServerError"
+            }
+          ]
+        },
+        {
+          name = "Connect.Success"
+          alias = "aws.iot.connectionRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Success"
+            }
+          ]
+        },
+        {
+          name = "Connect.Throttle"
+          alias = "aws.iot.connectionRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Throttle"
+            }
+          ]
+        },
+        {
+          name = "Ping.Success"
+          alias = "aws.iot.pingMessages"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Success"
+            }
+          ]
+        },
+        {
+          name = "PublishIn.AuthError"
+          alias = "aws.iot.publishInRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "AuthError"
+            }
+          ]
+        },
+        {
+          name = "PublishIn.ClientError"
+          alias = "aws.iot.publishInRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ClientError"
+            }
+          ]
+        },
+        {
+          name = "PublishIn.ServerError"
+          alias = "aws.iot.publishInRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ServerError"
+            }
+          ]
+        },
+        {
+          name = "PublishIn.Success"
+          alias = "aws.iot.publishInRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Success"
+            }
+          ]
+        },
+        {
+          name = "PublishIn.Throttle"
+          alias = "aws.iot.publishInRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Throttle"
+            }
+          ]
+        },
+        {
+          name = "PublishOut.AuthError"
+          alias = "aws.iot.publishOutRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "AuthError"
+            }
+          ]
+        },
+        {
+          name = "PublishOut.ClientError"
+          alias = "aws.iot.publishOutRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ClientError"
+            }
+          ]
+        },
+        {
+          name = "PublishOut.Success"
+          alias = "aws.iot.publishOutRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Success"
+            }
+          ]
+        },
+        {
+          name = "Subscribe.AuthError"
+          alias = "aws.iot.subscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "AuthError"
+            }
+          ]
+        },
+        {
+          name = "Subscribe.ClientError"
+          alias = "aws.iot.subscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ClientError"
+            }
+          ]
+        },
+        {
+          name = "Subscribe.ServerError"
+          alias = "aws.iot.subscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ServerError"
+            }
+          ]
+        },
+        {
+          name = "Subscribe.Success"
+          alias = "aws.iot.subscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Success"
+            }
+          ]
+        },
+        {
+          name = "Subscribe.Throttle"
+          alias = "aws.iot.subscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Throttle"
+            }
+          ]
+        },
+        {
+          name = "Unsubscribe.ClientError"
+          alias = "aws.iot.unsubscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ClientError"
+            }
+          ]
+        },
+        {
+          name = "Unsubscribe.ServerError"
+          alias = "aws.iot.unsubscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "ServerError"
+            }
+          ]
+        },
+        {
+          name = "Unsubscribe.Success"
+          alias = "aws.iot.unsubscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Success"
+            }
+          ]
+        },
+        {
+          name = "Unsubscribe.Throttle"
+          alias = "aws.iot.unsubscribeRequests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "Throttle"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/kinesis.conf
+++ b/atlas-cloudwatch/src/main/resources/kinesis.conf
@@ -1,0 +1,144 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/streams/latest/dev/monitoring-with-cloudwatch.html
+    kinesis = {
+      namespace = "AWS/Kinesis"
+      period = 1m
+
+      dimensions = [
+        "StreamName"
+      ]
+
+      metrics = [
+        {
+          name = "ReadProvisionedThroughputExceeded"
+          alias = "aws.kinesis.provisionedThroughputExceeded"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteProvisionedThroughputExceeded"
+          alias = "aws.kinesis.provisionedThroughputExceeded"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "GetRecords.IteratorAgeMilliseconds"
+          alias = "aws.kinesis.iteratorAge"
+          conversion = "max"
+        },
+        {
+          name = "PutRecords.Success"
+          alias = "aws.kinesis.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "putRecords"
+            }
+          ]
+        },
+        {
+          name = "PutRecord.Success"
+          alias = "aws.kinesis.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "putRecord"
+            }
+          ]
+        },
+        {
+          name = "GetRecords.Success"
+          alias = "aws.kinesis.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "getRecords"
+            }
+          ]
+        },
+        {
+          name = "PutRecords.Latency"
+          alias = "aws.kinesis.latency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "putRecords"
+            }
+          ]
+        },
+        {
+          name = "PutRecord.Latency"
+          alias = "aws.kinesis.latency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "putRecord"
+            }
+          ]
+        },
+        {
+          name = "GetRecords.Latency"
+          alias = "aws.kinesis.latency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "getRecords"
+            }
+          ]
+        },
+        {
+          name = "PutRecords.Bytes"
+          alias = "aws.kinesis.messageSize"
+          conversion = "dist-summary"
+          tags = [
+            {
+              key = "id"
+              value = "putRecords"
+            }
+          ]
+        },
+        {
+          name = "PutRecord.Bytes"
+          alias = "aws.kinesis.messageSize"
+          conversion = "dist-summary"
+          tags = [
+            {
+              key = "id"
+              value = "putRecord"
+            }
+          ]
+        },
+        {
+          name = "GetRecords.Bytes"
+          alias = "aws.kinesis.messageSize"
+          conversion = "dist-summary"
+          tags = [
+            {
+              key = "id"
+              value = "getRecords"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/lambda.conf
+++ b/atlas-cloudwatch/src/main/resources/lambda.conf
@@ -1,0 +1,81 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/lambda/latest/dg/monitoring-functions-metrics.html
+    lambda = {
+      namespace = "AWS/Lambda"
+      period = 1m
+
+      dimensions = []
+
+      metrics = [
+        {
+          name = "ConcurrentExecutions"
+          alias = "aws.lambda.concurrentExecutions"
+          conversion = "max"
+          tags = [
+            {
+              key = "concurrencyLimit"
+              value = "reserved"
+            }
+          ]
+        },
+        {
+          name = "UnreservedConcurrentExecutions"
+          alias = "aws.lambda.concurrentExecutions"
+          conversion = "max"
+          tags = [
+            {
+              key = "concurrencyLimit"
+              value = "unreserved"
+            }
+          ]
+        },
+      ]
+    }
+
+    lambda-fn-res = {
+      namespace = "AWS/Lambda"
+      period = 1m
+
+      dimensions = [
+        "FunctionName",
+        "Resource"
+      ]
+
+      metrics = [
+        {
+          name = "DeadLetterErrors"
+          alias = "aws.lambda.deadLetterErrors"
+          conversion = "sum,rate"
+        },
+        {
+          name = "Duration"
+          alias = "aws.lambda.duration"
+          conversion = "timer-millis"
+        },
+        {
+          name = "Errors"
+          alias = "aws.lambda.errors"
+          conversion = "sum,rate"
+        },
+        {
+          name = "Invocations"
+          alias = "aws.lambda.invocations"
+          conversion = "sum,rate"
+        },
+        {
+          name = "IteratorAge"
+          alias = "aws.lambda.iteratorAge"
+          conversion = "max"
+        },
+        {
+          name = "Throttles"
+          alias = "aws.lambda.throttles"
+          conversion = "sum,rate"
+        },
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/nat-gateway.conf
+++ b/atlas-cloudwatch/src/main/resources/nat-gateway.conf
@@ -1,0 +1,136 @@
+
+atlas {
+  cloudwatch {
+
+    // https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway-cloudwatch.html
+    nat-gateway = {
+      namespace = "AWS/NATGateway"
+      period = 1m
+
+      dimensions = [
+        "NatGatewayId"
+      ]
+
+      metrics = [
+        {
+          name = "ActiveConnectionCount"
+          alias = "aws.natgateway.activeConnectionCount"
+          conversion = "max"
+        },
+        {
+          name = "BytesInFromDestination"
+          alias = "aws.natgateway.bytesIn"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "FromDestination"
+            }
+          ]
+        },
+        {
+          name = "BytesInFromSource"
+          alias = "aws.natgateway.bytesIn"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "FromSource"
+            }
+          ]
+        },
+        {
+          name = "BytesOutToDestination"
+          alias = "aws.natgateway.bytesOut"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "ToDestination"
+            }
+          ]
+        },
+        {
+          name = "BytesOutToSource"
+          alias = "aws.natgateway.bytesOut"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "ToSource"
+            }
+          ]
+        },
+        {
+          name = "ConnectionAttemptCount"
+          alias = "aws.natgateway.attemptedConnections"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ConnectionEstablishedCount"
+          alias = "aws.natgateway.newConnections"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ErrorPortAllocation"
+          alias = "aws.natgateway.portAllocationErrors"
+          conversion = "sum,rate"
+        },
+        {
+          name = "IdleTimeoutCount"
+          alias = "aws.natgateway.idleTimeouts"
+          conversion = "sum,rate"
+        },
+        {
+          name = "PacketsDropCount"
+          alias = "aws.natgateway.packetsDropped"
+          conversion = "sum,rate"
+        },
+        {
+          name = "PacketsInFromDestination"
+          alias = "aws.natgateway.packetsIn"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "FromDestination"
+            }
+          ]
+        },
+        {
+          name = "PacketsInFromSource"
+          alias = "aws.natgateway.packetsIn"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "FromSource"
+            }
+          ]
+        },
+        {
+          name = "PacketsOutToDestination"
+          alias = "aws.natgateway.packetsOut"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "ToDestination"
+            }
+          ]
+        },
+        {
+          name = "PacketsOutToSource"
+          alias = "aws.natgateway.packetsOut"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "ToSource"
+            }
+          ]
+        },
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/neptune.conf
+++ b/atlas-cloudwatch/src/main/resources/neptune.conf
@@ -1,0 +1,251 @@
+
+atlas {
+  cloudwatch {
+    // https://docs.aws.amazon.com/neptune/latest/userguide/cw-metrics.html
+
+    neptune-common-metrics = [
+      {
+        name = "BufferCacheHitRatio"
+        alias = "aws.neptune.bufferCacheHitRatio"
+        conversion = "max"
+      },
+      {
+        name = "CPUUtilization"
+        alias = "aws.neptune.cpuUtilization"
+        conversion = "max"
+      },
+      {
+        name = "EngineUptime"
+        alias = "aws.neptune.engineUptime"
+        conversion = "max"
+      },
+      {
+        name = "FreeableMemory"
+        alias = "aws.neptune.freeableMemoryBytes"
+        conversion = "min"
+      },
+      {
+        name = "ClusterReplicaLag"
+        alias = "aws.neptune.replicaLag"
+        conversion = "max"
+      },
+      {
+        name = "ClusterReplicaLagMaximum"
+        alias = "aws.neptune.replicaLagMax"
+        conversion = "max"
+      },
+      {
+        name = "ClusterReplicaLagMinimum"
+        alias = "aws.neptune.replicaLagMin"
+        conversion = "min"
+      },
+      {
+        name = "GremlinRequestsPerSec"
+        alias = "aws.neptune.requests"
+        conversion = "sum,rate"
+        tags = [
+          {
+            key = "engine"
+            value = "gremlin"
+          }
+        ]
+      },
+      {
+        name = "SparqlRequestsPerSec"
+        alias = "aws.neptune.requests"
+        conversion = "sum,rate"
+        tags = [
+          {
+            key = "engine"
+            value = "sparql"
+          }
+        ]
+      },
+      {
+        name = "GremlinWebSocketOpenConnections"
+        alias = "aws.neptune.webSocketConnections"
+        conversion = "max"
+        tags = [
+          {
+            key = "engine"
+            value = "gremlin"
+          }
+        ]
+      },
+      {
+        name = "LoaderRequestsPerSec"
+        alias = "aws.neptune.loaderRequests"
+        conversion = "sum,rate"
+      },
+      {
+        name = "MainRequestQueuePendingRequests"
+        alias = "aws.neptune.pendingRequests"
+        conversion = "max"
+      },
+      {
+        name = "NetworkReceiveThroughput"
+        alias = "aws.neptune.networkThroughput"
+        conversion = "sum,rate"
+        tags = [
+          {
+            key = "id"
+            value = "in"
+          }
+        ]
+      },
+      {
+        name = "NetworkTransmitThroughput"
+        alias = "aws.neptune.networkThroughput"
+        conversion = "sum,rate"
+        tags = [
+          {
+            key = "id"
+            value = "out"
+          }
+        ]
+      },
+      {
+        name = "NumTxCommitted"
+        alias = "aws.neptune.transactions"
+        conversion = "sum,rate"
+        tags = [
+          {
+            key = "id"
+            value = "committed"
+          }
+        ]
+      },
+      {
+        name = "NumTxOpened"
+        alias = "aws.neptune.transactions"
+        conversion = "sum,rate"
+        tags = [
+          {
+            key = "id"
+            value = "openned"
+          }
+        ]
+      },
+      {
+        name = "NumTxRolledBack"
+        alias = "aws.neptune.transactions"
+        conversion = "sum,rate"
+        tags = [
+          {
+            key = "id"
+            value = "rolledback"
+          }
+        ]
+      },
+      {
+        name = "TotalClientErrorsPerSec"
+        alias = "aws.neptune.errors"
+        conversion = "sum,rate"
+        tags = [
+          {
+            key = "id"
+            value = "Client"
+          }
+        ]
+      },
+      {
+        name = "TotalServerErrorsPerSec"
+        alias = "aws.neptune.errors"
+        conversion = "sum,rate"
+        tags = [
+          {
+            key = "id"
+            value = "server"
+          }
+        ]
+      }
+    ]
+
+    neptune-instance = {
+      namespace = "AWS/Neptune"
+      period = 1m
+      timeout = 15m
+
+      dimensions = [
+        "DBInstanceIdentifier"
+      ]
+
+      metrics = ${atlas.cloudwatch.neptune-common-metrics}
+    }
+
+    neptune-cluster-role = {
+      namespace = "AWS/Neptune"
+      period = 1m
+      timeout = 15m
+
+      dimensions = [
+        "DBClusterIdentifier",
+        "Role"
+      ]
+
+      metrics = ${atlas.cloudwatch.neptune-common-metrics}
+    }
+
+    # Metrics published at cluster level, every 5 minutes
+    neptune-cluster-5m = {
+      namespace = "AWS/Neptune"
+      period = 5m
+      timeout = 15m
+
+      dimensions = [
+        "DBClusterIdentifier"
+      ]
+
+      metrics = [
+        {
+          name = "VolumeBytesUsed"
+          alias = "aws.neptune.volumeBytesUsed"
+          conversion = "max"
+        },
+        {
+          name = "VolumeReadIOPs"
+          alias = "aws.neptune.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "VolumeWriteIOPs"
+          alias = "aws.neptune.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        }
+      ]
+    }
+
+    # Metrics published at cluster level, once per day
+    neptune-cluster-1d = {
+      namespace = "AWS/Neptune"
+      period = 1d
+      period-count = 2
+      end-period-offset = 0
+      timeout = 15m
+
+      dimensions = [
+        "DBClusterIdentifier"
+      ]
+
+      metrics = [
+        {
+          name = "TotalBackupStorageBilled"
+          alias = "aws.neptune.totalBackupStorageBytes"
+          conversion = "max"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/nlb.conf
+++ b/atlas-cloudwatch/src/main/resources/nlb.conf
@@ -1,0 +1,232 @@
+
+atlas {
+  cloudwatch {
+
+    // Metrics for the overall load balancer by zone
+    // https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-cloudwatch-metrics.html
+    // Note that the dimensions available per metric is ambiguous in the docs (as of 2018/09/12).
+    // Though it may appear that AvailabilityZone, LoadBalancer, and TargetGroup are available on
+    // all metrics, they are not. All three are available only on Healthy/UnHealthyHostCount.
+    nlb = {
+      namespace = "AWS/NetworkELB"
+      period = 1m
+
+      dimensions = [
+        "LoadBalancer"
+      ]
+
+      metrics = [
+        {
+          name = "ConsumedLCUs"
+          alias = "aws.nlb.consumedLCUs"
+          conversion = "sum"
+        },
+      ]
+    }
+
+    nlb-zone = {
+      namespace = "AWS/NetworkELB"
+      period = 1m
+
+      dimensions = [
+        "AvailabilityZone",
+        "LoadBalancer"
+      ]
+
+      metrics = [
+        {
+          name = "ActiveFlowCount"
+          alias = "aws.nlb.activeFlowCount"
+          conversion = "max"
+          tags = [
+            {
+              key = "listener"
+              value = "tcp"
+            }
+          ]
+        },
+        {
+          name = "ActiveFlowCount_TLS"
+          alias = "aws.nlb.activeFlowCount"
+          conversion = "max"
+          tags = [
+            {
+              key = "listener"
+              value = "tls"
+            }
+          ]
+        },
+        {
+          name = "NewFlowCount"
+          alias = "aws.nlb.newFlows"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "listener"
+              value = "tcp"
+            }
+          ]
+        },
+        {
+          name = "NewFlowCount_TLS"
+          alias = "aws.nlb.newFlows"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "listener"
+              value = "tls"
+            }
+          ]
+        },
+        {
+          name = "PacketsPerSecondCapacity"
+          alias = "aws.nlb.packetsPerSecondCapacity"
+          conversion = "min"
+          tags = [
+            {
+              key = "listener"
+              value = "tcp"
+            }
+          ]
+        },
+        {
+          name = "PeakPacketsPerSecond"
+          alias = "aws.nlb.peakPacketsPerSecond"
+          conversion = "max"
+          tags = [
+            {
+              key = "listener"
+              value = "tcp"
+            }
+          ]
+        },
+        {
+          name = "ProcessedBytes"
+          alias = "aws.nlb.processedBytes"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "listener"
+              value = "tcp"
+            }
+          ]
+        },
+        {
+          name = "ProcessedBytes_TLS"
+          alias = "aws.nlb.processedBytes"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "listener"
+              value = "tls"
+            }
+          ]
+        },
+        {
+          name = "ProcessedPackets"
+          alias = "aws.nlb.processedPackets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "listener"
+              value = "tcp"
+            }
+          ]
+        },
+        {
+          name = "TCP_Client_Reset_Count"
+          alias = "aws.nlb.tcpResets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "resetBy"
+              value = "client"
+            }
+          ]
+        },
+        {
+          name = "TCP_ELB_Reset_Count"
+          alias = "aws.nlb.tcpResets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "resetBy"
+              value = "nlb"
+            }
+          ]
+        },
+        {
+          name = "TCP_Target_Reset_Count"
+          alias = "aws.nlb.tcpResets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "resetBy"
+              value = "target"
+            }
+          ]
+        },
+        {
+          name = "ClientTLSNegotiationErrorCount"
+          alias = "aws.nlb.tlsNegotiationError"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "entity"
+              value = "client"
+            }
+          ]
+        },
+        {
+          name = "TargetTLSNegotiationErrorCount"
+          alias = "aws.nlb.tlsNegotiationError"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "entity"
+              value = "target"
+            }
+          ]
+        }
+      ]
+    }
+
+    // Metrics available by target group
+    // https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-cloudwatch-metrics.html
+    nlb-tg-zone = {
+      namespace = "AWS/NetworkELB"
+      period = 1m
+
+      dimensions = [
+        "AvailabilityZone",
+        "LoadBalancer",
+        "TargetGroup"
+      ]
+
+      metrics = [
+        {
+          name = "HealthyHostCount"
+          alias = "aws.nlb.hostCount"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "healthy"
+            }
+          ]
+        },
+        {
+          name = "UnHealthyHostCount"
+          alias = "aws.nlb.hostCount"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "unhealthy"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/rds.conf
+++ b/atlas-cloudwatch/src/main/resources/rds.conf
@@ -1,0 +1,472 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/rds-metricscollected.html
+    rds = {
+      namespace = "AWS/RDS"
+      period = 1m
+      timeout = 15m
+
+      dimensions = [
+        "DBInstanceIdentifier"
+      ]
+
+      metrics = [
+        {
+          name = "CPUUtilization"
+          alias = "aws.rds.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "DatabaseConnections"
+          alias = "aws.rds.numConnections"
+          conversion = "max"
+        },
+        {
+          name = "DBLoadCPU"
+          alias = "aws.rds.numActiveSessions"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "cpu"
+            }
+          ]
+        },
+        {
+          name = "DBLoadNonCPU"
+          alias = "aws.rds.numActiveSessions"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "nonCpu"
+            }
+          ]
+        },
+        {
+          name = "FreeableMemory"
+          alias = "aws.rds.memoryFree"
+          conversion = "max"
+        },
+        {
+          name = "FreeLocalStorage"
+          alias = "aws.rds.diskFree"
+          conversion = "max"
+        },
+        {
+          name = "FreeStorageSpace"
+          alias = "aws.rds.diskFree"
+          conversion = "max"
+        },
+        {
+          name = "BinLogDiskUsage"
+          alias = "aws.rds.diskUsageLogs"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "binLog"
+            }
+          ]
+        },
+        {
+          name = "TransactionLogsDiskUsage"
+          alias = "aws.rds.diskUsageLogs"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "transactionLog"
+            }
+          ]
+        },
+        {
+          name = "ReplicaLag"
+          alias = "aws.rds.replicaLag"
+          conversion = "max"
+          tags = [
+            {
+              key = "engine"
+              value = "other"
+            }
+          ]
+        },
+        {
+          name = "AuroraReplicaLag"
+          alias = "aws.rds.replicaLag"
+          conversion = "max"
+          tags = [
+            {
+              key = "engine"
+              value = "aurora"
+            }
+          ]
+        },
+        {
+          name = "AuroraReplicaLagMaximum"
+          alias = "aws.rds.replicaLagMaximum"
+          conversion = "max"
+          tags = [
+            {
+              key = "engine"
+              value = "aurora"
+            }
+          ]
+        },
+        {
+          name = "AuroraBinlogReplicaLag"
+          alias = "aws.rds.binLogReplicaLag"
+          conversion = "max"
+        },
+        {
+          name = "AuroraVolumeBytesLeftTotal"
+          alias = "aws.rds.volumeBytesLeftTotal"
+          conversion = "max"
+          tags = [
+            {
+              key = "engine"
+              value = "aurora"
+            }
+          ]
+        },
+        {
+          name = "OldestReplicationSlotLag"
+          alias = "aws.rds.replicationDataBacklog"
+          conversion = "max"
+          tags = [
+            {
+              key = "engine"
+              value = "postgresql"
+            }
+          ]
+        },
+        {
+          name = "SwapUsage"
+          alias = "aws.rds.swapUsage"
+          conversion = "max"
+        },
+        {
+          name = "DiskQueueDepth"
+          alias = "aws.rds.diskQueueDepth"
+          conversion = "max"
+        },
+        {
+          name = "Deadlocks"
+          alias = "aws.rds.deadlocks"
+          conversion = "sum,rate"
+        },
+        {
+          name = "LoginFailures"
+          alias = "aws.rds.loginFailures"
+          conversion = "sum,rate"
+        },
+        {
+          name = "BufferCacheHitRatio"
+          alias = "aws.rds.bufferCacheHitPercent"
+          conversion = "max"
+        },
+        {
+          name = "ResultSetCacheHitRatio"
+          alias = "aws.rds.resultSetCacheHitPercent"
+          conversion = "max"
+        },
+        {
+          name = "NetworkReceiveThroughput"
+          alias = "aws.rds.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "NetworkTransmitThroughput"
+          alias = "aws.rds.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "ActiveTransactions"
+          alias = "aws.rds.transactions"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "active"
+            }
+          ]
+        },
+        {
+          name = "BlockedTransactions"
+          alias = "aws.rds.transactions"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "blocked"
+            }
+          ]
+        },
+        {
+          name = "CommitLatency"
+          alias = "aws.rds.queryLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "commit"
+            }
+          ]
+        },
+        {
+          name = "DDLLatency"
+          alias = "aws.rds.queryLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "ddl"
+            }
+          ]
+        },
+        {
+          name = "DMLLatency"
+          alias = "aws.rds.queryLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "dml"
+            }
+          ]
+        },
+        {
+          name = "DeleteLatency"
+          alias = "aws.rds.queryLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "delete"
+            }
+          ]
+        },
+        {
+          name = "InsertLatency"
+          alias = "aws.rds.queryLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "insert"
+            }
+          ]
+        },
+        {
+          name = "SelectLatency"
+          alias = "aws.rds.queryLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "select"
+            }
+          ]
+        },
+        {
+          name = "UpdateLatency"
+          alias = "aws.rds.queryLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "update"
+            }
+          ]
+        },
+        {
+          name = "CommitThroughput"
+          alias = "aws.rds.queries"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "commit"
+            }
+          ]
+        },
+        {
+          name = "DDLThroughput"
+          alias = "aws.rds.queries"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "ddl"
+            }
+          ]
+        },
+        {
+          name = "DMLThroughput"
+          alias = "aws.rds.queries"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "dml"
+            }
+          ]
+        },
+        {
+          name = "DeleteThroughput"
+          alias = "aws.rds.queries"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "delete"
+            }
+          ]
+        },
+        {
+          name = "InsertThroughput"
+          alias = "aws.rds.queries"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "insert"
+            }
+          ]
+        },
+        {
+          name = "SelectThroughput"
+          alias = "aws.rds.queries"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "select"
+            }
+          ]
+        },
+        {
+          name = "UpdateThroughput"
+          alias = "aws.rds.queries"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "update"
+            }
+          ]
+        },
+        {
+          name = "ReadLatency"
+          alias = "aws.rds.ioLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteLatency"
+          alias = "aws.rds.ioLatency"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "ReadThroughput"
+          alias = "aws.rds.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteThroughput"
+          alias = "aws.rds.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "ReadIOPS"
+          alias = "aws.rds.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteIOPS"
+          alias = "aws.rds.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "MaximumUsedTransactionIDs"
+          alias = "aws.rds.maxUsedTransactionIds"
+          conversion = "max"
+        },
+      ]
+    }
+
+    rds-cluster = {
+      namespace = "AWS/RDS"
+      #
+      # Note: these period parameters are for now based on metric "VolumeBytesUsed" being published
+      # about every hour, and they are configured to include data points within last 90 minutes
+      # (1m * (91 - 1)) to avoid gaps in minutely timeseries.
+      #
+      period = 1m
+      period-count = 91
+      end-period-offset = 1
+      timeout = 15m
+
+      dimensions = [
+        "DbClusterIdentifier"
+      ]
+
+      metrics = [
+        {
+          name = "VolumeBytesUsed"
+          alias = "aws.rds.volumeBytesUsed"
+          conversion = "max"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/redshift.conf
+++ b/atlas-cloudwatch/src/main/resources/redshift.conf
@@ -1,0 +1,132 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/redshift/latest/mgmt/metrics-listing.html
+    redshift = {
+      namespace = "AWS/Redshift"
+      period = 1m
+
+      dimensions = [
+        "ClusterIdentifier",
+        "NodeID"
+      ]
+
+      metrics = [
+        {
+          name = "CPUUtilization"
+          alias = "aws.redshift.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "DatabaseConnections"
+          alias = "aws.redshift.numConnections"
+          conversion = "max"
+        },
+        {
+          name = "HealthStatus"
+          alias = "aws.redshift.healthStatus"
+          conversion = "max"
+        },
+        {
+          name = "MaintenanceMode"
+          alias = "aws.redshift.maintenanceMode"
+          conversion = "max"
+        },
+        {
+          name = "NetworkReceiveThroughput"
+          alias = "aws.redshift.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "NetworkTransmitThroughput"
+          alias = "aws.redshift.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "ReadLatency"
+          alias = "aws.redshift.ioLatency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteLatency"
+          alias = "aws.redshift.ioLatency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "ReadThroughput"
+          alias = "aws.redshift.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteThroughput"
+          alias = "aws.redshift.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "ReadIOPS"
+          alias = "aws.redshift.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteIOPS"
+          alias = "aws.redshift.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "PercentageDiskSpaceUsed"
+          alias = "aws.redshift.diskUsedPercent"
+          conversion = "max"
+        },
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -1,0 +1,413 @@
+
+akka.actor.deployment {
+  /poller/poller-cloudwatch/metrics-get {
+    router = "round-robin-pool"
+    nr-of-instances = 100
+    pool-dispatcher {
+      executor = "thread-pool-executor"
+      thread-pool-executor {
+        core-pool-size-min = 100
+        core-pool-size-max = 100
+        core-pool-size-factor = 1.0
+      }
+    }
+  }
+
+  /poller/poller-cloudwatch/metrics-list {
+    router = "round-robin-pool"
+    nr-of-instances = 2
+    pool-dispatcher {
+      executor = "thread-pool-executor"
+      thread-pool-executor {
+        core-pool-size-min = 1
+        core-pool-size-max = 2
+        core-pool-size-factor = 1.0
+      }
+    }
+  }
+}
+
+atlas.akka {
+  actors = ${?atlas.akka.actors} [
+    {
+      name = "poller"
+      class = "com.netflix.atlas.poller.PollerManager"
+    }
+  ]
+}
+
+atlas {
+
+  poller {
+
+    // How often to collect data from the pollers.
+    frequency = 1 m
+
+    sink = {
+      class = "com.netflix.atlas.poller.ClientActor"
+
+      // URL for sending the data
+      uri = "http://localhost:7101/api/v1/publish"
+
+      // Maximum number of datapoints to send in a single HTTP request to the publish
+      // endpoint.
+      batch-size = 10000
+
+      // If set to false, then ClientActor will work in a fire and forget mode with no
+      // explicit response message. Setting to true it will send an ack message to indicate
+      // it is done processing the message.
+      send-ack = false
+
+      // Characters that are allowed in metric names
+      valid-tag-characters = "-._A-Za-z0-9"
+
+      // Overrides to be more permissive for the values of some keys
+      valid-tag-value-characters = ${?atlas.poller.valid-tag-value-characters} [
+        {
+          key = "nf.cluster"
+          value = "-._A-Za-z0-9^~"
+        },
+        {
+          key = "nf.asg"
+          value = "-._A-Za-z0-9^~"
+        }
+      ]
+    }
+
+    pollers = ${?atlas.poller.pollers} [
+      {
+        class = "com.netflix.atlas.cloudwatch.CloudWatchPoller"
+        name = "cloudwatch"
+      }
+    ]
+  }
+
+  cloudwatch {
+
+    // Batch size for flushing data back to the poller manager
+    batch-size = 1000
+
+    // How long to cache datapoints to avoid gaps
+    cache-ttl = 20 minutes
+
+    metrics-get-buffer-size = 10
+    metrics-get-max-rate-per-second = 400
+
+    // Class to use for mapping AWS dimensions to a tag map for use in Atlas
+    tagger = {
+      class = "com.netflix.atlas.cloudwatch.NetflixTagger"
+
+      // Enables extracting a substring of a dimension value using a regex.
+      // Only one capture group is supported, so only capture group 1 will
+      // be used. If no match is found, the unaltered original value is
+      // used.
+      extractors = ${?atlas.cloudwatch.tagger.extractors} [
+        {
+          name = "LoadBalancer"
+          directives = [
+            {
+              pattern = "^app/([^/]+)/.*"
+              alias = "aws.alb"
+            },
+            {
+              pattern = "^net/([^/]+)/.*"
+              alias = "aws.nlb"
+            }
+          ]
+        },
+        {
+          name = "TargetGroup"
+          directives = [
+            {
+              pattern = "^targetgroup/([^/]+)/.*"
+              alias = "aws.target"
+            }
+          ]
+        }
+      ]
+
+      // Allows the dimension names to be mapped to values that are more
+      // familiar internally at Netflix. If no explicit mapping is found,
+      // then the value from cloudwatch will be used as is.
+      mappings = [
+        {
+          name = "AutoScalingGroupName"
+          alias = "nf.asg"
+        },
+        {
+          name = "AvailabilityZone"
+          alias = "nf.zone"
+        },
+        {
+          name = "Region"
+          alias = "aws.region"
+        },
+        {
+          name = "LinkedAccount"
+          alias = "aws.account"
+        },
+        {
+          name = "Currency"
+          alias = "aws.currency"
+        },
+        {
+          name = "LoadBalancerName"
+          alias = "aws.elb"
+        },
+        {
+          name = "TopicName"
+          alias = "aws.topic"
+        },
+        {
+          name = "QueueName"
+          alias = "aws.queue"
+        },
+        {
+          name = "ServiceName"
+          alias = "aws.service"
+        },
+        {
+          name = "ServiceLimit"
+          alias = "aws.limit"
+        },
+        {
+          name = "BucketName"
+          alias = "aws.bucket"
+        },
+        {
+          name = "StorageType"
+          alias = "aws.storage"
+        },
+        {
+          name = "FunctionName"
+          alias = "aws.function"
+        },
+        {
+          name = "StreamName"
+          alias = "aws.stream"
+        },
+        {
+          name = "RuleName"
+          alias = "aws.rule"
+        },
+        {
+          name = "Resource"
+          alias = "aws.resource"
+        },
+        {
+          name = "Domain"
+          alias = "aws.domain"
+        },
+        {
+          name = "Operation"
+          alias = "aws.op"
+        },
+        {
+          name = "TableName"
+          alias = "aws.table"
+        },
+        {
+          name = "DomainName"
+          alias = "aws.domain"
+        },
+        {
+          name = "WorkflowTypeName"
+          alias = "id"
+        },
+        {
+          name = "WorkflowTypeVersion"
+          alias = "aws.version"
+        },
+        {
+          name = "ActivityTypeName"
+          alias = "id"
+        },
+        {
+          name = "ActivityTypeVersion"
+          alias = "aws.version"
+        },
+        {
+          name = "ClientId"
+          alias = "aws.client"
+        },
+        {
+          name = "CacheClusterId"
+          alias = "aws.cache"
+        },
+        {
+          name = "CacheNodeId"
+          alias = "aws.node"
+        },
+        {
+          name = "DBClusterIdentifier"
+          alias = "aws.dbcluster"
+        },
+        {
+          name = "DbClusterIdentifier"
+          alias = "aws.dbcluster"
+        },
+        {
+          name = "DBInstanceIdentifier"
+          alias = "aws.dbname"
+        },
+        {
+          name = "ClusterIdentifier"
+          alias = "aws.redshift"
+        },
+        {
+          name = "FileSystemId"
+          alias = "aws.efs"
+        },
+        {
+          name = "NodeID"
+          alias = "nf.node"
+        },
+        {
+          name = "FilterId"
+          alias = "aws.filter"
+        },
+        {
+          name = "NatGatewayId"
+          alias = "aws.gateway"
+        },
+        {
+          name = "Action"
+          alias = "aws.action"
+        },
+        {
+          name = "TransitGateway"
+          alias = "aws.tgw"
+        },
+        {
+          name = "ActionType"
+          alias = "aws.action"
+        },
+        {
+          name = "Protocol"
+          alias = "aws.protocol"
+        },
+        {
+          name = "ConnectionId"
+          alias = "aws.connection"
+        },
+        {
+          name = "HealthCheckId"
+          alias = "aws.healthcheck"
+        },
+        {
+          name = "HostedZoneId"
+          alias = "aws.hostedZone"
+        },
+        {
+          name = "EndpointId"
+          alias = "aws.endpoint"
+        },
+        {
+          name = "Role"
+          alias = "aws.role"
+        }
+      ]
+
+      // Tags that should get applied to all metrics from cloudwatch.
+      common-tags = [
+        {
+          key = "nf.region"
+          value = "us-west-2"
+        }
+      ]
+
+      // When using the netflix mapper, this setting specifies which keys should get
+      // processed via frigga to extract tags based on the internal naming conventions.
+      netflix-keys = [
+        "nf.asg",
+        "aws.elb"
+      ]
+    }
+
+    // Categories to load. The name will be used to load another config block:
+    // atlas.cloudwatch.${name}
+    //
+    // ec2 is excluded by default because at Netflix it tends to add a lot of load in terms of
+    // CW calls and offers little value over internal system metrics.
+    categories = [
+      "alb",
+      "alb-zone",
+      "alb-tg-zone",
+      "api-gateway",
+      "billing",
+      "dx-connection",
+      "dx-connection-light-level",
+      "dx-virtual-interface",
+      "dynamodb-table-1m",
+      "dynamodb-table-5m",
+      "dynamodb-table-ops",
+      //"ec2",
+      "ec2-api",
+      "ec2-credit",
+      "efs",
+      "elasticache",
+      "elb",
+      "elb-bytes",
+      "es",
+      "events",
+      "iot-base",
+      "iot-rule",
+      "iot-rule-action",
+      "iot-message-broker"
+      "kinesis",
+      "lambda",
+      "lambda-fn-res",
+      "nat-gateway",
+      "neptune-instance",
+      "neptune-cluster-role",
+      "neptune-cluster-5m",
+      "neptune-cluster-1d",
+      "nlb",
+      "nlb-zone",
+      "nlb-tg-zone",
+      "rds",
+      "rds-cluster",
+      "redshift",
+      "route53-healthcheck",
+      "route53-hostedzone",
+      "route53-resolver",
+      "s3",
+      "s3-request",
+      "sns",
+      "sqs",
+      "tgw",
+      //"trustedadvisor",
+      "workflow",
+      "workflow-activity"
+    ]
+
+  }
+}
+
+include "alb.conf"
+include "api-gateway.conf"
+include "billing.conf"
+include "dx.conf"
+include "dynamodb.conf"
+include "ec2.conf"
+include "elasticache.conf"
+include "elb.conf"
+include "efs.conf"
+include "es.conf"
+include "events.conf"
+include "iot.conf"
+include "kinesis.conf"
+include "lambda.conf"
+include "nat-gateway.conf"
+include "neptune.conf"
+include "nlb.conf"
+include "rds.conf"
+include "redshift.conf"
+include "route53.conf"
+include "s3.conf"
+include "s3-request.conf"
+include "sns.conf"
+include "sqs.conf"
+include "swf.conf"
+include "tgw.conf"
+include "trustedadvisor.conf"

--- a/atlas-cloudwatch/src/main/resources/route53.conf
+++ b/atlas-cloudwatch/src/main/resources/route53.conf
@@ -1,0 +1,95 @@
+
+atlas {
+  cloudwatch {
+
+    // https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/monitoring-cloudwatch.html
+    route53-healthcheck = {
+      namespace = "AWS/Route53"
+      period = 1m
+      end-period-offset = 3
+
+      dimensions = [
+        "HealthCheckId"
+      ]
+
+      metrics = [
+        {
+          name = "HealthCheckPercentageHealthy"
+          alias = "aws.route53.percentHealthy"
+          conversion = "max"
+        },
+        {
+          name = "HealthCheckStatus"
+          alias = "aws.route53.healthCheckStatus"
+          conversion = "max"
+        }
+      ]
+    }
+
+    // https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/monitoring-hosted-zones-with-cloudwatch.html
+    route53-hostedzone = {
+      namespace = "AWS/Route53"
+      period = 1m
+      end-period-offset = 3
+
+      dimensions = [
+        "HostedZoneId"
+      ]
+
+      metrics = [
+        {
+          name = "DNSQueries"
+          alias = "aws.route53.dnsQueries"
+          conversion = "sum,rate"
+        }
+      ]
+    }
+
+    // https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/monitoring-hosted-zones-with-cloudwatch.html
+    route53-resolver = {
+      namespace = "AWS/Route53Resolver"
+      period = 1m
+      end-period-offset = 3
+
+      dimensions = [
+        "EndpointId"
+      ]
+
+      metrics = [
+        {
+          name = "InboundQueryVolume"
+          alias = "aws.route53.resolverQueryVolume"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "inbound"
+            }
+          ]
+        },
+        {
+          name = "OutboundQueryVolume"
+          alias = "aws.route53.resolverQueryVolume"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "outbound"
+            }
+          ]
+        },
+        {
+          name = "OutboundQueryAggregateVolume"
+          alias = "aws.route53.resolverAggregateQueryVolume"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "outbound"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/s3-request.conf
+++ b/atlas-cloudwatch/src/main/resources/s3-request.conf
@@ -1,0 +1,144 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html
+    s3-request = {
+      namespace = "AWS/S3"
+      period = 1m
+
+      dimensions = [
+        "BucketName",
+        "FilterId"
+      ]
+
+      metrics = [
+        {
+          name = "AllRequests"
+          alias = "aws.s3.allRequests"
+          conversion = "sum,rate"
+        },
+        {
+          name = "GetRequests"
+          alias = "aws.s3.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "get"
+            }
+          ]
+        },
+        {
+          name = "PutRequests"
+          alias = "aws.s3.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "put"
+            }
+          ]
+        },
+        {
+          name = "DeleteRequests"
+          alias = "aws.s3.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "delete"
+            }
+          ]
+        },
+        {
+          name = "HeadRequests"
+          alias = "aws.s3.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "head"
+            }
+          ]
+        },
+        {
+          name = "PostRequests"
+          alias = "aws.s3.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "post"
+            }
+          ]
+        },
+        {
+          name = "ListRequests"
+          alias = "aws.s3.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "list"
+            }
+          ]
+        },
+        {
+          name = "BytesDownloaded"
+          alias = "aws.s3.bytesTransferred"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "downloaded"
+            }
+          ]
+        },
+        {
+          name = "BytesUploaded"
+          alias = "aws.s3.bytesTransferred"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "uploaded"
+            }
+          ]
+        },
+        {
+          name = "4xxErrors"
+          alias = "aws.s3.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "4xx"
+            }
+          ]
+        },
+        {
+          name = "5xxErrors"
+          alias = "aws.s3.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "5xx"
+            }
+          ]
+        },
+        {
+          name = "FirstByteLatency"
+          alias = "aws.s3.firstByteLatency"
+          conversion = "timer-millis"
+        },
+        {
+          name = "TotalRequestLatency"
+          alias = "aws.s3.totalRequestLatency"
+          conversion = "timer-millis"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/s3.conf
+++ b/atlas-cloudwatch/src/main/resources/s3.conf
@@ -1,0 +1,31 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html
+    s3 = {
+      namespace = "AWS/S3"
+      period = 1d
+      end-period-offset = 1
+      period-count = 2
+
+      dimensions = [
+        "BucketName",
+        "StorageType"
+      ]
+
+      metrics = [
+        {
+          name = "BucketSizeBytes"
+          alias = "aws.s3.bucketSizeBytes"
+          conversion = "max"
+        },
+        {
+          name = "NumberOfObjects"
+          alias = "aws.s3.numberOfObjects"
+          conversion = "max"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/sns.conf
+++ b/atlas-cloudwatch/src/main/resources/sns.conf
@@ -1,0 +1,52 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/sns/latest/dg/MonitorSNSwithCloudWatch.html
+    sns = {
+      namespace = "AWS/SNS"
+      period = 5m
+      end-period-offset = 1
+      period-count = 4
+
+      dimensions = [
+        "TopicName"
+      ]
+
+      metrics = [
+        {
+          name = "NumberOfMessagesPublished"
+          alias = "aws.sns.messagesPublished"
+          conversion = "sum,rate"
+        },
+        {
+          name = "NumberOfNotificationsDelivered"
+          alias = "aws.sns.notifications"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "delivered"
+            }
+          ]
+        },
+        {
+          name = "NumberOfNotificationsFailed"
+          alias = "aws.sns.notifications"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "failed"
+            }
+          ]
+        },
+        {
+          name = "PublishSize"
+          alias = "aws.sns.messageSize"
+          conversion = "dist-summary"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/sqs.conf
+++ b/atlas-cloudwatch/src/main/resources/sqs.conf
@@ -1,0 +1,83 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQS_metricscollected.html
+    sqs = {
+      namespace = "AWS/SQS"
+      period = 5m
+      end-period-offset = 1
+      period-count = 4
+
+      dimensions = [
+        "QueueName"
+      ]
+
+      metrics = [
+        {
+          name = "ApproximateNumberOfMessagesDelayed"
+          alias = "aws.sqs.approximateNumberOfMessages"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "delayed"
+            }
+          ]
+        },
+        {
+          name = "ApproximateNumberOfMessagesNotVisible"
+          alias = "aws.sqs.approximateNumberOfMessages"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "not-visible"
+            }
+          ]
+        },
+        {
+          name = "ApproximateNumberOfMessagesVisible"
+          alias = "aws.sqs.approximateNumberOfMessages"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "visible"
+            }
+          ]
+        },
+        {
+          name = "ApproximateAgeOfOldestMessage"
+          alias = "aws.sqs.approximateAgeOfOldestMessage"
+          conversion = "max"
+        },
+        {
+          name = "NumberOfMessagesSent"
+          alias = "aws.sqs.messagesSent"
+          conversion = "sum,rate"
+        },
+        {
+          name = "NumberOfMessagesReceived"
+          alias = "aws.sqs.messagesReceived"
+          conversion = "sum,rate"
+        },
+        {
+          name = "NumberOfMessagesDeleted"
+          alias = "aws.sqs.messagesDeleted"
+          conversion = "sum,rate"
+        },
+        {
+          name = "NumberOfEmptyReceives"
+          alias = "aws.sqs.emptyReceives"
+          conversion = "sum,rate"
+        },
+        {
+          name = "SentMessageSize"
+          alias = "aws.sqs.messageSize"
+          conversion = "dist-summary"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/swf.conf
+++ b/atlas-cloudwatch/src/main/resources/swf.conf
@@ -1,0 +1,231 @@
+
+atlas {
+  cloudwatch {
+
+    // http://docs.aws.amazon.com/amazonswf/latest/developerguide/cw-metrics.html
+    workflow = {
+      namespace = "AWS/SWF"
+      period = 1m
+
+      dimensions = [
+        "Domain",
+        "WorkflowTypeName",
+        "WorkflowTypeVersion"
+      ]
+
+      metrics = [
+        {
+          name = "DecisionTaskScheduleToStartTime"
+          alias = "aws.swf.decisionTaskTime"
+          conversion = "timer"
+          tags = [
+            {
+              key = "phase"
+              value = "scheduleToStart"
+            }
+          ]
+        },
+        {
+          name = "DecisionTaskStartToCloseTime"
+          alias = "aws.swf.decisionTaskTime"
+          conversion = "timer"
+          tags = [
+            {
+              key = "phase"
+              value = "startToClose"
+            }
+          ]
+        },
+        {
+          name = "DecisionTasksCompleted"
+          alias = "aws.swf.decisionTasksCompleted"
+          conversion = "sum,rate"
+        },
+        {
+          name = "WorkflowStartToCloseTime"
+          alias = "aws.swf.workflowExecutionTime"
+          conversion = "timer"
+        },
+        {
+          name = "WorkflowsCanceled"
+          alias = "aws.swf.workflows"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "canceled"
+            }
+          ]
+        },
+        {
+          name = "WorkflowsCompleted"
+          alias = "aws.swf.workflows"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "completed"
+            }
+          ]
+        },
+        {
+          name = "WorkflowsContinuedAsNew"
+          alias = "aws.swf.workflows"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "continuedAsNew"
+            }
+          ]
+        },
+        {
+          name = "WorkflowsFailed"
+          alias = "aws.swf.workflows"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "failed"
+            }
+          ]
+        },
+        {
+          name = "WorkflowsTerminated"
+          alias = "aws.swf.workflows"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "terminated"
+            }
+          ]
+        },
+        {
+          name = "WorkflowsTimedOut"
+          alias = "aws.swf.workflows"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "timedOut"
+            }
+          ]
+        }
+      ]
+    }
+
+    workflow-activity = {
+      namespace = "AWS/SWF"
+      period = 1m
+
+      dimensions = [
+        "Domain",
+        "ActivityTypeName",
+        "ActivityTypeVersion"
+      ]
+
+      metrics = [
+        {
+          name = "ActivityTaskScheduleToStartTime"
+          alias = "aws.swf.activityTaskTime"
+          conversion = "timer"
+          tags = [
+            {
+              key = "phase"
+              value = "scheduleToStart"
+            }
+          ]
+        },
+        {
+          name = "ActivityTaskStartToCloseTime"
+          alias = "aws.swf.activityTaskTime"
+          conversion = "timer"
+          tags = [
+            {
+              key = "phase"
+              value = "startToClose"
+            }
+          ]
+        },
+        {
+          name = "ActivityTasksCanceled"
+          alias = "aws.swf.activityTasks"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "canceled"
+            }
+          ]
+        },
+        {
+          name = "ActivityTasksCompleted"
+          alias = "aws.swf.activityTasks"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "completed"
+            }
+          ]
+        },
+        {
+          name = "ActivityTasksFailed"
+          alias = "aws.swf.activityTasks"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "failed"
+            }
+          ]
+        },
+        {
+          name = "ScheduledActivityTasksTimedOutOnClose"
+          alias = "aws.swf.activityTaskFailures"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "scheduledTimedOutOnClose"
+            }
+          ]
+        },
+        {
+          name = "ScheduledActivityTasksTimedOutOnStart"
+          alias = "aws.swf.activityTaskFailures"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "scheduledTimedOutOnStart"
+            }
+          ]
+        },
+        {
+          name = "StartedActivityTasksTimedOutOnClose"
+          alias = "aws.swf.activityTaskFailures"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "startedTimedOutOnClose"
+            }
+          ]
+        },
+        {
+          name = "StartedActivityTasksTimedOutOnHeartbeat"
+          alias = "aws.swf.activityTaskFailures"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "startedTimedOutOnHeartbeat"
+            }
+          ]
+        },
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/tgw.conf
+++ b/atlas-cloudwatch/src/main/resources/tgw.conf
@@ -1,0 +1,107 @@
+
+atlas {
+  cloudwatch {
+
+    // Metrics for the transit gateway service
+    // https://docs.aws.amazon.com/vpc/latest/tgw/transit-gateway-cloudwatch-metrics.html
+    tgw = {
+      namespace = "AWS/TransitGateway"
+      period = 1m
+
+      dimensions = [
+        "TransitGateway"
+      ]
+
+      metrics = [
+        {
+          name = "BytesIn"
+          alias = "aws.tgw.bytes"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "BytesOut"
+          alias = "aws.tgw.bytes"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "PacketsIn"
+          alias = "aws.tgw.packets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "PacketsOut"
+          alias = "aws.tgw.packets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "BytesDropCountBlackhole"
+          alias = "aws.tgw.bytesDropped"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Blackhole"
+            }
+          ]
+        },
+        {
+          name = "BytesDropCountNoRoute"
+          alias = "aws.tgw.bytesDropped"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "NoRoute"
+            }
+          ]
+        },
+        {
+          name = "PacketDropCountBlackhole"
+          alias = "aws.tgw.packetsDropped"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Blackhole"
+            }
+          ]
+        },
+        {
+          name = "PacketDropCountNoRoute"
+          alias = "aws.tgw.packetsDropped"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "NoRoute"
+            }
+          ]
+        },
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/trustedadvisor.conf
+++ b/atlas-cloudwatch/src/main/resources/trustedadvisor.conf
@@ -1,0 +1,35 @@
+
+atlas {
+  cloudwatch {
+
+    // https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/trusted-advisor-metricscollected.html
+    // Mapping for service limit metrics only. It isn't clear the others are of any use to us
+    // at this time.
+    trustedadvisor = {
+      namespace = "AWS/TrustedAdvisor"
+
+      // Update frequency seems to be ~1h15m, but isn't as regular as most other cloudwatch
+      // data. Using 2h to provide some buffer.
+      period = 2h
+      end-period-offset = 1
+      period-count = 2
+
+      // Note, TA data for all regions seems to show up in CloudWatch for us-east-1
+      dimensions = [
+        "Region",
+        "ServiceName",
+        "ServiceLimit"
+      ]
+
+      metrics = [
+        {
+          name = "ServiceLimitUsage"
+          alias = "aws.trustedadvisor.serviceLimitUsage"
+          // AWS documentation and unit indicate it is a percentage, but the actual values
+          // are from 0 to 1 instead of 0 to 100.
+          conversion = "max,percent"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
@@ -1,0 +1,421 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import java.util.function.LongFunction
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.actor.Props
+import akka.actor.Status
+import akka.routing.FromConfig
+import akka.stream.CompletionStrategy
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.netflix.atlas.poller.Messages
+import com.netflix.iep.leader.api.LeaderStatus
+import com.netflix.spectator.api.Functions
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.histogram.BucketCounter
+import com.netflix.spectator.api.patterns.PolledMeter
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+
+/**
+  * Poller for fetching data from CloudWatch and reporting the data into Atlas.
+  *
+  * @param config
+  *     Config for setting up the poller. See the reference.conf for more details
+  *     about the settings.
+  * @param registry
+  *     Registry for reporting metrics. The primary metrics are:
+  *
+  *     - `atlas.cloudwatch.listAge`: gauge showing the age in seconds of the list
+  *       metadata.
+  *     - `atlas.cloudwatch.listSize`: gauge showing the number of metrics found
+  *       by calling list metrics on CloudWatch.
+  *     - `atlas.cloudwatch.pendingGets`: gauge showing the number of metric get
+  *       requests that are currently in-flight. This should be less than the
+  *       list size or the system is starting to back up.
+  *
+  *     More detailed metrics on the specific AWS calls can be used by configuring
+  *     the `spectator-ext-aws` metric collector with the SDK.
+  * @param client
+  *     AWS CloudWatch client.
+  */
+class CloudWatchPoller(
+  config: Config,
+  registry: Registry,
+  client: CloudWatchClient,
+  leaderStatus: LeaderStatus
+) extends Actor
+    with StrictLogging {
+
+  import CloudWatchPoller._
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+  import scala.concurrent.duration._
+
+  // Load the categories and tagger based on the config settings
+  private val categories = getCategories(config)
+  private val tagger = getTagger(config)
+
+  // Metadata for the metrics in CloudWatch that we need to fetch and how to
+  // map them into Atlas metrics.
+  private val metricsMetadata = new AtomicReference[List[MetricMetadata]](Nil)
+
+  // Child actor for getting the data for a metric. This will do the call using the
+  // AWS SDK which is blocking and should be run in an isolated dispatcher.
+  private val metricsGetRef =
+    context.actorOf(
+      FromConfig.props(
+        Props(
+          classOf[GetMetricActor],
+          client,
+          registry,
+          buildBucketCounterCache(registry, categories)
+        )
+      ),
+      "metrics-get"
+    )
+
+  // Throttler to control the rate of get metrics calls in order to stay within AWS SDK limits.
+  private implicit val system = context.system
+
+  private val throttledMetricsGetRef = Source
+    .actorRef[List[MetricMetadata]](
+      {
+        case Status.Success(s: CompletionStrategy) => s
+        case Status.Success(_)                     => CompletionStrategy.draining
+      }: PartialFunction[Any, CompletionStrategy], {
+        case Status.Failure(t) => t
+      }: PartialFunction[Any, Throwable],
+      config.getInt("atlas.cloudwatch.metrics-get-buffer-size"),
+      OverflowStrategy.dropHead
+    )
+    .flatMapConcat(ms => Source(ms))
+    .throttle(config.getInt("atlas.cloudwatch.metrics-get-max-rate-per-second"), 1.second)
+    .toMat(Sink.foreach(message => metricsGetRef.tell(message, self)))(Keep.left)
+    .run()
+
+  // Child actor for listing metrics. This will do the call using the
+  // AWS SDK which is blocking and should be run in an isolated dispatcher.
+  private val metricsListRef =
+    context.actorOf(FromConfig.props(Props(new ListMetricsActor(client, tagger))), "metrics-list")
+
+  // Batch size to use for flushing data back to the poller manager.
+  private val batchSize = config.getInt("atlas.cloudwatch.batch-size")
+
+  // Actor that sent the Tick message and that should receive the response.
+  private var responder: ActorRef = _
+
+  // Indicates if a list operation is currently in-flight. Only one list operation
+  // should be running at a time.
+  private var pendingList: Boolean = false
+
+  // Last time the metadata list was successfully updated.
+  private val listUpdateTime: AtomicLong = PolledMeter
+    .using(registry)
+    .withName("atlas.cloudwatch.listAge")
+    .monitorValue(new AtomicLong(registry.clock().wallTime()), Functions.age(registry.clock()))
+
+  // Size of the metadata list. Compare with pending gets to get an idea of
+  // how well we are keeping up with polling all of the data.
+  private val listSize: AtomicLong = PolledMeter
+    .using(registry)
+    .withName("atlas.cloudwatch.listSize")
+    .monitorValue(new AtomicLong(0L))
+
+  // Number of get requests that are in-flight.
+  private val pendingGets: AtomicLong = PolledMeter
+    .using(registry)
+    .withName("atlas.cloudwatch.pendingGets")
+    .monitorValue(new AtomicLong(0L))
+
+  // Cache of the last values received for a given metric
+  private val cacheTTL = config.getDuration("atlas.cloudwatch.cache-ttl")
+
+  private val metricCache = Caffeine
+    .newBuilder()
+    .expireAfterWrite(cacheTTL.toMillis, TimeUnit.MILLISECONDS)
+    .build[MetricMetadata, MetricData]()
+
+  // List keeping track of current batch of metric data.
+  private val metricBatch: MList = new MList
+
+  // Regularly flush any pending data that is still buffered
+  context.system.scheduler.scheduleAtFixedRate(5.seconds, 5.seconds, self, Flush)
+
+  def receive: Receive = {
+    case Flush          => flush()
+    case Messages.Tick  => refresh() // From PollerManager
+    case m: MetricData  => processMetricData(m) // Response from GetMetricActor
+    case MetricList(ms) => processMetricList(ms) // Response from ListMetricsActor
+  }
+
+  private def refresh(): Unit = {
+    responder = sender()
+    if (leaderStatus.hasLeadership) {
+      logger.debug("Refreshing metrics")
+      refreshMetricsList()
+      fetchMetricsData()
+      sendMetricData()
+    } else {
+      logger.debug("Skipping metrics refresh, do not have leadership.")
+    }
+  }
+
+  /** Refresh the metadata list if one is not already in progress. */
+  private def refreshMetricsList(): Unit = {
+    if (pendingList) {
+      logger.debug(s"list already in progress, skipping")
+    } else {
+      logger.info(s"refreshing list of cloudwatch metrics for ${categories.size} categories")
+      pendingList = true
+      metricsListRef ! ListMetrics(categories)
+    }
+  }
+
+  /** Schedule all metrics in the metadata list for a refresh. */
+  private def fetchMetricsData(): Unit = {
+    val ms = metricsMetadata.get()
+    val pending = pendingGets.get()
+    val num = ms.size
+    if (pending > num) {
+      logger.warn(s"skipping fetch, still have ${pendingGets.get()} metrics pending")
+    } else {
+      if (pending > 0) {
+        logger.warn(s"not keeping up, still have ${pendingGets.get()} metrics pending")
+      }
+      pendingGets.addAndGet(num)
+      logger.info(s"requesting data for $num metrics")
+      throttledMetricsGetRef ! ms
+    }
+  }
+
+  /**
+    * Process the returned list of metrics. An empty list will get ignored as it is likely
+    * in error. The `atlas.cloudwatch.listAge` metric can be used to monitor how long it
+    * has been since the metadata was successfully updated.
+    */
+  private def processMetricList(ms: List[MetricMetadata]): Unit = {
+    pendingList = false
+    if (ms.nonEmpty) {
+      listUpdateTime.set(registry.clock().wallTime())
+      val size = ms.size
+      logger.info(s"found $size cloudwatch metrics")
+      listSize.set(size)
+      metricsMetadata.set(ms)
+    } else {
+      logger.warn("no cloudwatch metrics found")
+    }
+  }
+
+  /** Add a datapoint to the cache. */
+  private def processMetricData(data: MetricData): Unit = {
+    pendingGets.decrementAndGet()
+    val maybeMetricData = Option(metricCache.getIfPresent(data.meta))
+    val prev = maybeMetricData.flatMap(_.current)
+    val timestamp = data.lastReportedTimestamp.orElse {
+      maybeMetricData.flatMap(_.lastReportedTimestamp)
+    }
+    metricCache.put(data.meta, data.copy(previous = prev, lastReportedTimestamp = timestamp))
+  }
+
+  /** Send all metrics that are currently in the cache. */
+  private def sendMetricData(): Unit = {
+    metricCache.asMap().forEach { (meta, data) =>
+      val now = registry.clock().wallTime()
+      val d = data.datapoint(Instant.ofEpochMilli(now))
+      if (!d.sum.isNaN) {
+        val ts = tagger(meta.dimensions) ++ meta.definition.tags + ("name" -> meta.definition.alias)
+        val newValue = meta.convert(d)
+        metricBatch += new AtlasDatapoint(ts, now, newValue)
+        flush()
+      }
+    }
+  }
+
+  /** Flush data if the batch size is big enough or we are done with the current iteration. */
+  private def flush(): Unit = {
+    val now = registry.clock().wallTime()
+    if (metricBatch.nonEmpty) {
+      val age = now - metricBatch.head.timestamp
+      if (age > 5000) {
+        val batch = metricBatch.toList
+        metricBatch.clear()
+        logger.info(s"writing ${batch.size} metrics to client, age = $age ms")
+        responder ! Messages.MetricsPayload(Map.empty, batch)
+      } else if (metricBatch.lengthCompare(batchSize) >= 0) {
+        val batch = metricBatch.toList
+        metricBatch.clear()
+        logger.info(s"writing ${batch.size} metrics to client, max batch size reached")
+        responder ! Messages.MetricsPayload(Map.empty, batch)
+      } else {
+        logger.debug(s"not writing metrics, age = $age ms, size = ${metricBatch.size}")
+      }
+    }
+  }
+}
+
+object CloudWatchPoller {
+
+  case object Flush
+
+  private val Zero = Datapoint
+    .builder()
+    .minimum(0.0)
+    .maximum(0.0)
+    .sum(0.0)
+    .sampleCount(0.0)
+    .timestamp(Instant.now())
+    .unit(StandardUnit.NONE)
+    .build()
+
+  private val DatapointNaN = Datapoint
+    .builder()
+    .minimum(Double.NaN)
+    .maximum(Double.NaN)
+    .sum(Double.NaN)
+    .sampleCount(Double.NaN)
+    .timestamp(Instant.now())
+    .unit(StandardUnit.NONE)
+    .build()
+
+  private[cloudwatch] def getCategories(config: Config): List[MetricCategory] = {
+    import scala.jdk.CollectionConverters._
+    val categories = config.getStringList("atlas.cloudwatch.categories").asScala.map { name =>
+      val cfg = config.getConfig(s"atlas.cloudwatch.$name")
+      MetricCategory.fromConfig(cfg)
+    }
+    categories.toList
+  }
+
+  private[cloudwatch] def getTagger(config: Config): Tagger = {
+    val cfg = config.getConfig("atlas.cloudwatch.tagger")
+    val cls = Class.forName(cfg.getString("class"))
+    cls.getConstructor(classOf[Config]).newInstance(cfg).asInstanceOf[Tagger]
+  }
+
+  val PeriodLagIdName: String = "atlas.cloudwatch.periodLag"
+
+  private def buildBucketCounterCache(
+    registry: Registry,
+    metricCategories: List[MetricCategory]
+  ): Map[Id, BucketCounter] = {
+
+    metricCategories.flatMap { category =>
+      val noDataThreshold = category.periodCount + category.endPeriodOffset
+
+      val bucketFunction: LongFunction[String] =
+        (periodCount: Long) =>
+          if (periodCount > noDataThreshold) // threshold is intended to be small (< 10)
+            "no_data"
+          else
+            periodCount.toString
+
+      val id = registry
+        .createId(PeriodLagIdName)
+        .withTag("cwNamespace", category.namespace)
+        .withTag("periodSeconds", category.period.toString)
+
+      category.metrics.map { metric =>
+        val periodLagId = id.withTag("cwMetricName", metric.name)
+        periodLagId -> BucketCounter
+          .get(
+            registry,
+            periodLagId,
+            bucketFunction
+          )
+
+      }
+    }.toMap
+  }
+
+  case class GetMetricData(metric: MetricMetadata)
+
+  case class MetricData(
+    meta: MetricMetadata,
+    previous: Option[Datapoint],
+    current: Option[Datapoint],
+    lastReportedTimestamp: Option[Instant]
+  ) {
+
+    def datapoint(now: Instant = Instant.now): Datapoint = {
+      if (meta.definition.monotonicValue) {
+        previous.fold(DatapointNaN) { p =>
+          // For a monotonic counter, use the max statistic. These will typically have a
+          // single reporting source that maintains the state over time. If the sample count
+          // is larger than one, it will be a spike due to the reporter sending the value
+          // multiple times within that interval. The max will allow us to ignore those
+          // spikes and get the last written value.
+          val c = current.getOrElse(DatapointNaN)
+          val delta = math.max(c.maximum - p.maximum, 0.0)
+          Datapoint
+            .builder()
+            .minimum(delta)
+            .maximum(delta)
+            .sum(delta)
+            .sampleCount(c.sampleCount)
+            .timestamp(c.timestamp)
+            .unit(c.unit)
+            .build()
+        }
+      } else {
+        current.getOrElse {
+          // We send 0 values for gaps in CloudWatch data because previously, users were
+          // confused or concerned when they saw spans of NaN values in the data reported.
+          // Those spans occur especially for low-volume resources and resources where the
+          // only available period is greater than than the period configured for the
+          // `MetricCategory` (although, that may indicate a misconfiguration).
+          //
+          // This implementation reports `0` if there's no configured timeout or if we've
+          // received at least one datapoint until the timeout is exceeded. It reports `NaN`
+          // until the first datapoint is received or for no data within and beyond the
+          // timeout threshold.
+          //
+          // Requiring at least one datapoint prevents interpolating `0` from startup until
+          // the timeout for obsolete resources.  It may result in NaN gaps for low volume
+          // resources when deploying. But that is likely preferable to suddenly and briefly
+          // reporting `0` for obsolete resources and possibly triggering alerts for those
+          // with expressions that use wildcards for the resource selector.
+          val reportNaN = meta.category.timeout.exists { timeout =>
+            lastReportedTimestamp.fold(true) { timestamp =>
+              Duration.between(timestamp, now).compareTo(timeout) > 0
+            }
+          }
+
+          if (reportNaN) DatapointNaN else Zero
+        }
+      }
+    }
+  }
+
+  case class ListMetrics(categories: List[MetricCategory])
+
+  case class MetricList(data: List[MetricMetadata])
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/Conversions.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/Conversions.scala
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+
+/**
+  * Helpers for creating conversion functions to extract the value from a cloudwatch
+  * datapoint and normalize it to follow Atlas conventions.
+  */
+object Conversions {
+
+  /**
+    * Determine the Atlas DS type based on the conversion. Anything that has a rate
+    * conversion will use a rate, otherwise it will be treated as a gauge.
+    */
+  def determineDsType(name: String): String = {
+    if (name.contains("rate")) "rate" else "gauge"
+  }
+
+  /**
+    * Create a new conversion based on a simple comma separated list of known mappings.
+    * The first element should be the statistic to extract. Allowed values are: `min`,
+    * `max`, `sum`, `count`, and `avg`.
+    *
+    * This can optionally be followed by a rate conversion, e.g., `sum,rate`. The rate
+    * will divide the value by the sample period from the cloudwatch metadata to get a
+    * rate per second for the value. The rate conversion is unit aware, so if the unit
+    * for the datapoint is already a rate, then no conversion will take place.
+    *
+    * In addition to the conversions specified by name, a unit conversion will automatically
+    * be applied to the data. This ensures that a base unit is reported.
+    */
+  def fromName(name: String): Conversion = {
+    val conversions = name.split(",").toList.reverse
+    unit(from(name, conversions))
+  }
+
+  private def from(name: String, conversions: List[String]): Conversion = {
+    conversions match {
+      case "min" :: Nil    => min
+      case "max" :: Nil    => max
+      case "sum" :: Nil    => sum
+      case "count" :: Nil  => count
+      case "avg" :: Nil    => avg
+      case "rate" :: cs    => rate(from(name, cs))
+      case "percent" :: cs => multiply(from(name, cs), 100.0)
+      case v :: cs         => throw new IllegalArgumentException(s"unknown conversion '$v' ($name)")
+      case Nil             => throw new IllegalArgumentException(s"empty conversion list ($name)")
+    }
+  }
+
+  private def min: Conversion = (_, d) => d.minimum
+
+  private def max: Conversion = (_, d) => d.maximum
+
+  private def sum: Conversion = (_, d) => d.sum
+
+  private def count: Conversion = (_, d) => d.sampleCount
+
+  private def avg: Conversion = (_, d) => d.sum / d.sampleCount
+
+  private def unit(f: Conversion): Conversion = (m, d) => {
+    val factor = unitFactor(d.unit)
+    val newDatapoint = Datapoint
+      .builder()
+      .minimum(d.minimum * factor)
+      .maximum(d.maximum * factor)
+      .sum(d.sum * factor)
+      .sampleCount(d.sampleCount)
+      .timestamp(d.timestamp)
+      .unit(d.unit)
+      .build()
+    f(m, newDatapoint)
+  }
+
+  /**
+    * Convert the result to a rate per second if it is not already. If the unit
+    * for the datapoint indicates it is already a rate, then the value will not
+    * be modified.
+    */
+  private def rate(f: Conversion): Conversion = (m, d) => {
+    val v = f(m, d)
+    val unit = d.unitAsString()
+    if (unit.endsWith("/Second")) v else v / m.category.period
+  }
+
+  /** Modifies a conversion `f` to multiply the result by `v`. */
+  def multiply(f: Conversion, v: Double): Conversion = (m, d) => f(m, d) * v
+
+  /** Modifies a datapoint so that it has the specified unit. */
+  def toUnit(f: Conversion, unit: StandardUnit): Conversion = (m, d) => {
+    val newDatapoint = Datapoint
+      .builder()
+      .minimum(d.minimum)
+      .maximum(d.maximum)
+      .sum(d.sum)
+      .sampleCount(d.sampleCount)
+      .timestamp(d.timestamp)
+      .unit(unit)
+      .build()
+    f(m, newDatapoint)
+  }
+
+  private def unitFactor(unit: StandardUnit): Double = {
+    unit match {
+      case StandardUnit.COUNT => 1.0
+
+      //  Use a base unit of bytes
+      case StandardUnit.BITS     => 1.0 / 8.0
+      case StandardUnit.KILOBITS => 1e3 / 8.0
+      case StandardUnit.MEGABITS => 1e6 / 8.0
+      case StandardUnit.GIGABITS => 1e9 / 8.0
+      case StandardUnit.TERABITS => 1e12 / 8.0
+
+      // Use a base unit of bytes. Assumes that the raw input is using
+      // a decimal multiple, i.e., multiples of 1000 not 1024.
+      case StandardUnit.BYTES     => 1.0
+      case StandardUnit.KILOBYTES => 1e3
+      case StandardUnit.MEGABYTES => 1e6
+      case StandardUnit.GIGABYTES => 1e9
+      case StandardUnit.TERABYTES => 1e12
+
+      case StandardUnit.COUNT_SECOND => 1.0
+
+      // Use base unit of bytes/second
+      case StandardUnit.BITS_SECOND     => 1.0 / 8.0
+      case StandardUnit.KILOBITS_SECOND => 1e3 / 8.0
+      case StandardUnit.MEGABITS_SECOND => 1e6 / 8.0
+      case StandardUnit.GIGABITS_SECOND => 1e9 / 8.0
+      case StandardUnit.TERABITS_SECOND => 1e12 / 8.0
+
+      // Use base unit of bytes/second
+      case StandardUnit.BYTES_SECOND     => 1.0
+      case StandardUnit.KILOBYTES_SECOND => 1e3
+      case StandardUnit.MEGABYTES_SECOND => 1e6
+      case StandardUnit.GIGABYTES_SECOND => 1e9
+      case StandardUnit.TERABYTES_SECOND => 1e12
+
+      // Use base unit of seconds
+      case StandardUnit.MICROSECONDS => 1e-6
+      case StandardUnit.MILLISECONDS => 1e-3
+      case StandardUnit.SECONDS      => 1.0
+
+      case StandardUnit.PERCENT => 1.0
+      case StandardUnit.NONE    => 1.0
+      case _                    => 1.0
+    }
+  }
+
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.typesafe.config.Config
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+
+import scala.util.matching.Regex
+
+/**
+  * Tag datapoints with a set of common tags. Also allows mapping cloudwatch
+  * dimension names to names that match some other convention. For example,
+  * the cloudwatch dimension name AutoScalingGroupName corresponds to nf.asg
+  * and we would rather have a single key in use for common concepts.
+  */
+class DefaultTagger(config: Config) extends Tagger {
+  import scala.jdk.CollectionConverters._
+
+  private val extractors: Map[String, List[(Regex, String)]] = config
+    .getConfigList("extractors")
+    .asScala
+    .map { c =>
+      val directives = c
+        .getConfigList("directives")
+        .asScala
+        .map { cl =>
+          val alias = if (cl.hasPath("alias")) cl.getString("alias") else c.getString("name")
+          cl.getString("pattern").r -> alias
+        }
+        .toList
+      c.getString("name") -> directives
+    }
+    .toMap
+
+  private val mappings: Map[String, String] = config
+    .getConfigList("mappings")
+    .asScala
+    .map(c => c.getString("name") -> c.getString("alias"))
+    .toMap
+
+  private val commonTags: Map[String, String] = config
+    .getConfigList("common-tags")
+    .asScala
+    .map(c => c.getString("key") -> c.getString("value"))
+    .toMap
+
+  private def toTag(dimension: Dimension): (String, String) = {
+    val cwName = dimension.name
+    val cwValue = dimension.value
+
+    val extractor = DefaultTagger.ValueExtractor(cwValue)
+    extractors
+      .get(cwName)
+      .flatMap { directives =>
+        directives.collectFirst {
+          case extractor(a, v) => a -> v
+        }
+      }
+      .getOrElse(mappings.getOrElse(cwName, cwName) -> cwValue)
+  }
+
+  override def apply(dimensions: List[Dimension]): Map[String, String] = {
+    commonTags ++ dimensions.map(toTag).toMap
+  }
+}
+
+object DefaultTagger {
+
+  private case class ValueExtractor(rawValue: String) {
+
+    def unapply(extractorDirective: (Regex, String)): Option[(String, String)] = {
+      val (regex, alias) = extractorDirective
+      regex.findFirstMatchIn(rawValue).map { matches =>
+        val value = if (matches.groupCount > 0) matches.group(1) else rawValue
+        alias -> value
+      }
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/GetMetricActor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/GetMetricActor.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import java.time.Duration
+import java.time.Instant
+import akka.actor.Actor
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.histogram.BucketCounter
+import com.typesafe.scalalogging.StrictLogging
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+
+import java.time.temporal.ChronoUnit
+
+/**
+  * Queries CloudWatch to get a datapoint for given metric. This actor makes blocking
+  * calls to the Amazon SDK, it should be run in a dedicated dispatcher.
+  */
+class GetMetricActor(
+  client: CloudWatchClient,
+  registry: Registry,
+  bucketCounterCache: Map[Id, BucketCounter]
+) extends Actor
+    with StrictLogging {
+  import CloudWatchPoller._
+
+  private val basePeriodLagId = registry.createId(PeriodLagIdName)
+
+  def receive: Receive = {
+    case m: MetricMetadata =>
+      val metric = getMetric(m)
+      val timestamp = metric.map(m => m.timestamp)
+      sender() ! MetricData(m, None, metric, timestamp)
+  }
+
+  /**
+    * Queries CloudWatch for the metric with a time range ending at the current time and
+    * starting at the configured number of periods.
+    *
+    * @return the most recent value prior to the configured end offset or None (if no
+    *         values were reported in that time range).
+    */
+  private def getMetric(m: MetricMetadata): Option[Datapoint] = {
+    try {
+      import scala.jdk.CollectionConverters._
+      // Truncate to second boundary to avoid errors from CloudWatch service:
+      // https://github.com/aws/aws-sdk-java-v2/issues/2389
+      val now = Instant.now().truncatedTo(ChronoUnit.SECONDS)
+      val start = now.minusSeconds(m.category.periodCount * m.category.period)
+
+      val request = m.toGetRequest(start, now)
+      val result = client.getMetricStatistics(request)
+
+      // Datapoints might not be ordered by time, sort before using
+      val datapoints = result.datapoints.asScala.toList
+      val sorted = datapoints
+        .filter(!_.sum.isNaN)
+        .sortWith(_.timestamp.toEpochMilli > _.timestamp.toEpochMilli)
+      recordLag(now, sorted.headOption.map(_.timestamp), m)
+
+      val endOffset = now.minusSeconds(m.category.endPeriodOffset * m.category.period)
+      sorted.find(_.timestamp.isBefore(endOffset))
+    } catch {
+      case e: Exception =>
+        logger.warn(s"failed to get data for ${m.category.namespace}/${m.definition.name}", e)
+        None
+    }
+  }
+
+  /**
+    * Record how many periods back from now the latest returned datapoint is. Though not perfect,
+    * this will give a reasonable approximation of data latency across the collected metrics.
+    */
+  private def recordLag(now: Instant, maybeTimestamp: Option[Instant], m: MetricMetadata): Unit = {
+    val mostRecentDatapointTimestamp = maybeTimestamp.getOrElse(Instant.EPOCH)
+    val lagDuration = Duration.between(mostRecentDatapointTimestamp, now)
+
+    val lagSeconds = lagDuration.toMillis / 1000L
+    val periodLag = lagSeconds / m.category.period
+    val id = basePeriodLagId
+      .withTag("cwMetricName", m.definition.name)
+      .withTag("cwNamespace", m.category.namespace)
+      .withTag("periodSeconds", m.category.period.toString)
+
+    bucketCounterCache.get(id).foreach(_.record(periodLag))
+  }
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/ListMetricsActor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/ListMetricsActor.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import akka.actor.Actor
+import com.typesafe.scalalogging.StrictLogging
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+import software.amazon.awssdk.services.cloudwatch.model.ListMetricsRequest
+import software.amazon.awssdk.services.cloudwatch.model.Metric
+
+/**
+  * Queries CloudWatch to get a list of for available metrics. This actor makes blocking
+  * calls to the Amazon SDK, it should be run in a dedicated dispatcher.
+  */
+class ListMetricsActor(client: CloudWatchClient, tagger: Tagger) extends Actor with StrictLogging {
+  import CloudWatchPoller._
+
+  def receive: Receive = {
+    case ListMetrics(categories) => sender() ! MetricList(listMetrics(categories))
+  }
+
+  private def listMetrics(categories: List[MetricCategory]): List[MetricMetadata] = {
+    try {
+      val builder = categories.foldLeft(List.newBuilder[MetricMetadata]) { (acc, c) =>
+        acc ++= listMetrics(c)
+      }
+      builder.result()
+    } catch {
+      case e: Exception =>
+        logger.warn("failed to list metrics", e)
+        Nil
+    }
+  }
+
+  private def listMetrics(category: MetricCategory): List[MetricMetadata] = {
+    import scala.jdk.CollectionConverters._
+    category.toListRequests.flatMap {
+      case (definition, request) =>
+        val mname = s"${category.namespace}/${definition.name}"
+        logger.debug(s"refreshing list for $mname")
+        val candidates = listMetrics(request).map { m =>
+          MetricMetadata(category, definition, m.dimensions.asScala.toList)
+        }
+        logger.debug(s"before filtering, found ${candidates.size} metrics for $mname")
+        val after = candidates.filter { m =>
+          category.filter.matches(tagger(m.dimensions))
+        }
+        logger.debug(s"after filtering, found ${after.size} metrics for $mname")
+        after
+    }
+  }
+
+  private def listMetrics(request: ListMetricsRequest): List[Metric] = {
+    import scala.jdk.StreamConverters._
+    client
+      .listMetricsPaginator(request)
+      .metrics()
+      .stream()
+      .toScala(List)
+  }
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import com.netflix.atlas.core.model.Query
+import com.netflix.atlas.core.model.QueryVocabulary
+import com.netflix.atlas.core.stacklang.Interpreter
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+import software.amazon.awssdk.services.cloudwatch.model.DimensionFilter
+import software.amazon.awssdk.services.cloudwatch.model.ListMetricsRequest
+
+/**
+  * Category of metrics to fetch from CloudWatch. This will typically correspond with
+  * a CloudWatch namespace, though there may be multiple categories per namespace if
+  * there is some variation in the behavior. For example, some namespaces will use a
+  * different period for some metrics.
+  *
+  * @param namespace
+  *     CloudWatch namespace for the data.
+  * @param period
+  *     How frequently data in this category is updated. Atlas is meant for data that
+  *     is continuously reported and requires a consistent step. To minimize confusion
+  *     for CloudWatch data we use the last reported value in CloudWatch as long as it
+  *     is within one period from the polling time. The period is also needed for
+  *     performing rate conversions on some metrics.
+  * @param endPeriodOffset
+  *     How many periods back from `now` to set the end of the time range.
+  * @param periodCount
+  *     How many periods total to retrieve.
+  * @param timeout
+  *     How long the system should interpolate a base value for unreported CloudWatch
+  *     metrics before ceasing to send them. CloudWatch will return 0 metrics for at
+  *     least two cases:
+  *     - No metrics were recorded.
+  *     - The resource has been removed, metrics still show up when listing metrics due
+  *       to the retention window, but the specified time interval for the metric
+  *       statistics request is after the removal.
+  * @param dimensions
+  *     The dimensions to query for when getting data from CloudWatch. For the
+  *     GetMetricData calls we have to explicitly specify all of the dimensions. In some
+  *     cases CloudWatch has duplicate data for pre-computed aggregates. For example,
+  *     ELB data is reported overall for the load balancer and by zone. For Atlas it
+  *     is better to map in the most granular form and allow the aggregate to be done
+  *     dynamically at query time.
+  * @param metrics
+  *     The set of metrics to fetch and metadata for how to convert them.
+  * @param filter
+  *     Query expression used to select the set of metrics which should get published.
+  *     This can sometimes be useful for debugging or if there are many "spammy" metrics
+  *     for a given category.
+  */
+case class MetricCategory(
+  namespace: String,
+  period: Int,
+  endPeriodOffset: Int,
+  periodCount: Int,
+  timeout: Option[Duration],
+  dimensions: List[String],
+  metrics: List[MetricDefinition],
+  filter: Query
+) {
+
+  /**
+    * Returns a set of list requests to fetch the metadata for the metrics matching
+    * this category. As there may be a lot of data in CloudWatch that we are not
+    * interested in, the list is used to restrict to the subset we actually care
+    * about rather than a single request fetching everything for the namespace.
+    */
+  def toListRequests: List[(MetricDefinition, ListMetricsRequest)] = {
+    import scala.jdk.CollectionConverters._
+    metrics.map { m =>
+      m -> ListMetricsRequest
+        .builder()
+        .namespace(namespace)
+        .metricName(m.name)
+        .dimensions(dimensions.map(d => DimensionFilter.builder().name(d).build()).asJava)
+        .build()
+    }
+  }
+}
+
+object MetricCategory extends StrictLogging {
+
+  private val interpreter = Interpreter(QueryVocabulary.allWords)
+
+  private def parseQuery(query: String): Query = {
+    interpreter.execute(query).stack match {
+      case (q: Query) :: Nil => q
+      case _ =>
+        logger.warn(s"invalid query '$query', using default of ':true'")
+        Query.True
+    }
+  }
+
+  def fromConfig(config: Config): MetricCategory = {
+    import scala.jdk.CollectionConverters._
+    val metrics = config.getConfigList("metrics").asScala.toList
+    val filter =
+      if (!config.hasPath("filter")) Query.True
+      else {
+        parseQuery(config.getString("filter"))
+      }
+    val timeout = if (config.hasPath("timeout")) Some(config.getDuration("timeout")) else None
+    val endPeriodOffset =
+      if (config.hasPath("end-period-offset")) config.getInt("end-period-offset") else 1
+    val periodCount = if (config.hasPath("period-count")) config.getInt("period-count") else 6
+
+    apply(
+      namespace = config.getString("namespace"),
+      period = config.getDuration("period", TimeUnit.SECONDS).toInt,
+      endPeriodOffset = endPeriodOffset,
+      periodCount = periodCount,
+      timeout = timeout,
+      dimensions = config.getStringList("dimensions").asScala.toList,
+      metrics = metrics.flatMap(MetricDefinition.fromConfig),
+      filter = filter
+    )
+  }
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricDefinition.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricDefinition.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.netflix.atlas.core.model.TagKey
+import com.typesafe.config.Config
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+
+/**
+  * Definition for a particular cloudwatch metric.
+  *
+  * @param name
+  *     Name of the metric as it is stored in CloudWatch.
+  * @param alias
+  *     Alias to make the metric follow Atlas naming conventions.
+  * @param conversion
+  *     Conversion to apply to the datapoint when extracting the value. See [[Conversions]]
+  *     for more information.
+  * @param monotonicValue
+  *     Set to true if the value is monotonically increasing. These values will get converted
+  *     to a delta before passing into the conversion function.
+  * @param tags
+  *     Tags that should be applied to the metric.
+  */
+case class MetricDefinition(
+  name: String,
+  alias: String,
+  conversion: (MetricMetadata, Datapoint) => Double,
+  monotonicValue: Boolean,
+  tags: Map[String, String]
+)
+
+object MetricDefinition {
+
+  /**
+    * Create a set of metric definitions from a config. In most cases the list will have
+    * a single item if using a standard conversion from [[Conversions]]. Three composite
+    * types are supported: `timer`, `timer-millis`, and `dist-summary`. These will get
+    * mapped in as close as possible to way spectator would map in those types. The primary
+    * gap is that with CloudWatch we cannot get a totalOfSquares so the standard deviation
+    * cannot be computed.
+    *
+    * Note, `timer` should generally be preferred over `timer-millis`. If the unit is
+    * specified on the datapoint, then it will automatically convert to seconds. When using
+    * `timer-millis` the unit is ignored and the data will be assumed to be in milliseconds.
+    * It is mostly intended for use with some latency values that do not explicitly mark the
+    * unit.
+    */
+  def fromConfig(config: Config): List[MetricDefinition] = {
+    import scala.jdk.CollectionConverters._
+    val tags =
+      if (!config.hasPath("tags")) Map.empty[String, String]
+      else {
+        config
+          .getConfigList("tags")
+          .asScala
+          .map(c => c.getString("key") -> c.getString("value"))
+          .toMap
+      }
+
+    config.getString("conversion") match {
+      case "timer"        => newDist(config, "totalTime", tags)
+      case "timer-millis" => milliTimer(config, tags)
+      case "dist-summary" => newDist(config, "totalAmount", tags)
+      case cnv            => List(newMetricDef(config, cnv, tags))
+    }
+  }
+
+  /**
+    * Note, count must come first so it is easy to skip for other unit conversions. See
+    * [[milliTimer]] for example.
+    */
+  private def newDist(config: Config, total: String, tags: Tags): List[MetricDefinition] = {
+    List(
+      newMetricDef(config, "count,rate", tags + ("statistic" -> "count")),
+      newMetricDef(config, "sum,rate", tags + ("statistic"   -> total)),
+      newMetricDef(config, "max", tags + ("statistic"        -> "max"))
+    )
+  }
+
+  /**
+    * Timer where the input unit is milliseconds and we need to perform an unit conversion
+    * on the totalTime and max results.
+    */
+  private def milliTimer(config: Config, tags: Tags): List[MetricDefinition] = {
+    val ms = newDist(config, "totalTime", tags)
+    ms.head :: ms.tail.map { m =>
+      m.copy(conversion = Conversions.toUnit(m.conversion, StandardUnit.MILLISECONDS))
+    }
+  }
+
+  private def newMetricDef(config: Config, cnv: String, tags: Tags): MetricDefinition = {
+    val dstype = Map(TagKey.dsType -> Conversions.determineDsType(cnv))
+    val monotonic = config.hasPath("monotonic") && config.getBoolean("monotonic")
+    MetricDefinition(
+      name = config.getString("name"),
+      alias = config.getString("alias"),
+      conversion = Conversions.fromName(cnv),
+      monotonicValue = monotonic,
+      tags = tags ++ dstype
+    )
+  }
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricMetadata.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricMetadata.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsRequest
+import software.amazon.awssdk.services.cloudwatch.model.Statistic
+
+import java.time.Instant
+
+/**
+  * Metadata for a particular metric to retrieve from CloudWatch.
+  */
+case class MetricMetadata(
+  category: MetricCategory,
+  definition: MetricDefinition,
+  dimensions: List[Dimension]
+) {
+
+  def convert(d: Datapoint): Double = definition.conversion(this, d)
+
+  def toGetRequest(s: Instant, e: Instant): GetMetricStatisticsRequest = {
+    import scala.jdk.CollectionConverters._
+    GetMetricStatisticsRequest
+      .builder()
+      .metricName(definition.name)
+      .namespace(category.namespace)
+      .dimensions(dimensions.asJava)
+      .statistics(Statistic.MAXIMUM, Statistic.MINIMUM, Statistic.SUM, Statistic.SAMPLE_COUNT)
+      .period(category.period)
+      .startTime(s)
+      .endTime(e)
+      .build()
+  }
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/NetflixTagger.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/NetflixTagger.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.netflix.frigga.Names
+import com.typesafe.config.Config
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+
+/**
+  * Tag the datapoints using Frigga to extract app and cluster information based
+  * on naming conventions used by Spinnaker and Asgard.
+  */
+class NetflixTagger(config: Config) extends DefaultTagger(config) {
+  import scala.jdk.CollectionConverters._
+
+  private val keys = config.getStringList("netflix-keys").asScala
+
+  private def opt(k: String, s: String): Option[(String, String)] = {
+    Option(s).filter(_ != "").map(v => k -> v)
+  }
+
+  override def apply(dimensions: List[Dimension]): Map[String, String] = {
+    val baseTags = super.apply(dimensions)
+    val extractedTags = keys.flatMap { k =>
+      baseTags.get(k).map { v =>
+        val name = Names.parseName(v)
+        List(
+          opt("nf.app", name.getApp),
+          opt("nf.cluster", name.getCluster),
+          opt("nf.stack", name.getStack)
+        ).flatten
+      }
+    }
+    extractedTags.flatten.toMap ++ baseTags
+  }
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/package.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/package.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas
+
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+
+/**
+  * Helper types used in this package.
+  */
+package object cloudwatch {
+  type Tags = Map[String, String]
+
+  /**
+    * Converts a list of cloudwatch dimensions into a tag map that can be used
+    * for Atlas.
+    */
+  type Tagger = List[Dimension] => Tags
+
+  /**
+    * Converts a cloudwatch datapoint to a floating point value. The conversion is
+    * based on the corresponding [[MetricDefinition]]. The full metadata is passed
+    * in to allow access to other information that can be useful, such as the period
+    * used for reporting the data into cloudwatch.
+    */
+  type Conversion = (MetricMetadata, Datapoint) => Double
+
+  type AtlasDatapoint = com.netflix.atlas.core.model.Datapoint
+  type MList = scala.collection.mutable.ListBuffer[AtlasDatapoint]
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/guice/CloudWatchModule.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/guice/CloudWatchModule.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.guice
+
+import javax.inject.Singleton
+import com.google.inject.AbstractModule
+import com.google.inject.Provides
+import com.netflix.atlas.akka.AkkaModule
+import com.netflix.iep.aws2.AwsClientFactory
+import com.netflix.iep.aws2.AwsModule
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
+
+/**
+  * Configures the binding for the cloudwatch client and poller.
+  */
+final class CloudWatchModule extends AbstractModule {
+
+  override def configure(): Unit = {
+    install(new AkkaModule)
+    install(new AwsModule)
+  }
+
+  @Provides
+  @Singleton
+  protected def provideCloudWatchClient(factory: AwsClientFactory): CloudWatchClient = {
+    factory.newInstance(classOf[CloudWatchClient])
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj != null && getClass.equals(obj.getClass)
+  }
+
+  override def hashCode(): Int = getClass.hashCode()
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/poller/ClientActor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/poller/ClientActor.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.poller
+
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.HttpMethods
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.MediaTypes
+import akka.http.scaladsl.model.headers._
+import akka.stream.Materializer
+import com.netflix.atlas.akka.AccessLogger
+import com.netflix.atlas.akka.CustomMediaTypes
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.json.Json
+import com.netflix.atlas.poller.Messages.MetricsPayload
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.impl.AsciiSet
+import com.typesafe.config.Config
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+
+/**
+  * Sink for the poller data that publishes the metrics to Atlas. The actor expects
+  * [[Messages.MetricsPayload]] messages and does not send a response. Failures will
+  * be logged and reflected in the `atlas.client.dropped` counter as well as standard
+  * client access logging.
+  */
+class ClientActor(registry: Registry, config: Config, implicit val materializer: Materializer)
+    extends Actor {
+
+  private implicit val xc = scala.concurrent.ExecutionContext.global
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private val uri = config.getString("uri")
+  private val batchSize = config.getInt("batch-size")
+
+  private val shouldSendAck = config.getBoolean("send-ack")
+
+  private val validTagChars = AsciiSet.fromPattern(config.getString("valid-tag-characters"))
+
+  private val validTagValueChars = {
+    import scala.jdk.CollectionConverters._
+    config
+      .getConfigList("valid-tag-value-characters")
+      .asScala
+      .map { cfg =>
+        cfg.getString("key") -> AsciiSet.fromPattern(cfg.getString("value"))
+      }
+      .toMap
+  }
+
+  private val datapointsSent = registry.counter("atlas.client.sent")
+  private val datapointsDropped = registry.createId("atlas.client.dropped")
+
+  def receive: Receive = {
+    case MetricsPayload(_, ms) =>
+      val responder = sender()
+      datapointsSent.increment(ms.size)
+      ms.grouped(batchSize).foreach { batch =>
+        val msg = MetricsPayload(metrics = batch.map(fixTags))
+        post(msg).onComplete {
+          case Success(response) => handleResponse(responder, response, batch.size)
+          case Failure(t)        => handleFailure(responder, t, batch.size)
+        }
+      }
+  }
+
+  private def fixTags(d: Datapoint): Datapoint = {
+    val tags = d.tags.map {
+      case (k, v) =>
+        val nk = validTagChars.replaceNonMembers(k, '_')
+        val nv = validTagValueChars.getOrElse(nk, validTagChars).replaceNonMembers(v, '_')
+        nk -> nv
+    }
+    d.copy(tags = tags)
+  }
+
+  private def post(data: MetricsPayload): Future[HttpResponse] = {
+    post(Json.smileEncode(data))
+  }
+
+  /**
+    * Encode the data and start post to atlas. Method is protected to allow for
+    * easier testing.
+    */
+  protected def post(data: Array[Byte]): Future[HttpResponse] = {
+    val request = HttpRequest(
+      HttpMethods.POST,
+      uri = uri,
+      headers = ClientActor.headers,
+      entity = HttpEntity(CustomMediaTypes.`application/x-jackson-smile`, data)
+    )
+    val accessLogger = AccessLogger.newClientLogger("atlas_publish", request)
+    Http()(context.system).singleRequest(request).andThen { case t => accessLogger.complete(t) }
+  }
+
+  private def handleResponse(responder: ActorRef, response: HttpResponse, size: Int): Unit = {
+    response.status.intValue match {
+      case 200 => // All is well
+        response.discardEntityBytes()
+      case 202 => // Partial failure
+        val id = datapointsDropped.withTag("id", "PartialFailure")
+        incrementFailureCount(id, response, size)
+      case 400 => // Bad message, all data dropped
+        val id = datapointsDropped.withTag("id", "CompleteFailure")
+        incrementFailureCount(id, response, size)
+      case v => // Unexpected, assume all dropped
+        response.discardEntityBytes()
+        val id = datapointsDropped.withTag("id", s"Status_$v")
+        registry.counter(id).increment(size)
+    }
+    if (shouldSendAck) responder ! Messages.Ack
+  }
+
+  private def incrementFailureCount(id: Id, response: HttpResponse, size: Int): Unit = {
+    response.entity.dataBytes.runReduce(_ ++ _).onComplete {
+      case Success(bs) =>
+        val msg = Json.decode[Messages.FailureResponse](bs.toArray)
+        msg.message.headOption.foreach { reason =>
+          logger.warn("failed to validate some datapoints, first reason: {}", reason)
+        }
+        registry.counter(id).increment(msg.errorCount)
+      case Failure(_) =>
+        registry.counter(id).increment(size)
+    }
+  }
+
+  private def handleFailure(responder: ActorRef, t: Throwable, size: Int): Unit = {
+    val id = datapointsDropped.withTag("id", t.getClass.getSimpleName)
+    registry.counter(id).increment(size)
+    if (shouldSendAck) responder ! Messages.Ack
+  }
+}
+
+object ClientActor {
+  private val gzip = HttpEncodingRange(HttpEncodings.gzip)
+  private val headers = List(`Accept-Encoding`(gzip), Accept(MediaTypes.`application/json`))
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/poller/Messages.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/poller/Messages.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.poller
+
+import com.netflix.atlas.core.model.Datapoint
+
+/**
+  * Messages used for polling actors.
+  */
+object Messages {
+
+  /**
+    * Sent by the ClientActor to the sender to indicate that the message was sent out. This
+    * can be disabled using the `atlas.poller.sink.send-ack` property.
+    */
+  case object Ack
+
+  /**
+    * Sent by the PollerManager to pollers to request data. Pollers should respond with
+    * a MetricsPayload.
+    */
+  case object Tick
+
+  /**
+    * Metrics payload that pollers will send back to the manager.
+    *
+    * @param tags
+    *     Common tags that should get added to all metrics in the payload.
+    * @param metrics
+    *     Metrics collected by the poller.
+    */
+  case class MetricsPayload(tags: Map[String, String] = Map.empty, metrics: List[Datapoint] = Nil)
+
+  /**
+    * Represents a failure response message from the publish endpoint.
+    *
+    * @param `type`
+    *     Message type. Should always be "error".
+    * @param errorCount
+    *     Number of datapoints that failed validation.
+    * @param message
+    *     Reasons for why datapoints were dropped.
+    */
+  case class FailureResponse(`type`: String, errorCount: Int, message: List[String])
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/poller/PollerManager.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/poller/PollerManager.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.poller
+
+import java.lang.reflect.Type
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+import akka.actor.Actor
+import akka.actor.ActorInitializationException
+import akka.actor.ActorPath
+import akka.actor.ActorRef
+import akka.actor.OneForOneStrategy
+import akka.actor.Props
+import akka.actor.SupervisorStrategy
+import com.netflix.iep.service.ClassFactory
+import com.netflix.spectator.api.Functions
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.patterns.PolledMeter
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+
+/**
+  * Manager for a set of poller actors. The manager will send a Tick message to the pollers
+  * at a regular interval. The pollers should send by a MetricsPayload with the data
+  * collected.
+  */
+class PollerManager(registry: Registry, classFactory: ClassFactory, config: Config)
+    extends Actor
+    with StrictLogging {
+
+  import scala.concurrent.duration._
+  private implicit val xc = scala.concurrent.ExecutionContext.global
+
+  private val pollers = PollerManager.pollers(config)
+  private val lastUpdateTimes = createPollerActors()
+
+  private val sinkRef = createSinkActor()
+
+  override val supervisorStrategy = OneForOneStrategy() {
+    case e: ActorInitializationException =>
+      logger.error(s"initialization failed for ${sender().path}", e)
+      SupervisorStrategy.Escalate
+    case e: Exception =>
+      logRestart(sender().path, e)
+      SupervisorStrategy.Restart
+  }
+
+  val frequency = FiniteDuration(
+    config.getDuration("atlas.poller.frequency", TimeUnit.NANOSECONDS),
+    TimeUnit.NANOSECONDS
+  )
+  context.system.scheduler.scheduleAtFixedRate(frequency, frequency, self, Messages.Tick)
+
+  def receive: Receive = {
+    case Messages.Tick =>
+      pollers.foreach { p =>
+        context.actorSelection(p.name) ! Messages.Tick
+      }
+    case p @ Messages.MetricsPayload(_, ds) =>
+      val name = sender().path.name
+      registry.counter("atlas.poller.datapoints", "id", name).increment(ds.size)
+      lastUpdateTimes.get(name).foreach(_.set(registry.clock().wallTime()))
+      sinkRef ! p
+  }
+
+  private def createPollerActors(): Map[String, AtomicLong] = {
+    val updateTimes = pollers.map { p =>
+      context.actorOf(Props(classFactory.newInstance[Actor](p.cls)), p.name)
+      val updateTime = new AtomicLong(registry.clock().wallTime())
+      PolledMeter
+        .using(registry)
+        .withName("atlas.poller.dataAge")
+        .withTag("id", p.name)
+        .monitorValue(updateTime, Functions.age(registry.clock()))
+      p.name -> updateTime
+    }
+    updateTimes.toMap
+  }
+
+  private def createSinkActor(): ActorRef = {
+    import scala.compat.java8.FunctionConverters._
+    val cfg = config.getConfig("atlas.poller.sink")
+    val cls = cfg.getString("class")
+    val overrides = Map[Type, AnyRef](classOf[Config] -> cfg).withDefaultValue(null)
+    context.actorOf(
+      Props(classFactory.newInstance[Actor](cls, overrides.asJava)),
+      PollerManager.SinkName
+    )
+  }
+
+  private def logRestart(path: ActorPath, e: Exception): Unit = {
+    logger.warn(s"restarting ${path.name}", e)
+    val error = e.getClass.getSimpleName
+    registry.counter("atlas.poller.restarts", "id", path.name, "error", error).increment()
+  }
+}
+
+object PollerManager {
+
+  private val SinkName = "sink"
+
+  private def pollers(config: Config): List[PollerConfig] = {
+    val builder = List.newBuilder[PollerConfig]
+    config.getConfigList("atlas.poller.pollers").forEach { cfg =>
+      builder += PollerConfig(s"poller-${cfg.getString("name")}", cfg.getString("class"))
+    }
+    builder.result()
+  }
+
+  case class PollerConfig(name: String, cls: String)
+}

--- a/atlas-cloudwatch/src/test/resources/application.conf
+++ b/atlas-cloudwatch/src/test/resources/application.conf
@@ -1,0 +1,13 @@
+
+atlas.poller {
+
+  // Set to a large value because we don't want it running during tests
+  frequency = 60 minutes
+
+  pollers = [
+    {
+      name = "cloudwatch"
+      class = "com.netflix.atlas.cloudwatch.CloudWatchPoller"
+    }
+  ]
+}

--- a/atlas-cloudwatch/src/test/resources/local.conf
+++ b/atlas-cloudwatch/src/test/resources/local.conf
@@ -1,0 +1,12 @@
+
+atlas.poller {
+
+  frequency = 10 s
+
+  pollers = [
+    {
+      name = "cloudwatch"
+      class = "com.netflix.atlas.cloudwatch.CloudWatchPoller"
+    }
+  ]
+}

--- a/atlas-cloudwatch/src/test/resources/log4j2.xml
+++ b/atlas-cloudwatch/src/test/resources/log4j2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn">
+    <Properties>
+        <Property name="dfltPattern">%d{yyyy-MM-dd'T'HH:mm:ss.SSS} %-5level [%t] %class: %msg%n</Property>
+    </Properties>
+    <Appenders>
+        <Console name="STDERR" target="SYSTEM_ERR">
+            <PatternLayout pattern="${dfltPattern}"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.netflix.spectator" level="debug"/>
+        <Logger name="com.netflix.atlas" level="info"/>
+        <Root level="info">
+            <AppenderRef ref="STDERR"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/atlas-cloudwatch/src/test/resources/poll-mgr.conf
+++ b/atlas-cloudwatch/src/test/resources/poll-mgr.conf
@@ -1,0 +1,18 @@
+atlas.poller {
+
+  // Set to a large value because we don't want it running during tests
+  frequency = 60 minutes
+
+  sink = {
+    class = "com.netflix.atlas.poller.TestActor"
+    url = "http://localhost:7101/api/v1/publish"
+    send-ack = true
+  }
+
+  pollers = [
+    {
+      name = "test"
+      class = "com.netflix.atlas.poller.TestActor"
+    }
+  ]
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.netflix.atlas.core.model.Query
+import org.scalatest.funsuite.AnyFunSuite
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+
+import java.time.Instant
+
+class ConversionsSuite extends AnyFunSuite {
+
+  private val dp = Datapoint
+    .builder()
+    .minimum(1.0)
+    .maximum(5.0)
+    .sum(6.0)
+    .sampleCount(2.0)
+    .timestamp(Instant.now())
+    .unit(StandardUnit.NONE)
+    .build()
+
+  private def newDatapoint(v: Double, unit: StandardUnit = StandardUnit.NONE): Datapoint = {
+    Datapoint
+      .builder()
+      .minimum(v)
+      .maximum(v)
+      .sum(v)
+      .sampleCount(1.0)
+      .timestamp(Instant.now())
+      .unit(unit)
+      .build()
+  }
+
+  test("min") {
+    val cnv = Conversions.fromName("min")
+    val v = cnv(null, dp)
+    assert(v === 1.0)
+  }
+
+  test("max") {
+    val cnv = Conversions.fromName("max")
+    val v = cnv(null, dp)
+    assert(v === 5.0)
+  }
+
+  test("sum") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, dp)
+    assert(v === 6.0)
+  }
+
+  test("count") {
+    val cnv = Conversions.fromName("count")
+    val v = cnv(null, dp)
+    assert(v === 2.0)
+  }
+
+  test("avg") {
+    val cnv = Conversions.fromName("avg")
+    val v = cnv(null, dp)
+    assert(v === 3.0)
+  }
+
+  test("rate") {
+    val cnv = Conversions.fromName("sum,rate")
+    val meta = MetricMetadata(
+      MetricCategory("NFLX/Test", 300, 1, 3, None, Nil, Nil, Query.True),
+      MetricDefinition("test", "test-alias", cnv, false, Map.empty),
+      Nil
+    )
+    val v = cnv(meta, dp)
+    assert(v === 6.0 / 300.0)
+  }
+
+  test("rate already") {
+    val cnv = Conversions.fromName("sum,rate")
+    val meta = MetricMetadata(
+      MetricCategory("NFLX/Test", 300, 1, 3, None, Nil, Nil, Query.True),
+      MetricDefinition("test", "test-alias", cnv, false, Map.empty),
+      Nil
+    )
+    val v = cnv(meta, newDatapoint(6.0, StandardUnit.BYTES_SECOND))
+    assert(v === 6.0)
+  }
+
+  test("bad conversion") {
+    intercept[IllegalArgumentException] {
+      Conversions.fromName("foo")
+    }
+  }
+
+  test("empty conversion") {
+    intercept[IllegalArgumentException] {
+      Conversions.fromName("")
+    }
+  }
+
+  test("missing conversion") {
+    intercept[IllegalArgumentException] {
+      Conversions.fromName("rate") // Rate must be used with another conversion
+    }
+  }
+
+  test("unit count") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.COUNT))
+    assert(v === 42.0)
+  }
+
+  test("unit bits") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.BITS))
+    assert(v === 42.0 / 8.0)
+  }
+
+  test("unit kilobits") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.KILOBITS))
+    assert(v === 1e3 * 42.0 / 8.0)
+  }
+
+  test("unit megabits") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.MEGABITS))
+    assert(v === 1e6 * 42.0 / 8.0)
+  }
+
+  test("unit gigabits") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.GIGABITS))
+    assert(v === 1e9 * 42.0 / 8.0)
+  }
+
+  test("unit terabits") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.TERABITS))
+    assert(v === 1e12 * 42.0 / 8.0)
+  }
+
+  test("unit bytes") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.BYTES))
+    assert(v === 42.0)
+  }
+
+  test("unit kilobytes") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.KILOBYTES))
+    assert(v === 1e3 * 42.0)
+  }
+
+  test("unit megabytes") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.MEGABYTES))
+    assert(v === 1e6 * 42.0)
+  }
+
+  test("unit gigabytes") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.GIGABYTES))
+    assert(v === 1e9 * 42.0)
+  }
+
+  test("unit terabytes") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.TERABYTES))
+    assert(v === 1e12 * 42.0)
+  }
+
+  test("unit bits/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.BITS_SECOND))
+    assert(v === 42.0 / 8.0)
+  }
+
+  test("unit kilobits/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.KILOBITS_SECOND))
+    assert(v === 1e3 * 42.0 / 8.0)
+  }
+
+  test("unit megabits/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.MEGABITS_SECOND))
+    assert(v === 1e6 * 42.0 / 8.0)
+  }
+
+  test("unit gigabits/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.GIGABITS_SECOND))
+    assert(v === 1e9 * 42.0 / 8.0)
+  }
+
+  test("unit terabits/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.TERABITS_SECOND))
+    assert(v === 1e12 * 42.0 / 8.0)
+  }
+
+  test("unit bytes/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.BYTES_SECOND))
+    assert(v === 42.0)
+  }
+
+  test("unit kilobytes/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.KILOBYTES_SECOND))
+    assert(v === 1e3 * 42.0)
+  }
+
+  test("unit megabytes/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.MEGABYTES_SECOND))
+    assert(v === 1e6 * 42.0)
+  }
+
+  test("unit gigabytes/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.GIGABYTES_SECOND))
+    assert(v === 1e9 * 42.0)
+  }
+
+  test("unit terabytes/second") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.TERABYTES_SECOND))
+    assert(v === 1e12 * 42.0)
+  }
+
+  test("unit microseconds") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.MICROSECONDS))
+    assert(v === 1e-6 * 42.0)
+  }
+
+  test("unit milliseconds") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.MILLISECONDS))
+    assert(v === 1e-3 * 42.0)
+  }
+
+  test("unit seconds") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.SECONDS))
+    assert(v === 42.0)
+  }
+
+  test("unit percent") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.PERCENT))
+    assert(v === 42.0)
+  }
+
+  test("ratio to percent") {
+    val cnv = Conversions.fromName("sum,percent")
+    val v = cnv(null, newDatapoint(0.42, StandardUnit.PERCENT))
+    assert(v === 42.0)
+  }
+
+  test("unit none") {
+    val cnv = Conversions.fromName("sum")
+    val v = cnv(null, newDatapoint(42.0, StandardUnit.NONE))
+    assert(v === 42.0)
+  }
+
+  test("multiply") {
+    val cnv = Conversions.multiply(Conversions.fromName("sum"), 100.0)
+    val v = cnv(null, newDatapoint(42.0))
+    assert(v === 4200.0)
+  }
+
+  test("dstype for max") {
+    assert(Conversions.determineDsType("max") === "gauge")
+  }
+
+  test("dstype for sum") {
+    assert(Conversions.determineDsType("sum") === "gauge")
+  }
+
+  test("dstype for count") {
+    assert(Conversions.determineDsType("count") === "gauge")
+  }
+
+  test("dstype for sum,rate") {
+    assert(Conversions.determineDsType("sum,rate") === "rate")
+  }
+
+  test("dstype for count,rate") {
+    assert(Conversions.determineDsType("count,rate") === "rate")
+  }
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import java.util.regex.PatternSyntaxException
+import com.typesafe.config.ConfigException
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funsuite.AnyFunSuite
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+
+class DefaultTaggerSuite extends AnyFunSuite {
+
+  private val dimensions = List(
+    Dimension.builder().name("CloudWatch").value("abc").build(),
+    Dimension.builder().name("ExtractDotDelimited").value("abc.def.captured-portion").build(),
+    Dimension
+      .builder()
+      .name("ExtractSlashDelimited")
+      .value("abc/captured-portion/42beef9876")
+      .build(),
+    Dimension.builder().name("NoMapping").value("def").build()
+  )
+
+  test("bad config") {
+    val cfg = ConfigFactory.parseString("")
+    intercept[ConfigException] {
+      new DefaultTagger(cfg)
+    }
+  }
+
+  test("add common tags") {
+    val cfg = ConfigFactory.parseString("""
+        |extractors = []
+        |mappings = []
+        |common-tags = [
+        |  {
+        |    key = "foo"
+        |    value = "bar"
+        |  }
+        |]
+      """.stripMargin)
+
+    val expected = Map(
+      "foo"                   -> "bar",
+      "CloudWatch"            -> "abc",
+      "ExtractDotDelimited"   -> "abc.def.captured-portion",
+      "ExtractSlashDelimited" -> "abc/captured-portion/42beef9876",
+      "NoMapping"             -> "def"
+    )
+
+    val tagger = new DefaultTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+
+  test("apply key mappings") {
+    val cfg = ConfigFactory.parseString("""
+        |extractors = []
+        |mappings = [
+        |  {
+        |    name = "CloudWatch"
+        |    alias = "InternalAlias"
+        |  }
+        |]
+        |common-tags = []
+      """.stripMargin)
+
+    val expected = Map(
+      "ExtractDotDelimited"   -> "abc.def.captured-portion",
+      "ExtractSlashDelimited" -> "abc/captured-portion/42beef9876",
+      "InternalAlias"         -> "abc",
+      "NoMapping"             -> "def"
+    )
+
+    val tagger = new DefaultTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+
+  test("extract value for configured keys") {
+    val cfg = ConfigFactory.parseString("""
+        |extractors = [
+        |  {
+        |    name = "ExtractDotDelimited"
+        |    directives = [
+        |      {
+        |        pattern = "[^.]+\\.[^.]+\\.(.*)"
+        |      }
+        |    ]
+        |  },
+        |  {
+        |    name = "ExtractSlashDelimited"
+        |    directives = [
+        |      {
+        |        pattern = "[^.]+/([^.]+)/.*"
+        |      }
+        |    ]
+        |  }
+        |]
+        |mappings = []
+        |common-tags = []
+      """.stripMargin)
+
+    val expected = Map(
+      "ExtractDotDelimited"   -> "captured-portion",
+      "ExtractSlashDelimited" -> "captured-portion",
+      "CloudWatch"            -> "abc",
+      "NoMapping"             -> "def"
+    )
+
+    val tagger = new DefaultTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+
+  test("syntax error in extractor pattern throws") {
+    val cfg = ConfigFactory.parseString("""
+        |extractors = [
+        |  {
+        |    name = "ExtractDotDelimited"
+        |    directives = [
+        |      {
+        |        pattern = "[^.]+\\.[^.]+\\.(.*"
+        |      }
+        |    ]
+        |  }
+        |]
+        |mappings = []
+        |common-tags = []
+      """.stripMargin)
+
+    intercept[PatternSyntaxException] {
+      new DefaultTagger(cfg)
+    }
+  }
+
+  test("missing pattern in extractor throws") {
+    val cfg = ConfigFactory.parseString("""
+        |extractors = [
+        |  {
+        |    name = "ExtractDotDelimited"
+        |    directives = [
+        |      {
+        |        alias = "new-name"
+        |      }
+        |    ]
+        |  }
+        |]
+        |mappings = []
+        |common-tags = []
+      """.stripMargin)
+
+    intercept[ConfigException.Missing] {
+      new DefaultTagger(cfg)
+    }
+  }
+
+  test("extractor without capture group returns raw value") {
+    val cfg = ConfigFactory.parseString("""
+        |extractors = [
+        |  {
+        |    name = "ExtractDotDelimited"
+        |    directives = [
+        |      {
+        |        pattern = "[^.]+\\.[^.]+\\..*"
+        |      }
+        |    ]
+        |  }
+        |]
+        |mappings = []
+        |common-tags = []
+      """.stripMargin)
+
+    val expected = Map(
+      "ExtractDotDelimited"   -> "abc.def.captured-portion",
+      "ExtractSlashDelimited" -> "abc/captured-portion/42beef9876",
+      "CloudWatch"            -> "abc",
+      "NoMapping"             -> "def"
+    )
+
+    val tagger = new DefaultTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+
+  test("extract value and apply alias for configured keys") {
+    val cfg = ConfigFactory.parseString("""
+        |extractors = [
+        |  {
+        |    name = "ExtractDotDelimited"
+        |    directives = [
+        |      {
+        |        pattern = "[^.]+\\.[^.]+\\.(.*)"
+        |      }
+        |    ]
+        |  },
+        |  {
+        |    name = "ExtractSlashDelimited"
+        |    directives = [
+        |      {
+        |        pattern = "[^.]+/([^.]+)/.*"
+        |        alias = "extracted"
+        |      }
+        |    ]
+        |  }
+        |]
+        |mappings = []
+        |common-tags = []
+      """.stripMargin)
+
+    val expected = Map(
+      "ExtractDotDelimited" -> "captured-portion",
+      "extracted"           -> "captured-portion",
+      "CloudWatch"          -> "abc",
+      "NoMapping"           -> "def"
+    )
+
+    val tagger = new DefaultTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+
+  test("mapping is ignored if extractor of the same name exists") {
+    val cfg = ConfigFactory.parseString("""
+        |extractors = [
+        |  {
+        |    name = "ExtractSlashDelimited"
+        |    directives = [
+        |      {
+        |        pattern = "[^.]+/([^.]+)/.*"
+        |        alias = "extracted"
+        |      }
+        |    ]
+        |  }
+        |]
+        |mappings = [
+        |  {
+        |    name = "ExtractSlashDelimited"
+        |    alias = "ignored"
+        |  }
+        |]
+        |common-tags = []
+      """.stripMargin)
+
+    val expected = Map(
+      "ExtractDotDelimited" -> "abc.def.captured-portion",
+      "extracted"           -> "captured-portion",
+      "CloudWatch"          -> "abc",
+      "NoMapping"           -> "def"
+    )
+
+    val tagger = new DefaultTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+
+  test("first extractor pattern has precedence") {
+    val cfg = ConfigFactory.parseString("""
+        |extractors = [
+        |  {
+        |    name = "ExtractSlashDelimited"
+        |    directives = [
+        |      {
+        |        pattern = "[^.]+/([^.]+)/.*"
+        |        alias = "extracted"
+        |      },
+        |      {
+        |        pattern = "[^.]+/[^.]+/(.*)"
+        |        alias = "ignored"
+        |      }
+        |
+        |    ]
+        |  }
+        |]
+        |mappings = []
+        |common-tags = []
+      """.stripMargin)
+
+    val expected = Map(
+      "ExtractDotDelimited" -> "abc.def.captured-portion",
+      "extracted"           -> "captured-portion",
+      "CloudWatch"          -> "abc",
+      "NoMapping"           -> "def"
+    )
+
+    val tagger = new DefaultTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+
+  test("dimensions override common tags") {
+    val cfg = ConfigFactory.parseString("""
+        |extractors = []
+        |mappings = [
+        |  {
+        |    name = "CloudWatch"
+        |    alias = "foo"
+        |  }
+        |]
+        |common-tags = [
+        |  {
+        |    key = "foo"
+        |    value = "bar"
+        |  }
+        |]
+      """.stripMargin)
+
+    val expected = Map(
+      "ExtractDotDelimited"   -> "abc.def.captured-portion",
+      "ExtractSlashDelimited" -> "abc/captured-portion/42beef9876",
+      "foo"                   -> "abc",
+      "NoMapping"             -> "def"
+    )
+
+    val tagger = new DefaultTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+
+  test("aws.alb is assigned to LoadBalancer names starting with 'app' using production config") {
+    val cfg = ConfigFactory.parseResources("reference.conf").resolve()
+    val tagger = new DefaultTagger(cfg.getConfig("atlas.cloudwatch.tagger"))
+
+    val expected = Map(
+      "aws.alb"   -> "captured-portion",
+      "nf.region" -> "us-west-2"
+    )
+
+    val actual = tagger(
+      List(
+        Dimension.builder().name("LoadBalancer").value("app/captured-portion/42beef9876").build()
+      )
+    )
+
+    assert(actual === expected)
+  }
+
+  test("aws.nlb is assigned to LoadBalancer names starting with 'net' using production config") {
+    val cfg = ConfigFactory.parseResources("reference.conf").resolve()
+    val tagger = new DefaultTagger(cfg.getConfig("atlas.cloudwatch.tagger"))
+
+    val expected = Map(
+      "aws.nlb"   -> "captured-portion",
+      "nf.region" -> "us-west-2"
+    )
+
+    val actual = tagger(
+      List(
+        Dimension.builder().name("LoadBalancer").value("net/captured-portion/42beef9876").build()
+      )
+    )
+
+    assert(actual === expected)
+  }
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import java.time.Duration
+
+import com.netflix.atlas.core.model.Query
+import com.typesafe.config.ConfigException
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funsuite.AnyFunSuite
+
+class MetricCategorySuite extends AnyFunSuite {
+  test("bad config") {
+    val cfg = ConfigFactory.empty()
+    intercept[ConfigException] {
+      MetricCategory.fromConfig(cfg)
+    }
+  }
+
+  test("production config loads") {
+    val cfg = ConfigFactory.parseResources("reference.conf").resolve()
+    val categories = CloudWatchPoller.getCategories(cfg)
+    assert(categories.nonEmpty)
+  }
+
+  test("load category with empty dimensions succeeds") {
+    val cfg = ConfigFactory.parseString("""
+        |      namespace = "AWS/Lambda"
+        |      period = 1m
+        |
+        |      dimensions = []
+        |
+        |      metrics = [
+        |        {
+        |          name = "UnreservedConcurrentExecutions"
+        |          alias = "aws.lambda.concurrentExecutions"
+        |          conversion = "max"
+        |          tags = [
+        |            {
+        |              key = "concurrencyLimit"
+        |              value = "unreserved"
+        |            }
+        |          ]
+        |        },
+        |      ]
+      """.stripMargin)
+
+    val category = MetricCategory.fromConfig(cfg)
+    assert(category.namespace === "AWS/Lambda")
+    assert(category.dimensions.isEmpty)
+  }
+
+  test("load category with no dimensions throws") {
+    val cfg = ConfigFactory.parseString("""
+        |      namespace = "AWS/Lambda"
+        |      period = 1m
+        |
+        |      metrics = [
+        |        {
+        |          name = "UnreservedConcurrentExecutions"
+        |          alias = "aws.lambda.concurrentExecutions"
+        |          conversion = "max"
+        |          tags = [
+        |            {
+        |              key = "concurrencyLimit"
+        |              value = "unreserved"
+        |            }
+        |          ]
+        |        },
+        |      ]
+      """.stripMargin)
+
+    intercept[ConfigException.Missing] {
+      MetricCategory.fromConfig(cfg)
+    }
+  }
+
+  test("load from config") {
+    val cfg = ConfigFactory.parseString("""
+        |namespace = "AWS/ELB"
+        |period = 1 m
+        |dimensions = ["LoadBalancerName"]
+        |metrics = [
+        |  {
+        |    name = "RequestCount"
+        |    alias = "aws.elb.requests"
+        |    conversion = "sum,rate"
+        |  },
+        |  {
+        |    name = "HTTPCode_ELB_4XX"
+        |    alias = "aws.elb.errors"
+        |    conversion = "sum,rate"
+        |    tags = [
+        |      {
+        |        key = "status"
+        |        value = "4xx"
+        |      }
+        |    ]
+        |  }
+        |]
+      """.stripMargin)
+
+    val category = MetricCategory.fromConfig(cfg)
+    assert(category.namespace === "AWS/ELB")
+    assert(category.period === 60)
+    assert(category.toListRequests.size === 2)
+    assert(category.filter === Query.True)
+  }
+
+  test("category without timeout") {
+    val cfg = ConfigFactory.parseString("""
+        |namespace = "AWS/ELB"
+        |period = 1 m
+        |dimensions = ["LoadBalancerName"]
+        |metrics = []
+      """.stripMargin)
+
+    val category = MetricCategory.fromConfig(cfg)
+    assert(category.timeout.isEmpty)
+  }
+
+  test("category with timeout") {
+    val cfg = ConfigFactory.parseString("""
+        |namespace = "AWS/ELB"
+        |period = 1 m
+        |timeout = 1d
+        |dimensions = ["LoadBalancerName"]
+        |metrics = []
+      """.stripMargin)
+
+    val category = MetricCategory.fromConfig(cfg)
+    assert(category.timeout.nonEmpty)
+    assert(category.timeout.get === Duration.ofDays(1))
+  }
+
+  test("config with filter") {
+    val cfg = ConfigFactory.parseString("""
+        |namespace = "AWS/ELB"
+        |period = 1 m
+        |dimensions = ["LoadBalancerName"]
+        |metrics = [
+        |  {
+        |    name = "RequestCount"
+        |    alias = "aws.elb.requests"
+        |    conversion = "sum,rate"
+        |  }
+        |]
+        |filter = "name,RequestCount,:eq"
+      """.stripMargin)
+
+    val category = MetricCategory.fromConfig(cfg)
+    assert(category.filter === Query.Equal("name", "RequestCount"))
+  }
+
+  test("config with invalid filter") {
+    val cfg = ConfigFactory.parseString("""
+        |namespace = "AWS/ELB"
+        |period = 1 m
+        |dimensions = ["LoadBalancerName"]
+        |metrics = [
+        |  {
+        |    name = "RequestCount"
+        |    alias = "aws.elb.requests"
+        |    conversion = "sum,rate"
+        |  }
+        |]
+        |filter = "name,:invalid-command"
+      """.stripMargin)
+
+    intercept[IllegalStateException] {
+      MetricCategory.fromConfig(cfg)
+    }
+  }
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDataSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDataSuite.scala
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import java.time.Duration
+import java.time.Instant
+import com.netflix.atlas.cloudwatch.CloudWatchPoller.MetricData
+import com.netflix.atlas.core.model.Query
+import org.scalatest.funsuite.AnyFunSuite
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+
+class MetricDataSuite extends AnyFunSuite {
+
+  private val definition =
+    MetricDefinition("test", "alias", Conversions.fromName("sum"), false, Map.empty)
+
+  private val category =
+    MetricCategory("namespace", 60, 1, 5, None, List("dimension"), List(definition), Query.True)
+  private val metadata = MetricMetadata(category, definition, Nil)
+
+  private val monotonicMetadata = metadata.copy(definition = definition.copy(monotonicValue = true))
+
+  private val metadataWithTimeout =
+    metadata.copy(category = category.copy(timeout = Some(Duration.ofMinutes(2))))
+
+  private def datapoint(v: Double, c: Double = 1.0): Option[Datapoint] = {
+    val d = Datapoint
+      .builder()
+      .minimum(v)
+      .maximum(v)
+      .sum(v * c)
+      .sampleCount(c)
+      .timestamp(Instant.now())
+      .unit(StandardUnit.NONE)
+      .build()
+    Some(d)
+  }
+
+  test("access datapoint with no current value") {
+    val data = MetricData(metadata, None, None, None)
+    assert(data.datapoint().sum === 0.0)
+  }
+
+  test("access datapoint with current value") {
+    val data = MetricData(metadata, None, datapoint(1.0), None)
+    assert(data.datapoint().sum === 1.0)
+  }
+
+  test("category with timeout, first datapoint not yet received") {
+    val now = Instant.now()
+    val data = MetricData(metadataWithTimeout, None, None, None)
+    assert(data.datapoint(now).sum.isNaN)
+  }
+
+  test("category with timeout, datapoint with current value and not timed out") {
+    val now = Instant.now()
+    val data = MetricData(metadataWithTimeout, None, datapoint(1.0), Some(now.minusSeconds(60)))
+    assert(data.datapoint(now).sum === 1.0)
+  }
+
+  // current and timed out shouldn't be possible, but fail open by ensuring the current value is
+  // reported
+  test("category with timeout, datapoint with current value and timed out") {
+    val now = Instant.now()
+    val data = MetricData(metadataWithTimeout, None, datapoint(1.0), Some(now.minusSeconds(600)))
+    assert(data.datapoint(now).sum === 1.0)
+  }
+
+  test("category with timeout, datapoint with current and previous value and not timed out") {
+    val now = Instant.now()
+    val data =
+      MetricData(metadataWithTimeout, datapoint(2.0), datapoint(1.0), Some(now.minusSeconds(60)))
+    assert(data.datapoint(now).sum === 1.0)
+  }
+
+  // current and timed out shouldn't be possible, but fail open by ensuring the current value is
+  // reported
+  test("category with timeout, datapoint with current and previous value and timed out") {
+    val now = Instant.now()
+    val data =
+      MetricData(metadataWithTimeout, datapoint(2.0), datapoint(1.0), Some(now.minusSeconds(600)))
+    assert(data.datapoint(now).sum === 1.0)
+  }
+
+  test("category with timeout, datapoint with only previous value and not timed out") {
+    val now = Instant.now()
+    val data = MetricData(metadataWithTimeout, datapoint(1.0), None, Some(now.minusSeconds(60)))
+    assert(data.datapoint(now).sum === 0.0)
+  }
+
+  test("category with timeout, datapoint with only previous value and timed out") {
+    val now = Instant.now()
+    val data = MetricData(metadataWithTimeout, datapoint(1.0), None, Some(now.minusSeconds(600)))
+    assert(data.datapoint(now).sum.isNaN)
+  }
+
+  test("category with timeout, datapoint with no current or previous value and not timed out") {
+    val now = Instant.now()
+    val data = MetricData(metadataWithTimeout, None, None, Some(now.minusSeconds(60)))
+    assert(data.datapoint(now).sum === 0.0)
+  }
+
+  test("category with timeout, datapoint with no current or previous value and timed out") {
+    val now = Instant.now()
+    val data = MetricData(metadataWithTimeout, None, None, Some(now.minusSeconds(600)))
+    assert(data.datapoint(now).sum.isNaN)
+  }
+
+  test("access monotonic datapoint with no previous or current value") {
+    val data = MetricData(monotonicMetadata, None, None, None)
+    assert(data.datapoint().sum.isNaN)
+  }
+
+  test("access monotonic datapoint with no current value") {
+    val data = MetricData(monotonicMetadata, datapoint(1.0), None, None)
+    assert(data.datapoint().sum.isNaN)
+  }
+
+  test("access monotonic datapoint with no previous value") {
+    val data = MetricData(monotonicMetadata, None, datapoint(1.0), None)
+    assert(data.datapoint().sum.isNaN)
+  }
+
+  test("access monotonic datapoint, current is larger") {
+    val data = MetricData(monotonicMetadata, datapoint(1.0), datapoint(2.0), None)
+    assert(data.datapoint().sum === 1.0)
+  }
+
+  test("access monotonic datapoint, previous is larger") {
+    val data = MetricData(monotonicMetadata, datapoint(2.0), datapoint(1.0), None)
+    assert(data.datapoint().sum === 0.0)
+  }
+
+  test("access monotonic datapoint, previous equals current") {
+    val data = MetricData(monotonicMetadata, datapoint(1.0), datapoint(1.0), None)
+    assert(data.datapoint().sum === 0.0)
+  }
+
+  test("access monotonic datapoint, current is larger, previous dup") {
+    val data = MetricData(monotonicMetadata, datapoint(1.0, 3), datapoint(2.0), None)
+    assert(data.datapoint().sum === 1.0)
+  }
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.netflix.atlas.core.model.Query
+import com.typesafe.config.ConfigException
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
+
+import java.time.Instant
+
+class MetricDefinitionSuite extends AnyFunSuite with Matchers {
+
+  private val meta = MetricMetadata(
+    MetricCategory("AWS/ELB", 60, 1, 5, None, Nil, Nil, Query.True),
+    null,
+    Nil
+  )
+
+  test("bad config") {
+    val cfg = ConfigFactory.empty()
+    intercept[ConfigException] {
+      MetricCategory.fromConfig(cfg)
+    }
+  }
+
+  test("config with no tags") {
+    val cfg = ConfigFactory.parseString("""
+        |name = "RequestCount"
+        |alias = "aws.elb.requests"
+        |conversion = "sum,rate"
+      """.stripMargin)
+
+    val definitions = MetricDefinition.fromConfig(cfg)
+    assert(definitions.size === 1)
+    assert(definitions.head.name === "RequestCount")
+    assert(definitions.head.alias === "aws.elb.requests")
+  }
+
+  test("config with dsytpe rate") {
+    val cfg = ConfigFactory.parseString("""
+        |name = "RequestCount"
+        |alias = "aws.elb.requests"
+        |conversion = "sum,rate"
+      """.stripMargin)
+
+    val definitions = MetricDefinition.fromConfig(cfg)
+    assert(definitions.size === 1)
+    assert(definitions.head.tags === Map("atlas.dstype" -> "rate"))
+  }
+
+  test("config with dsytpe gauge") {
+    val cfg = ConfigFactory.parseString("""
+        |name = "RequestCount"
+        |alias = "aws.elb.requests"
+        |conversion = "sum"
+      """.stripMargin)
+
+    val definitions = MetricDefinition.fromConfig(cfg)
+    assert(definitions.size === 1)
+    assert(definitions.head.tags === Map("atlas.dstype" -> "gauge"))
+  }
+
+  test("config for timer") {
+    val cfg = ConfigFactory.parseString("""
+        |name = "Latency"
+        |alias = "aws.elb.latency"
+        |conversion = "timer"
+      """.stripMargin)
+
+    val definitions = MetricDefinition.fromConfig(cfg)
+    assert(definitions.size === 3)
+    assert(definitions.map(_.tags("statistic")).toSet === Set("totalTime", "count", "max"))
+
+    val dp = Datapoint
+      .builder()
+      .maximum(6.0)
+      .minimum(0.0)
+      .sum(600.0)
+      .sampleCount(1000.0)
+      .unit(StandardUnit.SECONDS)
+      .timestamp(Instant.now())
+      .build()
+
+    definitions.find(_.tags("statistic") == "totalTime").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 10.0)
+    }
+
+    definitions.find(_.tags("statistic") == "count").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 1000.0 / 60.0)
+    }
+
+    definitions.find(_.tags("statistic") == "max").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 6.0)
+    }
+  }
+
+  test("config for timer-millis no unit") {
+    val cfg = ConfigFactory.parseString("""
+        |name = "Latency"
+        |alias = "aws.elb.latency"
+        |conversion = "timer-millis"
+      """.stripMargin)
+
+    val definitions = MetricDefinition.fromConfig(cfg)
+    assert(definitions.size === 3)
+    assert(definitions.map(_.tags("statistic")).toSet === Set("totalTime", "count", "max"))
+
+    val dp = Datapoint
+      .builder()
+      .maximum(6.0)
+      .minimum(0.0)
+      .sum(600.0)
+      .sampleCount(1000.0)
+      .unit(StandardUnit.NONE)
+      .timestamp(Instant.now())
+      .build()
+
+    definitions.find(_.tags("statistic") == "totalTime").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 10.0 / 1000.0)
+    }
+
+    definitions.find(_.tags("statistic") == "count").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 1000.0 / 60.0)
+    }
+
+    definitions.find(_.tags("statistic") == "max").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 6.0 / 1000.0)
+    }
+  }
+
+  test("config for timer-millis correct unit") {
+    val cfg = ConfigFactory.parseString("""
+        |name = "Latency"
+        |alias = "aws.elb.latency"
+        |conversion = "timer-millis"
+      """.stripMargin)
+
+    val definitions = MetricDefinition.fromConfig(cfg)
+    assert(definitions.size === 3)
+    assert(definitions.map(_.tags("statistic")).toSet === Set("totalTime", "count", "max"))
+
+    val dp = Datapoint
+      .builder()
+      .maximum(6.0)
+      .minimum(0.0)
+      .sum(600.0)
+      .sampleCount(1000.0)
+      .unit(StandardUnit.MILLISECONDS)
+      .timestamp(Instant.now())
+      .build()
+
+    definitions.find(_.tags("statistic") == "totalTime").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 10.0 / 1000.0)
+    }
+
+    definitions.find(_.tags("statistic") == "count").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 1000.0 / 60.0)
+    }
+
+    definitions.find(_.tags("statistic") == "max").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 6.0 / 1000.0)
+    }
+  }
+
+  test("config for dist-summary") {
+    val cfg = ConfigFactory.parseString("""
+        |name = "Latency"
+        |alias = "aws.elb.latency"
+        |conversion = "dist-summary"
+      """.stripMargin)
+
+    val definitions = MetricDefinition.fromConfig(cfg)
+    assert(definitions.size === 3)
+    assert(definitions.map(_.tags("statistic")).toSet === Set("totalAmount", "count", "max"))
+
+    val dp = Datapoint
+      .builder()
+      .maximum(6.0)
+      .minimum(0.0)
+      .sum(600.0)
+      .sampleCount(1000.0)
+      .unit(StandardUnit.BYTES)
+      .timestamp(Instant.now())
+      .build()
+
+    definitions.find(_.tags("statistic") == "totalAmount").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 10.0)
+    }
+
+    definitions.find(_.tags("statistic") == "count").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 1000.0 / 60.0)
+    }
+
+    definitions.find(_.tags("statistic") == "max").foreach { d =>
+      val m = meta.copy(definition = d)
+      assert(m.convert(dp) === 6.0)
+    }
+  }
+
+  test("config for max with unit of millis has correct unit") {
+    val cfg = ConfigFactory.parseString("""
+        |name = "ReplicaLagMaximum"
+        |alias = "aws.aurora.replicaLagMaximum"
+        |conversion = "max"
+      """.stripMargin)
+
+    val definitions = MetricDefinition.fromConfig(cfg)
+    assert(definitions.size === 1)
+
+    val definition = definitions.head
+    assert(definition.tags === Map("atlas.dstype" -> "gauge"))
+
+    val dp = Datapoint
+      .builder()
+      .maximum(15.867)
+      .minimum(15.867)
+      .sum(15.867)
+      .sampleCount(1.0)
+      .unit(StandardUnit.MILLISECONDS)
+      .timestamp(Instant.now())
+      .build()
+
+    val metadata = MetricMetadata(
+      MetricCategory("AWS/RDS", 60, 1, 5, None, Nil, Nil, Query.True),
+      definition,
+      Nil
+    )
+
+    metadata.convert(dp) shouldEqual 15.867 / 1000.0 +- 1e-7
+  }
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/NetflixTaggerSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/NetflixTaggerSuite.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.typesafe.config.ConfigException
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funsuite.AnyFunSuite
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+
+class NetflixTaggerSuite extends AnyFunSuite {
+
+  private val dimensions = List(
+    Dimension.builder().name("AutoScalingGroupName").value("app_name-stack-detail-v001").build(),
+    Dimension.builder().name("ClusterName").value("different_name-foo-bar-v002").build()
+  )
+
+  test("production config loads") {
+    val cfg = ConfigFactory.parseResources("reference.conf").resolve()
+
+    val tagger = CloudWatchPoller.getTagger(cfg)
+    val tagged = tagger(
+      List(
+        Dimension.builder().name("aTag").value("aValue").build(),
+        Dimension.builder().name("LinkedAccount").value("12345").build()
+      )
+    )
+    assert(tagged.getOrElse("aTag", "fail") === "aValue")
+    assert(tagged.getOrElse("aws.account", "fail") === "12345")
+  }
+
+  test("bad config") {
+    val cfg = ConfigFactory.parseString("")
+    intercept[ConfigException] {
+      new NetflixTagger(cfg)
+    }
+  }
+
+  test("extract tags using naming conventions") {
+    val cfg = ConfigFactory.parseString("""
+        |extractors = []
+        |mappings = [
+        |  {
+        |    name = "AutoScalingGroupName"
+        |    alias = "nf.asg"
+        |  }
+        |]
+        |common-tags = []
+        |netflix-keys = ["nf.asg"]
+      """.stripMargin)
+
+    val expected = Map(
+      "nf.app"      -> "app_name",
+      "nf.cluster"  -> "app_name-stack-detail",
+      "nf.asg"      -> "app_name-stack-detail-v001",
+      "nf.stack"    -> "stack",
+      "ClusterName" -> "different_name-foo-bar-v002"
+    )
+
+    val tagger = new NetflixTagger(cfg)
+    assert(tagger(dimensions) === expected)
+  }
+
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/guice/CloudWatchModuleSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/guice/CloudWatchModuleSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.guice
+
+import akka.actor.ActorSystem
+import com.google.inject.AbstractModule
+import com.google.inject.Guice
+import com.netflix.atlas.akka.ActorService
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class CloudWatchModuleSuite extends AnyFunSuite {
+
+  test("load module") {
+    val deps = new AbstractModule {
+
+      override def configure(): Unit = {
+        bind(classOf[Config]).toInstance(ConfigFactory.load())
+        bind(classOf[Registry]).toInstance(new DefaultRegistry())
+      }
+    }
+    val injector = Guice.createInjector(deps, new CloudWatchModule, new CloudWatchModule)
+    val actors = injector.getInstance(classOf[ActorService])
+    assert(actors.isHealthy)
+    actors.stop()
+
+    Await.ready(injector.getInstance(classOf[ActorSystem]).terminate(), Duration.Inf)
+  }
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/poller/ClientActorSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/poller/ClientActorSuite.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.poller
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.StatusCodes
+import akka.stream.Materializer
+import akka.testkit.ImplicitSender
+import akka.testkit.TestActorRef
+import akka.testkit.TestKit
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.json.Json
+import com.netflix.atlas.poller.ClientActorSuite.TestClientActor
+import com.netflix.atlas.poller.Messages.MetricsPayload
+import com.netflix.atlas.webapi.PublishApi
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.ManualClock
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuiteLike
+
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+class ClientActorSuite
+    extends TestKit(ActorSystem())
+    with ImplicitSender
+    with AnyFunSuiteLike
+    with BeforeAndAfterAll {
+
+  import scala.concurrent.duration._
+
+  private val clock = new ManualClock()
+  private val registry = new DefaultRegistry(clock)
+  private val config = ConfigFactory.load("poll-mgr.conf").getConfig("atlas.poller.sink")
+  private val materializer = Materializer(system)
+  private val ref = TestActorRef(new TestClientActor(registry, config, materializer))
+
+  override def afterAll(): Unit = {
+    system.terminate()
+  }
+
+  private def waitForCompletion(): Unit = {
+    expectMsgPF(1.minute) { case Messages.Ack => }
+  }
+
+  private def testSend(
+    datapoints: List[Datapoint],
+    numSent: Int,
+    numDropped: Int,
+    batches: Int = 1
+  ): Unit = {
+    val sent = registry.counter("atlas.client.sent")
+
+    val initSent = sent.count()
+
+    ref ! MetricsPayload(metrics = datapoints)
+    (0 until batches).foreach { _ =>
+      waitForCompletion()
+    }
+
+    assert(sent.count() === initSent + numSent)
+  }
+
+  test("publish datapoints, exception") {
+    ref ! Failure(new RuntimeException("fail"))
+    val datapoints = (0 until 10)
+      .map(i => Datapoint(Map("name" -> s"foo_$i"), 0L, i.toDouble))
+      .toList
+    testSend(datapoints, 10, 10)
+  }
+
+  test("publish datapoints, ok") {
+    ref ! Success(HttpResponse(StatusCodes.OK))
+    val datapoints = (0 until 10)
+      .map(i => Datapoint(Map("name" -> s"foo_$i"), 0L, i.toDouble))
+      .toList
+    testSend(datapoints, 10, 0)
+  }
+
+  test("publish datapoints, several batches") {
+    ref ! Success(HttpResponse(StatusCodes.OK))
+    val datapoints = (0 until 50000)
+      .map(i => Datapoint(Map("name" -> s"foo_$i"), 0L, i.toDouble))
+      .toList
+    testSend(datapoints, 50000, 0, 5)
+  }
+
+  test("publish datapoints, partial failure") {
+    val json =
+      """
+        |{
+        |  "type": "error",
+        |  "errorCount": 7,
+        |  "message": ["abc"]
+        |}
+      """.stripMargin
+    ref ! Success(HttpResponse(StatusCodes.Accepted, entity = json))
+    val datapoints = (0 until 10)
+      .map(i => Datapoint(Map("name" -> s"foo_$i"), 0L, i.toDouble))
+      .toList
+    testSend(datapoints, 10, 7)
+  }
+
+  test("publish datapoints, partial failure, cannot parse response") {
+    ref ! Success(HttpResponse(StatusCodes.Accepted))
+    val datapoints = Datapoint(Map("name" -> s"invalid name!!"), 0L, 1.0) :: (0 until 10)
+        .map(i => Datapoint(Map("name" -> s"foo_$i"), 0L, i.toDouble))
+        .toList
+    testSend(datapoints, 11, 11)
+  }
+
+  test("publish datapoints, complete failure") {
+    ref ! Success(HttpResponse(StatusCodes.BadRequest))
+    val datapoints = (0 until 10)
+      .map(i => Datapoint(Map("name" -> s"foo_$i"), 0L, i.toDouble))
+      .toList
+    testSend(datapoints, 10, 10)
+  }
+
+  test("publish datapoints, unexpected status code") {
+    ref ! Success(HttpResponse(StatusCodes.InternalServerError))
+    val datapoints = (0 until 10)
+      .map(i => Datapoint(Map("name" -> s"foo_$i"), 0L, i.toDouble))
+      .toList
+    testSend(datapoints, 10, 10)
+  }
+}
+
+object ClientActorSuite {
+
+  object Done
+
+  class TestClientActor(registry: Registry, config: Config, materializer: Materializer)
+      extends ClientActor(registry, config, materializer) {
+
+    var response: Try[HttpResponse] = Failure(new RuntimeException("not set"))
+
+    override protected def post(data: Array[Byte]): Future[HttpResponse] = {
+      val t = Try {
+        PublishApi.decodeBatch(Json.newSmileParser(data))
+        response.get
+      }
+      Promise.fromTry(t).future
+    }
+
+    override def receive: Receive = testReceive.orElse(super.receive)
+
+    private def testReceive: Receive = {
+      case t: Try[_] => response = t.asInstanceOf[Try[HttpResponse]]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/poller/DataRef.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/poller/DataRef.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.poller
+
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+class DataRef {
+
+  private val sendMsg = new AtomicReference[Try[Any]](Failure(new RuntimeException("not set")))
+  private var recvPromise: Promise[AnyRef] = Promise()
+
+  def set(msg: Try[Any]): Unit = sendMsg.set(msg)
+
+  def get: Try[Any] = sendMsg.get()
+
+  def receive(v: AnyRef): Unit = recvPromise.complete(Success(v))
+
+  def complete(): Unit = {
+    if (!recvPromise.isCompleted) recvPromise.complete(Failure(new RuntimeException("done")))
+  }
+
+  def reset(): Unit = {
+    recvPromise = Promise()
+  }
+
+  def future: Future[AnyRef] = recvPromise.future
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/poller/PollerManagerSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/poller/PollerManagerSuite.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.poller
+
+import java.lang.reflect.Type
+
+import akka.actor.ActorSystem
+import akka.testkit.ImplicitSender
+import akka.testkit.TestActorRef
+import akka.testkit.TestKit
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.iep.service.DefaultClassFactory
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.ManualClock
+import com.netflix.spectator.api.patterns.PolledMeter
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuiteLike
+
+import scala.concurrent.Await
+import scala.util.Failure
+import scala.util.Success
+
+class PollerManagerSuite
+    extends TestKit(ActorSystem())
+    with ImplicitSender
+    with AnyFunSuiteLike
+    with BeforeAndAfterAll {
+
+  import scala.concurrent.duration._
+
+  import scala.compat.java8.FunctionConverters._
+  private val dataRef = new DataRef
+  private val bindings = Map[Type, AnyRef](classOf[DataRef] -> dataRef).withDefaultValue(null)
+  private val classFactory = new DefaultClassFactory(bindings.asJava)
+
+  private val clock = new ManualClock()
+  private val registry = new DefaultRegistry(clock)
+  private val config = ConfigFactory.load("poll-mgr.conf")
+  private val ref = TestActorRef(new PollerManager(registry, classFactory, config))
+
+  override def afterAll(): Unit = {
+    system.terminate()
+  }
+
+  private def dataValue: AnyRef = {
+    val value = Await.result(dataRef.future, 1.minute)
+    dataRef.reset()
+    value
+  }
+
+  private def waitForCompletion(): Unit = {
+    Await.ready(dataRef.future, 1.minute)
+    dataRef.reset()
+  }
+
+  test("datapoints passed to sink") {
+    dataRef.reset()
+    dataRef.set(Success(Messages.MetricsPayload()))
+    ref ! Messages.Tick
+    assert(dataValue === Messages.MetricsPayload())
+
+    val payload =
+      Messages.MetricsPayload(Map.empty, List(Datapoint(Map("name" -> "foo"), 0L, 42.0)))
+
+    dataRef.set(Success(payload))
+    ref ! Messages.Tick
+    assert(dataValue === payload)
+  }
+
+  test("datapoints counter incremented") {
+    dataRef.reset()
+    val datapoints = (0 until 1234)
+      .map(i => Datapoint(Map("name" -> "foo"), 0L, i.toDouble))
+      .toList
+    val payload = Messages.MetricsPayload(Map.empty, datapoints)
+
+    val counter = registry.counter("atlas.poller.datapoints", "id", "poller-test")
+    val init = counter.count()
+
+    dataRef.set(Success(payload))
+    ref ! Messages.Tick
+    assert(dataValue === payload)
+
+    assert(counter.count() === init + datapoints.size)
+  }
+
+  test("restarts counter incremented") {
+    val e1 = new RuntimeException("foo")
+    val e2 = new IllegalArgumentException("bar")
+
+    val c1 =
+      registry.counter("atlas.poller.restarts", "id", "poller-test", "error", "RuntimeException")
+    val c2 = registry.counter(
+      "atlas.poller.restarts",
+      "id",
+      "poller-test",
+      "error",
+      "IllegalArgumentException"
+    )
+
+    val init1 = c1.count()
+    val init2 = c2.count()
+
+    // Update with RuntimeException
+    dataRef.reset()
+    dataRef.set(Failure(e1))
+    ref ! Messages.Tick
+    waitForCompletion()
+    assert(c1.count() === init1 + 1)
+    assert(c2.count() === init2)
+
+    // Update with IllegalArgumentException
+    dataRef.reset()
+    dataRef.set(Failure(e2))
+    ref ! Messages.Tick
+    waitForCompletion()
+    assert(c1.count() === init1 + 1)
+    assert(c2.count() === init2 + 1)
+  }
+
+  private def updateGauges(): Unit = {
+    // Forces the update of passive gauges
+    PolledMeter.update(registry)
+  }
+
+  test("age is updated on success") {
+    dataRef.reset()
+    val payload = Messages.MetricsPayload()
+    val m = registry.gauge(registry.createId("atlas.poller.dataAge", "id", "poller-test"))
+
+    val t = clock.wallTime()
+    updateGauges()
+    assert(m.value() === 0.0)
+
+    clock.setWallTime(t + 60000L)
+    dataRef.set(Success(payload))
+    ref ! Messages.Tick
+    waitForCompletion()
+    updateGauges()
+    assert(m.value() === 0.0)
+
+  }
+
+  test("age is not updated on failure") {
+    dataRef.reset()
+    val e1 = new RuntimeException("foo")
+    val m = registry.gauge(registry.createId("atlas.poller.dataAge", "id", "poller-test"))
+
+    val t = clock.wallTime()
+    updateGauges()
+    assert(m.value() === 0.0)
+
+    clock.setWallTime(t + 60000L)
+    dataRef.set(Failure(e1))
+    ref ! Messages.Tick
+    waitForCompletion()
+    updateGauges()
+    assert(m.value() === 60.0)
+
+  }
+
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/poller/TestActor.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/poller/TestActor.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.poller
+
+import akka.actor.Actor
+
+import scala.util.Failure
+import scala.util.Try
+
+class TestActor(ref: DataRef) extends Actor {
+
+  // If there is a failure causing a restart, then we need to mark the
+  // promise completed so test cases can move forward.
+  ref.complete()
+
+  var data: Try[Any] = Failure(new RuntimeException("not set"))
+
+  def receive: Receive = {
+    case Messages.Tick => sender() ! ref.get.get
+    case v: AnyRef     => ref.receive(v)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ lazy val `iep-apps` = project.in(file("."))
   .configure(BuildSettings.profile)
   .aggregate(
     `atlas-aggregator`,
+    `atlas-cloudwatch`,
     `atlas-druid`,
     `atlas-persistence`,
     `atlas-slotting`,
@@ -32,6 +33,30 @@ lazy val `atlas-aggregator` = project
     Dependencies.log4jSlf4j,
     Dependencies.spectatorAtlas,
 
+    Dependencies.akkaHttpTestkit % "test",
+    Dependencies.akkaTestkit % "test",
+    Dependencies.scalatest % "test"
+  ))
+
+lazy val `atlas-cloudwatch` = project
+  .configure(BuildSettings.profile)
+  .settings(libraryDependencies ++= Seq(
+    Dependencies.atlasCore,
+    Dependencies.atlasJson,
+    Dependencies.atlasModuleAkka,
+    Dependencies.aws2CloudWatch,
+    Dependencies.frigga,
+    Dependencies.iepGuice,
+    Dependencies.iepLeaderDynamoDb,
+    Dependencies.iepModuleAws2,
+    Dependencies.iepModuleLeader,
+    Dependencies.iepNflxEnv,
+    Dependencies.iepService,
+    Dependencies.log4jApi,
+    Dependencies.log4jCore,
+    Dependencies.log4jSlf4j,
+
+    Dependencies.atlasWebApi % "test",
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaTestkit % "test",
     Dependencies.scalatest % "test"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,6 +35,7 @@ object Dependencies {
   val atlasModuleAkka    = "com.netflix.atlas_v1" %% "atlas-module-akka" % atlas
   val atlasModuleEval    = "com.netflix.atlas_v1" %% "atlas-module-eval" % atlas
   val atlasModuleWebApi  = "com.netflix.atlas_v1" %% "atlas-module-webapi" % atlas
+  val atlasWebApi        = "com.netflix.atlas_v1" %% "atlas-webapi" % atlas
   val aws2AutoScaling    = "software.amazon.awssdk" % "autoscaling" % aws2
   val aws2CloudWatch     = "software.amazon.awssdk" % "cloudwatch" % aws2
   val aws2DynamoDB       = "software.amazon.awssdk" % "dynamodb" % aws2
@@ -45,10 +46,13 @@ object Dependencies {
   val guiceCore          = "com.google.inject" % "guice" % guice
   val guiceMulti         = "com.google.inject.extensions" % "guice-multibindings" % guice
   val iepGuice           = "com.netflix.iep" % "iep-guice" % iep
+  val iepLeaderApi      = "com.netflix.iep" % "iep-leader-api" % iep
+  val iepLeaderDynamoDb = "com.netflix.iep" % "iep-leader-dynamodb" % iep
   val iepModuleAdmin     = "com.netflix.iep" % "iep-module-admin" % iep
   val iepModuleAtlas     = "com.netflix.iep" % "iep-module-atlas" % iep
   val iepModuleAws2      = "com.netflix.iep" % "iep-module-aws2" % iep
   val iepModuleJmx       = "com.netflix.iep" % "iep-module-jmxport" % iep
+  val iepModuleLeader   = "com.netflix.iep" % "iep-module-leader" % iep
   val iepNflxEnv         = "com.netflix.iep" % "iep-nflxenv" % iep
   val iepService         = "com.netflix.iep" % "iep-service" % iep
   val jsonSchema         = "com.github.java-json-tools" % "json-schema-validator" % "2.2.14"


### PR DESCRIPTION
This is a merge of the `atlas-poller`, `atlas-poller-cloudwatch`,
and `atlas-module-cloudwatch` sub-projects from the Atlas repo.
Moving here as a single app project should make it easier to
run locally for testing and refactor to use streaming CloudWatch
APIs.