### PR TITLE
druid: add double to counter types

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -217,7 +217,7 @@ object DruidClient {
   case class Datasource(dimensions: List[String], metrics: List[Metric])
 
   case class Metric(name: String, dataType: String) {
-    def isCounter: Boolean = dataType == "FLOAT" || dataType == "LONG"
+    def isCounter: Boolean = dataType == "DOUBLE" || dataType == "FLOAT" || dataType == "LONG"
     def isHistogram: Boolean = dataType == "netflixHistogram"
     def isSupported: Boolean = isCounter
   }


### PR DESCRIPTION
Include double in the set of data types that will get
treated as a counter value.