### PR TITLE
fix vpn metrics

### DIFF
--- a/atlas-cloudwatch/src/main/resources/vpn.conf
+++ b/atlas-cloudwatch/src/main/resources/vpn.conf
@@ -10,7 +10,6 @@ atlas {
 
       dimensions = [
         "VpnId",
-        "TunnelIpAddress",
       ]
 
       metrics = [


### PR DESCRIPTION
The VpnId and and TunnelIpAddress dimensions are not both present on
the metrics that are published - it is one or the other. Each VPN
connection has two tunnels, a primary and a backup, and the preference
is to monitor these metrics based on VPN connection. As a result, we
will drop the TunnelIpAddress dimension.