### PR TITLE
add vpn site-to-site metrics

### DIFF
--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -131,92 +131,12 @@ atlas {
       // then the value from cloudwatch will be used as is.
       mappings = [
         {
-          name = "AutoScalingGroupName"
-          alias = "nf.asg"
+          name = "Action"
+          alias = "aws.action"
         },
         {
-          name = "AvailabilityZone"
-          alias = "nf.zone"
-        },
-        {
-          name = "Region"
-          alias = "aws.region"
-        },
-        {
-          name = "LinkedAccount"
-          alias = "aws.account"
-        },
-        {
-          name = "Currency"
-          alias = "aws.currency"
-        },
-        {
-          name = "LoadBalancerName"
-          alias = "aws.elb"
-        },
-        {
-          name = "TopicName"
-          alias = "aws.topic"
-        },
-        {
-          name = "QueueName"
-          alias = "aws.queue"
-        },
-        {
-          name = "ServiceName"
-          alias = "aws.service"
-        },
-        {
-          name = "ServiceLimit"
-          alias = "aws.limit"
-        },
-        {
-          name = "BucketName"
-          alias = "aws.bucket"
-        },
-        {
-          name = "StorageType"
-          alias = "aws.storage"
-        },
-        {
-          name = "FunctionName"
-          alias = "aws.function"
-        },
-        {
-          name = "StreamName"
-          alias = "aws.stream"
-        },
-        {
-          name = "RuleName"
-          alias = "aws.rule"
-        },
-        {
-          name = "Resource"
-          alias = "aws.resource"
-        },
-        {
-          name = "Domain"
-          alias = "aws.domain"
-        },
-        {
-          name = "Operation"
-          alias = "aws.op"
-        },
-        {
-          name = "TableName"
-          alias = "aws.table"
-        },
-        {
-          name = "DomainName"
-          alias = "aws.domain"
-        },
-        {
-          name = "WorkflowTypeName"
-          alias = "id"
-        },
-        {
-          name = "WorkflowTypeVersion"
-          alias = "aws.version"
+          name = "ActionType"
+          alias = "aws.action"
         },
         {
           name = "ActivityTypeName"
@@ -227,8 +147,16 @@ atlas {
           alias = "aws.version"
         },
         {
-          name = "ClientId"
-          alias = "aws.client"
+          name = "AutoScalingGroupName"
+          alias = "nf.asg"
+        },
+        {
+          name = "AvailabilityZone"
+          alias = "nf.zone"
+        },
+        {
+          name = "BucketName"
+          alias = "aws.bucket"
         },
         {
           name = "CacheClusterId"
@@ -237,6 +165,22 @@ atlas {
         {
           name = "CacheNodeId"
           alias = "aws.node"
+        },
+        {
+          name = "ClientId"
+          alias = "aws.client"
+        },
+        {
+          name = "ClusterIdentifier"
+          alias = "aws.redshift"
+        },
+        {
+          name = "ConnectionId"
+          alias = "aws.connection"
+        },
+        {
+          name = "Currency"
+          alias = "aws.currency"
         },
         {
           name = "DBClusterIdentifier"
@@ -251,48 +195,28 @@ atlas {
           alias = "aws.dbname"
         },
         {
-          name = "ClusterIdentifier"
-          alias = "aws.redshift"
+          name = "Domain"
+          alias = "aws.domain"
+        },
+        {
+          name = "DomainName"
+          alias = "aws.domain"
+        },
+        {
+          name = "EndpointId"
+          alias = "aws.endpoint"
         },
         {
           name = "FileSystemId"
           alias = "aws.efs"
         },
         {
-          name = "NodeID"
-          alias = "nf.node"
-        },
-        {
           name = "FilterId"
           alias = "aws.filter"
         },
         {
-          name = "NatGatewayId"
-          alias = "aws.gateway"
-        },
-        {
-          name = "Action"
-          alias = "aws.action"
-        },
-        {
-          name = "TransitGateway"
-          alias = "aws.tgw"
-        },
-        {
-          name = "TransitGatewayAttachment"
-          alias = "aws.tgw-attach"
-        },
-        {
-          name = "ActionType"
-          alias = "aws.action"
-        },
-        {
-          name = "Protocol"
-          alias = "aws.protocol"
-        },
-        {
-          name = "ConnectionId"
-          alias = "aws.connection"
+          name = "FunctionName"
+          alias = "aws.function"
         },
         {
           name = "HealthCheckId"
@@ -303,13 +227,97 @@ atlas {
           alias = "aws.hostedZone"
         },
         {
-          name = "EndpointId"
-          alias = "aws.endpoint"
+          name = "LinkedAccount"
+          alias = "aws.account"
+        },
+        {
+          name = "LoadBalancerName"
+          alias = "aws.elb"
+        },
+        {
+          name = "NatGatewayId"
+          alias = "aws.gateway"
+        },
+        {
+          name = "NodeID"
+          alias = "nf.node"
+        },
+        {
+          name = "Operation"
+          alias = "aws.op"
+        },
+        {
+          name = "Protocol"
+          alias = "aws.protocol"
+        },
+        {
+          name = "QueueName"
+          alias = "aws.queue"
+        },
+        {
+          name = "Region"
+          alias = "aws.region"
+        },
+        {
+          name = "Resource"
+          alias = "aws.resource"
         },
         {
           name = "Role"
           alias = "aws.role"
         }
+        {
+          name = "RuleName"
+          alias = "aws.rule"
+        },
+        {
+          name = "ServiceLimit"
+          alias = "aws.limit"
+        },
+        {
+          name = "ServiceName"
+          alias = "aws.service"
+        },
+        {
+          name = "StorageType"
+          alias = "aws.storage"
+        },
+        {
+          name = "StreamName"
+          alias = "aws.stream"
+        },
+        {
+          name = "TableName"
+          alias = "aws.table"
+        },
+        {
+          name = "TopicName"
+          alias = "aws.topic"
+        },
+        {
+          name = "TransitGateway"
+          alias = "aws.tgw"
+        },
+        {
+          name = "TransitGatewayAttachment"
+          alias = "aws.tgw-attach"
+        },
+        {
+          name = "TunnelIpAddress"
+          alias = "aws.tunnel-ip"
+        },
+        {
+          name = "VpnId"
+          alias = "aws.vpn"
+        },
+        {
+          name = "WorkflowTypeName"
+          alias = "id"
+        },
+        {
+          name = "WorkflowTypeVersion"
+          alias = "aws.version"
+        },
       ]
 
       // Tags that should get applied to all metrics from cloudwatch.
@@ -381,6 +389,7 @@ atlas {
       "sqs",
       "tgw",
       //"trustedadvisor",
+      "vpn",
       "workflow",
       "workflow-activity"
     ]
@@ -415,3 +424,4 @@ include "sqs.conf"
 include "swf.conf"
 include "tgw.conf"
 include "trustedadvisor.conf"
+include "vpn.conf"

--- a/atlas-cloudwatch/src/main/resources/vpn.conf
+++ b/atlas-cloudwatch/src/main/resources/vpn.conf
@@ -1,0 +1,47 @@
+
+atlas {
+  cloudwatch {
+
+    // Metrics for the site-to-site vpn service
+    // https://docs.aws.amazon.com/vpn/latest/s2svpn/monitoring-cloudwatch-vpn.html
+    vpn = {
+      namespace = "AWS/VPN"
+      period = 1m
+
+      dimensions = [
+        "VpnId",
+        "TunnelIpAddress",
+      ]
+
+      metrics = [
+        {
+          name = "TunnelState"
+          alias = "aws.vpn.tunnelState"
+          conversion = "max"
+        },
+        {
+          name = "TunnelDataIn"
+          alias = "aws.vpn.tunnelData"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "TunnelDataOut"
+          alias = "aws.vpn.tunnelData"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This change also sorts the mappings by name in the reference configuration,
so that it is easier to tell if we have mappings defined for a given name.