### PR TITLE
update CI builds to include jdk16

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 15]
+        java: [8, 11, 16]
         scala: [2.13.6]
     steps:
       - uses: actions/checkout@v2
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 15
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 15
+          java-version: 11
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 15
+          java-version: 11
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 15
+          java-version: 11
       - uses: actions/cache@v2
         with:
           path: |

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val `iep-apps` = project.in(file("."))
 
 lazy val `atlas-aggregator` = project
   .configure(BuildSettings.profile)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.atlasJson,
     Dependencies.atlasModuleAkka,
     Dependencies.atlasModuleEval,
@@ -40,7 +40,7 @@ lazy val `atlas-aggregator` = project
 
 lazy val `atlas-cloudwatch` = project
   .configure(BuildSettings.profile)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.atlasCore,
     Dependencies.atlasJson,
     Dependencies.atlasModuleAkka,
@@ -64,7 +64,7 @@ lazy val `atlas-cloudwatch` = project
 
 lazy val `atlas-druid` = project
   .configure(BuildSettings.profile)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++Seq(
     Dependencies.atlasModuleAkka,
     Dependencies.atlasModuleWebApi,
     Dependencies.iepGuice,
@@ -76,7 +76,7 @@ lazy val `atlas-druid` = project
 lazy val `atlas-persistence` = project
   .configure(BuildSettings.profile)
   .settings(
-    libraryDependencies ++= Seq(
+    libraryDependencies ++= Dependencies.guiceCoreAndMulti ++Seq(
       Dependencies.atlasModuleAkka,
       Dependencies.atlasModuleWebApi,
       Dependencies.avro,
@@ -91,7 +91,7 @@ lazy val `atlas-persistence` = project
 
 lazy val `atlas-slotting` = project
   .configure(BuildSettings.profile)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++Seq(
       Dependencies.akkaHttpCaching,
       Dependencies.atlasModuleAkka,
       Dependencies.aws2AutoScaling,
@@ -113,7 +113,7 @@ lazy val `atlas-slotting` = project
 
 lazy val `atlas-stream` = project
   .configure(BuildSettings.profile)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++Seq(
     Dependencies.atlasModuleAkka,
     Dependencies.atlasModuleEval,
     Dependencies.iepGuice,
@@ -128,7 +128,7 @@ lazy val `atlas-stream` = project
 
 lazy val `iep-archaius` = project
   .configure(BuildSettings.profile)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++Seq(
     Dependencies.atlasModuleAkka,
     Dependencies.aws2DynamoDB,
     Dependencies.frigga,
@@ -147,7 +147,7 @@ lazy val `iep-archaius` = project
 
 lazy val `iep-atlas` = project
   .configure(BuildSettings.profile)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++Seq(
     Dependencies.atlasModuleAkka,
     Dependencies.atlasModuleWebApi,
     Dependencies.iepGuice,
@@ -161,7 +161,7 @@ lazy val `iep-atlas` = project
 
 lazy val `iep-clienttest` = project
   .configure(BuildSettings.profile)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++Seq(
     Dependencies.atlasModuleAkka,
     Dependencies.iepGuice,
     Dependencies.log4jApi,
@@ -173,7 +173,7 @@ lazy val `iep-clienttest` = project
 
 lazy val `iep-lwc-bridge` = project
   .configure(BuildSettings.profile)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++Seq(
     Dependencies.atlasCore,
     Dependencies.atlasModuleAkka,
     Dependencies.frigga,
@@ -195,7 +195,7 @@ lazy val `iep-lwc-cloudwatch-model` = project
 lazy val `iep-lwc-cloudwatch` = project
   .configure(BuildSettings.profile)
   .dependsOn(`iep-lwc-cloudwatch-model`)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.atlasModuleAkka,
     Dependencies.atlasModuleEval,
     Dependencies.aws2CloudWatch,
@@ -216,7 +216,7 @@ lazy val `iep-lwc-cloudwatch` = project
 lazy val `iep-lwc-fwding-admin` = project
   .configure(BuildSettings.profile)
   .dependsOn(`iep-lwc-cloudwatch-model`)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.atlasEval,
     Dependencies.atlasModuleAkka,
     Dependencies.atlasModuleEval,
@@ -238,7 +238,7 @@ lazy val `iep-lwc-fwding-admin` = project
 
 lazy val `iep-lwc-loadgen` = project
   .configure(BuildSettings.profile)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.atlasModuleAkka,
     Dependencies.atlasModuleEval,
     Dependencies.iepGuice,
@@ -254,7 +254,7 @@ lazy val `iep-lwc-loadgen` = project
 
 lazy val `iep-ses-monitor` = project
   .configure(BuildSettings.profile)
-  .settings(libraryDependencies ++= Seq(
+  .settings(libraryDependencies ++= Dependencies.guiceCoreAndMulti ++ Seq(
     Dependencies.atlasModuleAkka,
     Dependencies.aws2SQS,
     Dependencies.alpakkaSqs,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,5 @@
 import sbt._
+import sbt.librarymanagement.DependencyBuilders.OrganizationArtifactName
 
 // format: off
 
@@ -9,7 +10,7 @@ object Dependencies {
     val atlas      = "1.7.0-SNAPSHOT"
     val aws2       = "2.17.34"
     val iep        = "3.0.5"
-    val guice      = "4.1.0"
+    val guice      = "5.0.1"
     val log4j      = "2.14.1"
     val scala      = "2.13.6"
     val servo      = "0.13.2"
@@ -43,11 +44,11 @@ object Dependencies {
   val aws2S3             = "software.amazon.awssdk" % "s3" % aws2
   val aws2SQS            = "software.amazon.awssdk" % "sqs" % aws2
   val frigga             = "com.netflix.frigga" % "frigga" % "0.25.0"
-  val guiceCore          = "com.google.inject" % "guice" % guice
-  val guiceMulti         = "com.google.inject.extensions" % "guice-multibindings" % guice
+  val guiceCoreBase      = "com.google.inject" % "guice"
+  val guiceMultiBase     = "com.google.inject.extensions" % "guice-multibindings"
   val iepGuice           = "com.netflix.iep" % "iep-guice" % iep
-  val iepLeaderApi      = "com.netflix.iep" % "iep-leader-api" % iep
-  val iepLeaderDynamoDb = "com.netflix.iep" % "iep-leader-dynamodb" % iep
+  val iepLeaderApi       = "com.netflix.iep" % "iep-leader-api" % iep
+  val iepLeaderDynamoDb  = "com.netflix.iep" % "iep-leader-dynamodb" % iep
   val iepModuleAdmin     = "com.netflix.iep" % "iep-module-admin" % iep
   val iepModuleAtlas     = "com.netflix.iep" % "iep-module-atlas" % iep
   val iepModuleAws2      = "com.netflix.iep" % "iep-module-aws2" % iep
@@ -79,6 +80,23 @@ object Dependencies {
   val spectatorM2        = "com.netflix.spectator" % "spectator-reg-metrics2" % spectator
   val spectatorSandbox   = "com.netflix.spectator" % "spectator-ext-sandbox" % spectator
   val typesafeConfig     = "com.typesafe" % "config" % "1.4.1"
+
+  def isBeforeJava16: Boolean = {
+    System.getProperty("java.specification.version").toDouble < 16
+  }
+
+  private def guiceDep(base: OrganizationArtifactName): ModuleID = {
+    base % (if (isBeforeJava16) "4.1.0" else guice)
+  }
+
+  def guiceCore: ModuleID = guiceDep(guiceCoreBase)
+
+  def guiceCoreAndMulti: Seq[ModuleID] = {
+    if (isBeforeJava16)
+      Seq(guiceDep(guiceCoreBase), guiceDep(guiceMultiBase))
+    else
+      Seq(guiceDep(guiceCoreBase))
+  }
 }
 
 // format: on


### PR DESCRIPTION
Jdk16 strongly encapsulates the internals by default
causing problems for older versions of Guice. When
running on a newer JDK, have the build use Guice 5.
For the published library still need to use 4.1.0
to avoid creating problems internally for other
users stuck on old versions.