### PR TITLE
[patch] Use limit only if less than Int.MAX_VALUE

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -189,7 +189,7 @@ class DruidDatabaseActor(config: Config) extends Actor with StrictLogging {
             dimension = toDimensionSpec(DefaultDimensionSpec(k, "value"), dimensionFilterMatches),
             intervals = List(tagsQueryInterval),
             filter = DruidFilter.forQuery(query),
-            threshold = tq.limit
+            threshold = if (tq.limit < Int.MaxValue) tq.limit else 1000
           )
           val druidQueries = List(client.topn(topnQuery))
           Source(druidQueries)


### PR DESCRIPTION
This is a requirement for Druid TopN queries, they are rejected if >= Int.MAX_VALUE