### PR TITLE
add tgw max metrics and tgw-attach dimension

### DIFF
--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -279,6 +279,10 @@ atlas {
           alias = "aws.tgw"
         },
         {
+          name = "TransitGatewayAttachment"
+          alias = "aws.tgw-attach"
+        },
+        {
           name = "ActionType"
           alias = "aws.action"
         },

--- a/atlas-cloudwatch/src/main/resources/tgw.conf
+++ b/atlas-cloudwatch/src/main/resources/tgw.conf
@@ -9,58 +9,26 @@ atlas {
       period = 1m
 
       dimensions = [
-        "TransitGateway"
+        "TransitGateway",
+        "TransitGatewayAttachment",
       ]
 
       metrics = [
         {
-          name = "BytesIn"
-          alias = "aws.tgw.bytes"
+          name = "BytesDropCountBlackhole"
+          alias = "aws.tgw.bytesDropped"
           conversion = "sum,rate"
           tags = [
             {
               key = "id"
-              value = "in"
-            }
-          ]
-        },
-        {
-          name = "BytesOut"
-          alias = "aws.tgw.bytes"
-          conversion = "sum,rate"
-          tags = [
-            {
-              key = "id"
-              value = "out"
-            }
-          ]
-        },
-        {
-          name = "PacketsIn"
-          alias = "aws.tgw.packets"
-          conversion = "sum,rate"
-          tags = [
-            {
-              key = "id"
-              value = "in"
-            }
-          ]
-        },
-        {
-          name = "PacketsOut"
-          alias = "aws.tgw.packets"
-          conversion = "sum,rate"
-          tags = [
-            {
-              key = "id"
-              value = "out"
+              value = "Blackhole"
             }
           ]
         },
         {
           name = "BytesDropCountBlackhole"
-          alias = "aws.tgw.bytesDropped"
-          conversion = "sum,rate"
+          alias = "aws.tgw.maxBytesDropped"
+          conversion = "max"
           tags = [
             {
               key = "id"
@@ -80,9 +48,75 @@ atlas {
           ]
         },
         {
+          name = "BytesDropCountNoRoute"
+          alias = "aws.tgw.maxBytesDropped"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "NoRoute"
+            }
+          ]
+        },
+        {
+          name = "BytesIn"
+          alias = "aws.tgw.bytes"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "BytesIn"
+          alias = "aws.tgw.maxBytes"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "BytesOut"
+          alias = "aws.tgw.bytes"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "BytesOut"
+          alias = "aws.tgw.maxBytes"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
           name = "PacketDropCountBlackhole"
           alias = "aws.tgw.packetsDropped"
           conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "Blackhole"
+            }
+          ]
+        },
+        {
+          name = "PacketDropCountBlackhole"
+          alias = "aws.tgw.maxPacketsDropped"
+          conversion = "max"
           tags = [
             {
               key = "id"
@@ -98,6 +132,61 @@ atlas {
             {
               key = "id"
               value = "NoRoute"
+            }
+          ]
+        },
+        {
+          name = "PacketDropCountNoRoute"
+          alias = "aws.tgw.maxPacketsDropped"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "NoRoute"
+            }
+          ]
+        },
+        {
+          name = "PacketsIn"
+          alias = "aws.tgw.packets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "PacketsIn"
+          alias = "aws.tgw.maxPackets"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "PacketsOut"
+          alias = "aws.tgw.packets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "PacketsOut"
+          alias = "aws.tgw.maxPackets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
             }
           ]
         },


### PR DESCRIPTION
These will allow teams to monitor for specific instances of exceeding
configured limits within a sample period, as opposed to monitoring the
average rate over a sample period.