### PR TITLE
aggr: use akka client for publishing

### DIFF
--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AggrConfig.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AggrConfig.scala
@@ -15,14 +15,20 @@
  */
 package com.netflix.atlas.aggregator
 
-import java.security.SecureRandom
+import akka.actor.ActorSystem
 
+import java.security.SecureRandom
 import com.netflix.spectator.api.Clock
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.atlas.AtlasConfig
+import com.netflix.spectator.atlas.Publisher
 import com.typesafe.config.Config
 
-class AggrConfig(config: Config, registry: Registry) extends AtlasConfig {
+class AggrConfig(
+  config: Config,
+  registry: Registry,
+  system: ActorSystem
+) extends AtlasConfig {
 
   private val maxMeters = super.maxNumberOfMeters()
 
@@ -63,4 +69,8 @@ class AggrConfig(config: Config, registry: Registry) extends AtlasConfig {
     * Set to null since this will get corrected before it gets to the registry.
     */
   override def validTagCharacters(): String = null
+
+  override def publisher(): Publisher = {
+    new AkkaPublisher(this, system)
+  }
 }

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AkkaPublisher.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AkkaPublisher.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2014-2021 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.aggregator
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.HttpMethods
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.headers._
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.dataformat.smile.SmileFactory
+import com.netflix.atlas.akka.AccessLogger
+import com.netflix.atlas.akka.CustomMediaTypes
+import com.netflix.spectator.api.Measurement
+import com.netflix.spectator.atlas.Publisher
+import com.netflix.spectator.atlas.impl.EvalPayload
+import com.netflix.spectator.atlas.impl.PublishPayload
+
+import java.io.ByteArrayOutputStream
+import java.io.OutputStream
+import java.util.concurrent.CompletableFuture
+import java.util.zip.Deflater
+import java.util.zip.GZIPOutputStream
+import scala.concurrent.ExecutionContext
+import scala.util.Using
+
+/**
+  * Use Akka-Http client for sending data instead of default which is based on the
+  * URLConnection class built into the JDK. This helps reduce the number of threads
+  * needed overall.
+  */
+class AkkaPublisher(config: AggrConfig, implicit val system: ActorSystem) extends Publisher {
+
+  import AkkaPublisher._
+
+  private implicit val ec: ExecutionContext = system.dispatcher
+
+  private val atlasUri = Uri(config.uri())
+  private val evalUri = Uri(config.evalUri())
+
+  private val headers = List(`Content-Encoding`(HttpEncodings.gzip))
+
+  override def init(): Unit = {}
+
+  private def encode(payload: AnyRef): Array[Byte] = {
+    val baos = getOrCreateStream
+    Using.resource(new GzipLevelOutputStream(baos)) { out =>
+      mapper.writeValue(out, payload)
+    }
+    baos.toByteArray
+  }
+
+  private def doPost(uri: Uri, id: String, payload: AnyRef): CompletableFuture[Void] = {
+    import scala.jdk.FutureConverters._
+    val entity = HttpEntity(CustomMediaTypes.`application/x-jackson-smile`, encode(payload))
+    val request = HttpRequest(HttpMethods.POST, uri, headers, entity)
+    val logger = AccessLogger.newClientLogger(id, request)
+    val future = Http().singleRequest(request)
+    future.onComplete(logger.complete)
+    future.map(_ => VoidInstance).asJava.toCompletableFuture
+  }
+
+  override def publish(payload: PublishPayload): CompletableFuture[Void] = {
+    doPost(atlasUri, "publisher-atlas", payload)
+  }
+
+  override def publish(payload: EvalPayload): CompletableFuture[Void] = {
+    doPost(evalUri, "publisher-lwc", payload)
+  }
+
+  override def close(): Unit = {}
+}
+
+object AkkaPublisher {
+
+  private val VoidInstance = null.asInstanceOf[Void]
+
+  private val mapper = {
+    val serializer = new JsonSerializer[Measurement] {
+      override def serialize(
+        value: Measurement,
+        gen: JsonGenerator,
+        serializers: SerializerProvider
+      ): Unit = {
+        val id = value.id
+        gen.writeStartObject()
+        gen.writeObjectFieldStart("tags")
+        gen.writeStringField("name", id.name)
+        val n = id.size
+        var i = 1
+        while (i < n) {
+          val k = id.getKey(i)
+          val v = id.getValue(i)
+          gen.writeStringField(k, v)
+          i += 1
+        }
+        gen.writeEndObject()
+        gen.writeNumberField("timestamp", value.timestamp)
+        gen.writeNumberField("value", value.value)
+        gen.writeEndObject()
+      }
+    }
+    val module = new SimpleModule().addSerializer(classOf[Measurement], serializer)
+    new ObjectMapper(new SmileFactory()).registerModule(module)
+  }
+
+  private val streams = new ThreadLocal[ByteArrayOutputStream]
+
+  /** Use thread local to reuse byte array buffers across calls. */
+  def getOrCreateStream: ByteArrayOutputStream = {
+    var baos = streams.get
+    if (baos == null) {
+      baos = new ByteArrayOutputStream
+      streams.set(baos)
+    } else {
+      baos.reset()
+    }
+    baos
+  }
+
+  /** Wrap GZIPOutputStream to set the best speed compression level. */
+  final class GzipLevelOutputStream(out: OutputStream) extends GZIPOutputStream(out) {
+    `def`.setLevel(Deflater.BEST_SPEED)
+  }
+}

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AtlasAggregatorService.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AtlasAggregatorService.scala
@@ -15,22 +15,28 @@
  */
 package com.netflix.atlas.aggregator
 
+import akka.actor.ActorSystem
 import com.netflix.iep.service.AbstractService
 import com.netflix.spectator.api.Clock
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.atlas.AtlasRegistry
 import com.typesafe.config.Config
+
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class AtlasAggregatorService @Inject()(config: Config, clock: Clock, registry: Registry)
-    extends AbstractService
+class AtlasAggregatorService @Inject()(
+  config: Config,
+  clock: Clock,
+  registry: Registry,
+  system: ActorSystem
+) extends AbstractService
     with Aggregator {
 
   private val n = math.max(1, Runtime.getRuntime.availableProcessors() / 2)
-  private val aggrCfg = new AggrConfig(config, registry)
+  private val aggrCfg = new AggrConfig(config, registry, system)
   private val registries = (0 until n)
     .map(_ => new AtlasRegistry(clock, aggrCfg))
     .toArray

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AggrConfigSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AggrConfigSuite.scala
@@ -25,7 +25,7 @@ class AggrConfigSuite extends AnyFunSuite {
   test("initial polling delay") {
     val step = 60000L
     val clock = new ManualClock()
-    val config = new AggrConfig(ConfigFactory.load(), new NoopRegistry,  null)
+    val config = new AggrConfig(ConfigFactory.load(), new NoopRegistry, null)
     (0L until step).foreach { t =>
       clock.setWallTime(t)
       val delay = config.initialPollingDelay(clock, step)

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AggrConfigSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AggrConfigSuite.scala
@@ -15,7 +15,6 @@
  */
 package com.netflix.atlas.aggregator
 
-import akka.actor.ActorSystem
 import com.netflix.spectator.api.ManualClock
 import com.netflix.spectator.api.NoopRegistry
 import com.typesafe.config.ConfigFactory
@@ -26,7 +25,7 @@ class AggrConfigSuite extends AnyFunSuite {
   test("initial polling delay") {
     val step = 60000L
     val clock = new ManualClock()
-    val config = new AggrConfig(ConfigFactory.load(), new NoopRegistry, ActorSystem("test"))
+    val config = new AggrConfig(ConfigFactory.load(), new NoopRegistry,  null)
     (0L until step).foreach { t =>
       clock.setWallTime(t)
       val delay = config.initialPollingDelay(clock, step)

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AggrConfigSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AggrConfigSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.aggregator
 
+import akka.actor.ActorSystem
 import com.netflix.spectator.api.ManualClock
 import com.netflix.spectator.api.NoopRegistry
 import com.typesafe.config.ConfigFactory
@@ -25,7 +26,7 @@ class AggrConfigSuite extends AnyFunSuite {
   test("initial polling delay") {
     val step = 60000L
     val clock = new ManualClock()
-    val config = new AggrConfig(ConfigFactory.load(), new NoopRegistry)
+    val config = new AggrConfig(ConfigFactory.load(), new NoopRegistry, ActorSystem("test"))
     (0L until step).foreach { t =>
       clock.setWallTime(t)
       val delay = config.initialPollingDelay(clock, step)

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AppModuleSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AppModuleSuite.scala
@@ -15,6 +15,8 @@
  */
 package com.netflix.atlas.aggregator
 
+import akka.actor.ActorSystem
+
 import javax.inject.Singleton
 import com.google.inject.AbstractModule
 import com.google.inject.Guice
@@ -41,6 +43,7 @@ class AppModuleSuite extends AnyFunSuite {
         override def configure(): Unit = {
           bind(classOf[Config]).toInstance(config)
           bind(classOf[Registry]).toProvider(classOf[RegistryProvider])
+          bind(classOf[ActorSystem]).toInstance(ActorSystem("AppModuleSuite"))
         }
       }
     )
@@ -53,7 +56,7 @@ class AppModuleSuite extends AnyFunSuite {
     val config = ConfigFactory.parseString("""
         |netflix.atlas.aggr.registry.atlas.uri = "test"
       """.stripMargin)
-    val aggr = new AggrConfig(config, new NoopRegistry)
+    val aggr = new AggrConfig(config, new NoopRegistry, null)
     assert(aggr.uri() === "test")
   }
 
@@ -61,7 +64,7 @@ class AppModuleSuite extends AnyFunSuite {
     val config = ConfigFactory.parseString("""
         |netflix.atlas.aggr.registry.atlas.uri = "test"
       """.stripMargin)
-    val aggr = new AggrConfig(config, new NoopRegistry)
+    val aggr = new AggrConfig(config, new NoopRegistry, null)
     assert(aggr.batchSize() === 10000)
   }
 }

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.aggregator
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.model.StatusCodes
@@ -34,12 +35,13 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class UpdateApiSuite extends AnyFunSuite {
 
+  private val system = ActorSystem("UpdateApiSuite")
   private val factory = new JsonFactory()
 
   private val aggrTag = Tag.of("atlas.dstype", "sum")
 
   private def createAggrService(clock: Clock): AtlasAggregatorService = {
-    new AtlasAggregatorService(ConfigFactory.load(), clock, new NoopRegistry)
+    new AtlasAggregatorService(ConfigFactory.load(), clock, new NoopRegistry, system)
   }
 
   test("simple payload") {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
     val scala      = "2.13.6"
     val servo      = "0.13.2"
     val slf4j      = "1.7.32"
-    val spectator  = "0.133.0"
+    val spectator  = "0.135.0"
     val avroV      = "1.10.2"
 
     val crossScala = Seq(scala)


### PR DESCRIPTION
Use Akka-Http client for sending data instead of the
default which is based on the URLConnection class built
into the JDK. This helps reduce the number of threads
needed overall.