### PR TITLE
druid: add configurable filter for datasources

### DIFF
--- a/atlas-druid/src/main/resources/application.conf
+++ b/atlas-druid/src/main/resources/application.conf
@@ -10,6 +10,10 @@ atlas {
     // Maximum size for intermediate data response. If it is exceeded, then the
     // processing will be fail early.
     max-data-size = 2g
+
+    // Filter for the set of allowed data sources. Only datasources that match this regex will
+    // be exposed.
+    datasource-filter = ".*"
   }
 
   akka {


### PR DESCRIPTION
Allows the set of datasources exposed to be filtered using
a regex. This can be useful for cases where there are some
datasources that should not be exposed for a given Druid
cluster.