### PR TITLE
move tests to MUnit

### DIFF
--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AggrConfigSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AggrConfigSuite.scala
@@ -18,9 +18,9 @@ package com.netflix.atlas.aggregator
 import com.netflix.spectator.api.ManualClock
 import com.netflix.spectator.api.NoopRegistry
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class AggrConfigSuite extends AnyFunSuite {
+class AggrConfigSuite extends FunSuite {
 
   test("initial polling delay") {
     val step = 60000L

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AppModuleSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/AppModuleSuite.scala
@@ -28,9 +28,9 @@ import com.netflix.spectator.atlas.AtlasConfig
 import com.netflix.spectator.atlas.AtlasRegistry
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class AppModuleSuite extends AnyFunSuite {
+class AppModuleSuite extends FunSuite {
 
   import AppModuleSuite._
 
@@ -57,7 +57,7 @@ class AppModuleSuite extends AnyFunSuite {
         |netflix.atlas.aggr.registry.atlas.uri = "test"
       """.stripMargin)
     val aggr = new AggrConfig(config, new NoopRegistry, null)
-    assert(aggr.uri() === "test")
+    assertEquals(aggr.uri(), "test")
   }
 
   test("aggr config should use default for missing props") {
@@ -65,7 +65,7 @@ class AppModuleSuite extends AnyFunSuite {
         |netflix.atlas.aggr.registry.atlas.uri = "test"
       """.stripMargin)
     val aggr = new AggrConfig(config, new NoopRegistry, null)
-    assert(aggr.batchSize() === 10000)
+    assertEquals(aggr.batchSize(), 10000)
   }
 }
 

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
@@ -16,13 +16,13 @@
 package com.netflix.atlas.cloudwatch
 
 import com.netflix.atlas.core.model.Query
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 import software.amazon.awssdk.services.cloudwatch.model.Datapoint
 import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
 
 import java.time.Instant
 
-class ConversionsSuite extends AnyFunSuite {
+class ConversionsSuite extends FunSuite {
 
   private val dp = Datapoint
     .builder()
@@ -49,31 +49,31 @@ class ConversionsSuite extends AnyFunSuite {
   test("min") {
     val cnv = Conversions.fromName("min")
     val v = cnv(null, dp)
-    assert(v === 1.0)
+    assertEquals(v, 1.0)
   }
 
   test("max") {
     val cnv = Conversions.fromName("max")
     val v = cnv(null, dp)
-    assert(v === 5.0)
+    assertEquals(v, 5.0)
   }
 
   test("sum") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, dp)
-    assert(v === 6.0)
+    assertEquals(v, 6.0)
   }
 
   test("count") {
     val cnv = Conversions.fromName("count")
     val v = cnv(null, dp)
-    assert(v === 2.0)
+    assertEquals(v, 2.0)
   }
 
   test("avg") {
     val cnv = Conversions.fromName("avg")
     val v = cnv(null, dp)
-    assert(v === 3.0)
+    assertEquals(v, 3.0)
   }
 
   test("rate") {
@@ -84,7 +84,7 @@ class ConversionsSuite extends AnyFunSuite {
       Nil
     )
     val v = cnv(meta, dp)
-    assert(v === 6.0 / 300.0)
+    assertEquals(v, 6.0 / 300.0)
   }
 
   test("rate already") {
@@ -95,7 +95,7 @@ class ConversionsSuite extends AnyFunSuite {
       Nil
     )
     val v = cnv(meta, newDatapoint(6.0, StandardUnit.BYTES_SECOND))
-    assert(v === 6.0)
+    assertEquals(v, 6.0)
   }
 
   test("bad conversion") {
@@ -119,188 +119,188 @@ class ConversionsSuite extends AnyFunSuite {
   test("unit count") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.COUNT))
-    assert(v === 42.0)
+    assertEquals(v, 42.0)
   }
 
   test("unit bits") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.BITS))
-    assert(v === 42.0 / 8.0)
+    assertEquals(v, 42.0 / 8.0)
   }
 
   test("unit kilobits") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.KILOBITS))
-    assert(v === 1e3 * 42.0 / 8.0)
+    assertEquals(v, 1e3 * 42.0 / 8.0)
   }
 
   test("unit megabits") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.MEGABITS))
-    assert(v === 1e6 * 42.0 / 8.0)
+    assertEquals(v, 1e6 * 42.0 / 8.0)
   }
 
   test("unit gigabits") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.GIGABITS))
-    assert(v === 1e9 * 42.0 / 8.0)
+    assertEquals(v, 1e9 * 42.0 / 8.0)
   }
 
   test("unit terabits") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.TERABITS))
-    assert(v === 1e12 * 42.0 / 8.0)
+    assertEquals(v, 1e12 * 42.0 / 8.0)
   }
 
   test("unit bytes") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.BYTES))
-    assert(v === 42.0)
+    assertEquals(v, 42.0)
   }
 
   test("unit kilobytes") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.KILOBYTES))
-    assert(v === 1e3 * 42.0)
+    assertEquals(v, 1e3 * 42.0)
   }
 
   test("unit megabytes") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.MEGABYTES))
-    assert(v === 1e6 * 42.0)
+    assertEquals(v, 1e6 * 42.0)
   }
 
   test("unit gigabytes") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.GIGABYTES))
-    assert(v === 1e9 * 42.0)
+    assertEquals(v, 1e9 * 42.0)
   }
 
   test("unit terabytes") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.TERABYTES))
-    assert(v === 1e12 * 42.0)
+    assertEquals(v, 1e12 * 42.0)
   }
 
   test("unit bits/second") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.BITS_SECOND))
-    assert(v === 42.0 / 8.0)
+    assertEquals(v, 42.0 / 8.0)
   }
 
   test("unit kilobits/second") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.KILOBITS_SECOND))
-    assert(v === 1e3 * 42.0 / 8.0)
+    assertEquals(v, 1e3 * 42.0 / 8.0)
   }
 
   test("unit megabits/second") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.MEGABITS_SECOND))
-    assert(v === 1e6 * 42.0 / 8.0)
+    assertEquals(v, 1e6 * 42.0 / 8.0)
   }
 
   test("unit gigabits/second") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.GIGABITS_SECOND))
-    assert(v === 1e9 * 42.0 / 8.0)
+    assertEquals(v, 1e9 * 42.0 / 8.0)
   }
 
   test("unit terabits/second") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.TERABITS_SECOND))
-    assert(v === 1e12 * 42.0 / 8.0)
+    assertEquals(v, 1e12 * 42.0 / 8.0)
   }
 
   test("unit bytes/second") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.BYTES_SECOND))
-    assert(v === 42.0)
+    assertEquals(v, 42.0)
   }
 
   test("unit kilobytes/second") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.KILOBYTES_SECOND))
-    assert(v === 1e3 * 42.0)
+    assertEquals(v, 1e3 * 42.0)
   }
 
   test("unit megabytes/second") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.MEGABYTES_SECOND))
-    assert(v === 1e6 * 42.0)
+    assertEquals(v, 1e6 * 42.0)
   }
 
   test("unit gigabytes/second") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.GIGABYTES_SECOND))
-    assert(v === 1e9 * 42.0)
+    assertEquals(v, 1e9 * 42.0)
   }
 
   test("unit terabytes/second") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.TERABYTES_SECOND))
-    assert(v === 1e12 * 42.0)
+    assertEquals(v, 1e12 * 42.0)
   }
 
   test("unit microseconds") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.MICROSECONDS))
-    assert(v === 1e-6 * 42.0)
+    assertEquals(v, 1e-6 * 42.0)
   }
 
   test("unit milliseconds") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.MILLISECONDS))
-    assert(v === 1e-3 * 42.0)
+    assertEquals(v, 1e-3 * 42.0)
   }
 
   test("unit seconds") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.SECONDS))
-    assert(v === 42.0)
+    assertEquals(v, 42.0)
   }
 
   test("unit percent") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.PERCENT))
-    assert(v === 42.0)
+    assertEquals(v, 42.0)
   }
 
   test("ratio to percent") {
     val cnv = Conversions.fromName("sum,percent")
     val v = cnv(null, newDatapoint(0.42, StandardUnit.PERCENT))
-    assert(v === 42.0)
+    assertEquals(v, 42.0)
   }
 
   test("unit none") {
     val cnv = Conversions.fromName("sum")
     val v = cnv(null, newDatapoint(42.0, StandardUnit.NONE))
-    assert(v === 42.0)
+    assertEquals(v, 42.0)
   }
 
   test("multiply") {
     val cnv = Conversions.multiply(Conversions.fromName("sum"), 100.0)
     val v = cnv(null, newDatapoint(42.0))
-    assert(v === 4200.0)
+    assertEquals(v, 4200.0)
   }
 
   test("dstype for max") {
-    assert(Conversions.determineDsType("max") === "gauge")
+    assertEquals(Conversions.determineDsType("max"), "gauge")
   }
 
   test("dstype for sum") {
-    assert(Conversions.determineDsType("sum") === "gauge")
+    assertEquals(Conversions.determineDsType("sum"), "gauge")
   }
 
   test("dstype for count") {
-    assert(Conversions.determineDsType("count") === "gauge")
+    assertEquals(Conversions.determineDsType("count"), "gauge")
   }
 
   test("dstype for sum,rate") {
-    assert(Conversions.determineDsType("sum,rate") === "rate")
+    assertEquals(Conversions.determineDsType("sum,rate"), "rate")
   }
 
   test("dstype for count,rate") {
-    assert(Conversions.determineDsType("count,rate") === "rate")
+    assertEquals(Conversions.determineDsType("count,rate"), "rate")
   }
 }

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
@@ -18,10 +18,10 @@ package com.netflix.atlas.cloudwatch
 import java.util.regex.PatternSyntaxException
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 import software.amazon.awssdk.services.cloudwatch.model.Dimension
 
-class DefaultTaggerSuite extends AnyFunSuite {
+class DefaultTaggerSuite extends FunSuite {
 
   private val dimensions = List(
     Dimension.builder().name("CloudWatch").value("abc").build(),
@@ -62,7 +62,7 @@ class DefaultTaggerSuite extends AnyFunSuite {
     )
 
     val tagger = new DefaultTagger(cfg)
-    assert(tagger(dimensions) === expected)
+    assertEquals(tagger(dimensions), expected)
   }
 
   test("apply key mappings") {
@@ -85,7 +85,7 @@ class DefaultTaggerSuite extends AnyFunSuite {
     )
 
     val tagger = new DefaultTagger(cfg)
-    assert(tagger(dimensions) === expected)
+    assertEquals(tagger(dimensions), expected)
   }
 
   test("extract value for configured keys") {
@@ -120,7 +120,7 @@ class DefaultTaggerSuite extends AnyFunSuite {
     )
 
     val tagger = new DefaultTagger(cfg)
-    assert(tagger(dimensions) === expected)
+    assertEquals(tagger(dimensions), expected)
   }
 
   test("syntax error in extractor pattern throws") {
@@ -189,7 +189,7 @@ class DefaultTaggerSuite extends AnyFunSuite {
     )
 
     val tagger = new DefaultTagger(cfg)
-    assert(tagger(dimensions) === expected)
+    assertEquals(tagger(dimensions), expected)
   }
 
   test("extract value and apply alias for configured keys") {
@@ -225,7 +225,7 @@ class DefaultTaggerSuite extends AnyFunSuite {
     )
 
     val tagger = new DefaultTagger(cfg)
-    assert(tagger(dimensions) === expected)
+    assertEquals(tagger(dimensions), expected)
   }
 
   test("mapping is ignored if extractor of the same name exists") {
@@ -258,7 +258,7 @@ class DefaultTaggerSuite extends AnyFunSuite {
     )
 
     val tagger = new DefaultTagger(cfg)
-    assert(tagger(dimensions) === expected)
+    assertEquals(tagger(dimensions), expected)
   }
 
   test("first extractor pattern has precedence") {
@@ -291,7 +291,7 @@ class DefaultTaggerSuite extends AnyFunSuite {
     )
 
     val tagger = new DefaultTagger(cfg)
-    assert(tagger(dimensions) === expected)
+    assertEquals(tagger(dimensions), expected)
   }
 
   test("dimensions override common tags") {
@@ -319,7 +319,7 @@ class DefaultTaggerSuite extends AnyFunSuite {
     )
 
     val tagger = new DefaultTagger(cfg)
-    assert(tagger(dimensions) === expected)
+    assertEquals(tagger(dimensions), expected)
   }
 
   test("aws.alb is assigned to LoadBalancer names starting with 'app' using production config") {
@@ -337,7 +337,7 @@ class DefaultTaggerSuite extends AnyFunSuite {
       )
     )
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("aws.nlb is assigned to LoadBalancer names starting with 'net' using production config") {
@@ -355,6 +355,6 @@ class DefaultTaggerSuite extends AnyFunSuite {
       )
     )
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 }

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
@@ -20,9 +20,9 @@ import java.time.Duration
 import com.netflix.atlas.core.model.Query
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class MetricCategorySuite extends AnyFunSuite {
+class MetricCategorySuite extends FunSuite {
   test("bad config") {
     val cfg = ConfigFactory.empty()
     intercept[ConfigException] {
@@ -59,7 +59,7 @@ class MetricCategorySuite extends AnyFunSuite {
       """.stripMargin)
 
     val category = MetricCategory.fromConfig(cfg)
-    assert(category.namespace === "AWS/Lambda")
+    assertEquals(category.namespace, "AWS/Lambda")
     assert(category.dimensions.isEmpty)
   }
 
@@ -114,10 +114,10 @@ class MetricCategorySuite extends AnyFunSuite {
       """.stripMargin)
 
     val category = MetricCategory.fromConfig(cfg)
-    assert(category.namespace === "AWS/ELB")
-    assert(category.period === 60)
-    assert(category.toListRequests.size === 2)
-    assert(category.filter === Query.True)
+    assertEquals(category.namespace, "AWS/ELB")
+    assertEquals(category.period, 60)
+    assertEquals(category.toListRequests.size, 2)
+    assertEquals(category.filter, Query.True)
   }
 
   test("category without timeout") {
@@ -143,7 +143,7 @@ class MetricCategorySuite extends AnyFunSuite {
 
     val category = MetricCategory.fromConfig(cfg)
     assert(category.timeout.nonEmpty)
-    assert(category.timeout.get === Duration.ofDays(1))
+    assertEquals(category.timeout.get, Duration.ofDays(1))
   }
 
   test("config with filter") {
@@ -162,7 +162,7 @@ class MetricCategorySuite extends AnyFunSuite {
       """.stripMargin)
 
     val category = MetricCategory.fromConfig(cfg)
-    assert(category.filter === Query.Equal("name", "RequestCount"))
+    assertEquals(category.filter, Query.Equal("name", "RequestCount"))
   }
 
   test("config with invalid filter") {

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDataSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDataSuite.scala
@@ -19,11 +19,11 @@ import java.time.Duration
 import java.time.Instant
 import com.netflix.atlas.cloudwatch.CloudWatchPoller.MetricData
 import com.netflix.atlas.core.model.Query
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 import software.amazon.awssdk.services.cloudwatch.model.Datapoint
 import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
 
-class MetricDataSuite extends AnyFunSuite {
+class MetricDataSuite extends FunSuite {
 
   private val definition =
     MetricDefinition("test", "alias", Conversions.fromName("sum"), false, Map.empty)
@@ -52,12 +52,12 @@ class MetricDataSuite extends AnyFunSuite {
 
   test("access datapoint with no current value") {
     val data = MetricData(metadata, None, None, None)
-    assert(data.datapoint().sum === 0.0)
+    assertEquals(data.datapoint().sum.doubleValue(), 0.0)
   }
 
   test("access datapoint with current value") {
     val data = MetricData(metadata, None, datapoint(1.0), None)
-    assert(data.datapoint().sum === 1.0)
+    assertEquals(data.datapoint().sum.doubleValue(), 1.0)
   }
 
   test("category with timeout, first datapoint not yet received") {
@@ -69,7 +69,7 @@ class MetricDataSuite extends AnyFunSuite {
   test("category with timeout, datapoint with current value and not timed out") {
     val now = Instant.now()
     val data = MetricData(metadataWithTimeout, None, datapoint(1.0), Some(now.minusSeconds(60)))
-    assert(data.datapoint(now).sum === 1.0)
+    assertEquals(data.datapoint(now).sum.doubleValue(), 1.0)
   }
 
   // current and timed out shouldn't be possible, but fail open by ensuring the current value is
@@ -77,14 +77,14 @@ class MetricDataSuite extends AnyFunSuite {
   test("category with timeout, datapoint with current value and timed out") {
     val now = Instant.now()
     val data = MetricData(metadataWithTimeout, None, datapoint(1.0), Some(now.minusSeconds(600)))
-    assert(data.datapoint(now).sum === 1.0)
+    assertEquals(data.datapoint(now).sum.doubleValue(), 1.0)
   }
 
   test("category with timeout, datapoint with current and previous value and not timed out") {
     val now = Instant.now()
     val data =
       MetricData(metadataWithTimeout, datapoint(2.0), datapoint(1.0), Some(now.minusSeconds(60)))
-    assert(data.datapoint(now).sum === 1.0)
+    assertEquals(data.datapoint(now).sum.doubleValue(), 1.0)
   }
 
   // current and timed out shouldn't be possible, but fail open by ensuring the current value is
@@ -93,13 +93,13 @@ class MetricDataSuite extends AnyFunSuite {
     val now = Instant.now()
     val data =
       MetricData(metadataWithTimeout, datapoint(2.0), datapoint(1.0), Some(now.minusSeconds(600)))
-    assert(data.datapoint(now).sum === 1.0)
+    assertEquals(data.datapoint(now).sum.doubleValue(), 1.0)
   }
 
   test("category with timeout, datapoint with only previous value and not timed out") {
     val now = Instant.now()
     val data = MetricData(metadataWithTimeout, datapoint(1.0), None, Some(now.minusSeconds(60)))
-    assert(data.datapoint(now).sum === 0.0)
+    assertEquals(data.datapoint(now).sum.doubleValue(), 0.0)
   }
 
   test("category with timeout, datapoint with only previous value and timed out") {
@@ -111,7 +111,7 @@ class MetricDataSuite extends AnyFunSuite {
   test("category with timeout, datapoint with no current or previous value and not timed out") {
     val now = Instant.now()
     val data = MetricData(metadataWithTimeout, None, None, Some(now.minusSeconds(60)))
-    assert(data.datapoint(now).sum === 0.0)
+    assertEquals(data.datapoint(now).sum.doubleValue(), 0.0)
   }
 
   test("category with timeout, datapoint with no current or previous value and timed out") {
@@ -137,21 +137,21 @@ class MetricDataSuite extends AnyFunSuite {
 
   test("access monotonic datapoint, current is larger") {
     val data = MetricData(monotonicMetadata, datapoint(1.0), datapoint(2.0), None)
-    assert(data.datapoint().sum === 1.0)
+    assertEquals(data.datapoint().sum.doubleValue(), 1.0)
   }
 
   test("access monotonic datapoint, previous is larger") {
     val data = MetricData(monotonicMetadata, datapoint(2.0), datapoint(1.0), None)
-    assert(data.datapoint().sum === 0.0)
+    assertEquals(data.datapoint().sum.doubleValue(), 0.0)
   }
 
   test("access monotonic datapoint, previous equals current") {
     val data = MetricData(monotonicMetadata, datapoint(1.0), datapoint(1.0), None)
-    assert(data.datapoint().sum === 0.0)
+    assertEquals(data.datapoint().sum.doubleValue(), 0.0)
   }
 
   test("access monotonic datapoint, current is larger, previous dup") {
     val data = MetricData(monotonicMetadata, datapoint(1.0, 3), datapoint(2.0), None)
-    assert(data.datapoint().sum === 1.0)
+    assertEquals(data.datapoint().sum.doubleValue(), 1.0)
   }
 }

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
@@ -18,14 +18,13 @@ package com.netflix.atlas.cloudwatch
 import com.netflix.atlas.core.model.Query
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
+import munit.FunSuite
 import software.amazon.awssdk.services.cloudwatch.model.Datapoint
 import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
 
 import java.time.Instant
 
-class MetricDefinitionSuite extends AnyFunSuite with Matchers {
+class MetricDefinitionSuite extends FunSuite {
 
   private val meta = MetricMetadata(
     MetricCategory("AWS/ELB", 60, 1, 5, None, Nil, Nil, Query.True),
@@ -48,9 +47,9 @@ class MetricDefinitionSuite extends AnyFunSuite with Matchers {
       """.stripMargin)
 
     val definitions = MetricDefinition.fromConfig(cfg)
-    assert(definitions.size === 1)
-    assert(definitions.head.name === "RequestCount")
-    assert(definitions.head.alias === "aws.elb.requests")
+    assertEquals(definitions.size, 1)
+    assertEquals(definitions.head.name, "RequestCount")
+    assertEquals(definitions.head.alias, "aws.elb.requests")
   }
 
   test("config with dsytpe rate") {
@@ -61,8 +60,8 @@ class MetricDefinitionSuite extends AnyFunSuite with Matchers {
       """.stripMargin)
 
     val definitions = MetricDefinition.fromConfig(cfg)
-    assert(definitions.size === 1)
-    assert(definitions.head.tags === Map("atlas.dstype" -> "rate"))
+    assertEquals(definitions.size, 1)
+    assertEquals(definitions.head.tags, Map("atlas.dstype" -> "rate"))
   }
 
   test("config with dsytpe gauge") {
@@ -73,8 +72,8 @@ class MetricDefinitionSuite extends AnyFunSuite with Matchers {
       """.stripMargin)
 
     val definitions = MetricDefinition.fromConfig(cfg)
-    assert(definitions.size === 1)
-    assert(definitions.head.tags === Map("atlas.dstype" -> "gauge"))
+    assertEquals(definitions.size, 1)
+    assertEquals(definitions.head.tags, Map("atlas.dstype" -> "gauge"))
   }
 
   test("config for timer") {
@@ -85,8 +84,8 @@ class MetricDefinitionSuite extends AnyFunSuite with Matchers {
       """.stripMargin)
 
     val definitions = MetricDefinition.fromConfig(cfg)
-    assert(definitions.size === 3)
-    assert(definitions.map(_.tags("statistic")).toSet === Set("totalTime", "count", "max"))
+    assertEquals(definitions.size, 3)
+    assertEquals(definitions.map(_.tags("statistic")).toSet, Set("totalTime", "count", "max"))
 
     val dp = Datapoint
       .builder()
@@ -100,17 +99,17 @@ class MetricDefinitionSuite extends AnyFunSuite with Matchers {
 
     definitions.find(_.tags("statistic") == "totalTime").foreach { d =>
       val m = meta.copy(definition = d)
-      assert(m.convert(dp) === 10.0)
+      assertEquals(m.convert(dp), 10.0)
     }
 
     definitions.find(_.tags("statistic") == "count").foreach { d =>
       val m = meta.copy(definition = d)
-      assert(m.convert(dp) === 1000.0 / 60.0)
+      assertEquals(m.convert(dp), 1000.0 / 60.0)
     }
 
     definitions.find(_.tags("statistic") == "max").foreach { d =>
       val m = meta.copy(definition = d)
-      assert(m.convert(dp) === 6.0)
+      assertEquals(m.convert(dp), 6.0)
     }
   }
 
@@ -122,8 +121,8 @@ class MetricDefinitionSuite extends AnyFunSuite with Matchers {
       """.stripMargin)
 
     val definitions = MetricDefinition.fromConfig(cfg)
-    assert(definitions.size === 3)
-    assert(definitions.map(_.tags("statistic")).toSet === Set("totalTime", "count", "max"))
+    assertEquals(definitions.size, 3)
+    assertEquals(definitions.map(_.tags("statistic")).toSet, Set("totalTime", "count", "max"))
 
     val dp = Datapoint
       .builder()
@@ -137,17 +136,17 @@ class MetricDefinitionSuite extends AnyFunSuite with Matchers {
 
     definitions.find(_.tags("statistic") == "totalTime").foreach { d =>
       val m = meta.copy(definition = d)
-      assert(m.convert(dp) === 10.0 / 1000.0)
+      assertEquals(m.convert(dp), 10.0 / 1000.0)
     }
 
     definitions.find(_.tags("statistic") == "count").foreach { d =>
       val m = meta.copy(definition = d)
-      assert(m.convert(dp) === 1000.0 / 60.0)
+      assertEquals(m.convert(dp), 1000.0 / 60.0)
     }
 
     definitions.find(_.tags("statistic") == "max").foreach { d =>
       val m = meta.copy(definition = d)
-      assert(m.convert(dp) === 6.0 / 1000.0)
+      assertEquals(m.convert(dp), 6.0 / 1000.0)
     }
   }
 
@@ -159,8 +158,8 @@ class MetricDefinitionSuite extends AnyFunSuite with Matchers {
       """.stripMargin)
 
     val definitions = MetricDefinition.fromConfig(cfg)
-    assert(definitions.size === 3)
-    assert(definitions.map(_.tags("statistic")).toSet === Set("totalTime", "count", "max"))
+    assertEquals(definitions.size, 3)
+    assertEquals(definitions.map(_.tags("statistic")).toSet, Set("totalTime", "count", "max"))
 
     val dp = Datapoint
       .builder()
@@ -174,17 +173,17 @@ class MetricDefinitionSuite extends AnyFunSuite with Matchers {
 
     definitions.find(_.tags("statistic") == "totalTime").foreach { d =>
       val m = meta.copy(definition = d)
-      assert(m.convert(dp) === 10.0 / 1000.0)
+      assertEquals(m.convert(dp), 10.0 / 1000.0)
     }
 
     definitions.find(_.tags("statistic") == "count").foreach { d =>
       val m = meta.copy(definition = d)
-      assert(m.convert(dp) === 1000.0 / 60.0)
+      assertEquals(m.convert(dp), 1000.0 / 60.0)
     }
 
     definitions.find(_.tags("statistic") == "max").foreach { d =>
       val m = meta.copy(definition = d)
-      assert(m.convert(dp) === 6.0 / 1000.0)
+      assertEquals(m.convert(dp), 6.0 / 1000.0)
     }
   }
 
@@ -196,8 +195,8 @@ class MetricDefinitionSuite extends AnyFunSuite with Matchers {
       """.stripMargin)
 
     val definitions = MetricDefinition.fromConfig(cfg)
-    assert(definitions.size === 3)
-    assert(definitions.map(_.tags("statistic")).toSet === Set("totalAmount", "count", "max"))
+    assertEquals(definitions.size, 3)
+    assertEquals(definitions.map(_.tags("statistic")).toSet, Set("totalAmount", "count", "max"))
 
     val dp = Datapoint
       .builder()
@@ -211,17 +210,17 @@ class MetricDefinitionSuite extends AnyFunSuite with Matchers {
 
     definitions.find(_.tags("statistic") == "totalAmount").foreach { d =>
       val m = meta.copy(definition = d)
-      assert(m.convert(dp) === 10.0)
+      assertEquals(m.convert(dp), 10.0)
     }
 
     definitions.find(_.tags("statistic") == "count").foreach { d =>
       val m = meta.copy(definition = d)
-      assert(m.convert(dp) === 1000.0 / 60.0)
+      assertEquals(m.convert(dp), 1000.0 / 60.0)
     }
 
     definitions.find(_.tags("statistic") == "max").foreach { d =>
       val m = meta.copy(definition = d)
-      assert(m.convert(dp) === 6.0)
+      assertEquals(m.convert(dp), 6.0)
     }
   }
 
@@ -233,10 +232,10 @@ class MetricDefinitionSuite extends AnyFunSuite with Matchers {
       """.stripMargin)
 
     val definitions = MetricDefinition.fromConfig(cfg)
-    assert(definitions.size === 1)
+    assertEquals(definitions.size, 1)
 
     val definition = definitions.head
-    assert(definition.tags === Map("atlas.dstype" -> "gauge"))
+    assertEquals(definition.tags, Map("atlas.dstype" -> "gauge"))
 
     val dp = Datapoint
       .builder()
@@ -254,6 +253,6 @@ class MetricDefinitionSuite extends AnyFunSuite with Matchers {
       Nil
     )
 
-    metadata.convert(dp) shouldEqual 15.867 / 1000.0 +- 1e-7
+    assertEqualsDouble(metadata.convert(dp), 15.867 / 1000.0, 1e-7)
   }
 }

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/NetflixTaggerSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/NetflixTaggerSuite.scala
@@ -17,10 +17,10 @@ package com.netflix.atlas.cloudwatch
 
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 import software.amazon.awssdk.services.cloudwatch.model.Dimension
 
-class NetflixTaggerSuite extends AnyFunSuite {
+class NetflixTaggerSuite extends FunSuite {
 
   private val dimensions = List(
     Dimension.builder().name("AutoScalingGroupName").value("app_name-stack-detail-v001").build(),
@@ -37,8 +37,8 @@ class NetflixTaggerSuite extends AnyFunSuite {
         Dimension.builder().name("LinkedAccount").value("12345").build()
       )
     )
-    assert(tagged.getOrElse("aTag", "fail") === "aValue")
-    assert(tagged.getOrElse("aws.account", "fail") === "12345")
+    assertEquals(tagged.getOrElse("aTag", "fail"), "aValue")
+    assertEquals(tagged.getOrElse("aws.account", "fail"), "12345")
   }
 
   test("bad config") {
@@ -70,7 +70,7 @@ class NetflixTaggerSuite extends AnyFunSuite {
     )
 
     val tagger = new NetflixTagger(cfg)
-    assert(tagger(dimensions) === expected)
+    assertEquals(tagger(dimensions), expected)
   }
 
 }

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/guice/CloudWatchModuleSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/guice/CloudWatchModuleSuite.scala
@@ -23,12 +23,12 @@ import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class CloudWatchModuleSuite extends AnyFunSuite {
+class CloudWatchModuleSuite extends FunSuite {
 
   test("load module") {
     val deps = new AbstractModule {

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/poller/ClientActorSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/poller/ClientActorSuite.scala
@@ -21,7 +21,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.stream.Materializer
 import akka.testkit.ImplicitSender
 import akka.testkit.TestActorRef
-import akka.testkit.TestKit
+import akka.testkit.TestKitBase
 import com.netflix.atlas.core.model.Datapoint
 import com.netflix.atlas.json.Json
 import com.netflix.atlas.poller.ClientActorSuite.TestClientActor
@@ -32,8 +32,7 @@ import com.netflix.spectator.api.ManualClock
 import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuiteLike
+import munit.FunSuite
 
 import scala.concurrent.Future
 import scala.concurrent.Promise
@@ -41,13 +40,11 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-class ClientActorSuite
-    extends TestKit(ActorSystem())
-    with ImplicitSender
-    with AnyFunSuiteLike
-    with BeforeAndAfterAll {
+class ClientActorSuite extends FunSuite with TestKitBase with ImplicitSender {
 
   import scala.concurrent.duration._
+
+  implicit val system: ActorSystem = ActorSystem()
 
   private val clock = new ManualClock()
   private val registry = new DefaultRegistry(clock)
@@ -78,7 +75,7 @@ class ClientActorSuite
       waitForCompletion()
     }
 
-    assert(sent.count() === initSent + numSent)
+    assertEquals(sent.count(), initSent + numSent)
   }
 
   test("publish datapoints, exception") {

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
@@ -33,8 +33,7 @@ import com.fasterxml.jackson.databind.JsonMappingException
 import com.netflix.atlas.akka.AccessLogger
 import com.netflix.atlas.json.Json
 import com.typesafe.config.ConfigFactory
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -43,7 +42,7 @@ import scala.util.Success
 import scala.util.Try
 import scala.util.Using
 
-class DruidClientSuite extends AnyFunSuite with BeforeAndAfterAll {
+class DruidClientSuite extends FunSuite {
 
   import DruidClient._
 
@@ -73,7 +72,7 @@ class DruidClientSuite extends AnyFunSuite with BeforeAndAfterAll {
     val client = newClient(Success(ok(List("a", "b", "c"))))
     val future = client.datasources.runWith(Sink.head)
     val result = Await.result(future, Duration.Inf)
-    assert(result === List("a", "b", "c"))
+    assertEquals(result, List("a", "b", "c"))
   }
 
   test("get datasources http error") {
@@ -119,7 +118,7 @@ class DruidClientSuite extends AnyFunSuite with BeforeAndAfterAll {
     val client = newClient(Success(ok(Datasource(Nil, Nil))))
     val future = client.datasource("abc").runWith(Sink.head)
     val result = Await.result(future, Duration.Inf)
-    assert(result === Datasource(Nil, Nil))
+    assertEquals(result, Datasource(Nil, Nil))
   }
 
   test("get datasource with data") {
@@ -127,7 +126,7 @@ class DruidClientSuite extends AnyFunSuite with BeforeAndAfterAll {
     val client = newClient(Success(ok(ds)))
     val future = client.datasource("abc").runWith(Sink.head)
     val result = Await.result(future, Duration.Inf)
-    assert(result === ds)
+    assertEquals(result, ds)
   }
 
   private def executeSegmentMetadataRequest: List[SegmentMetadataResult] = {
@@ -143,10 +142,10 @@ class DruidClientSuite extends AnyFunSuite with BeforeAndAfterAll {
 
   test("segmentMetadata columns") {
     val result = executeSegmentMetadataRequest
-    assert(result.size === 1)
+    assertEquals(result.size, 1)
 
     val columns = result.head.columns
-    assert(columns.size === 5)
+    assertEquals(columns.size, 5)
 
     val expected = Set(
       "__time",
@@ -155,27 +154,27 @@ class DruidClientSuite extends AnyFunSuite with BeforeAndAfterAll {
       "test.dim.2",
       "test.metric.histogram"
     )
-    assert(columns.keySet === expected)
+    assertEquals(columns.keySet, expected)
   }
 
   test("segmentMetadata column types") {
     val columns = executeSegmentMetadataRequest.head.columns
-    assert(columns("__time").`type` === "LONG")
-    assert(columns("test.metric.counter").`type` === "LONG")
-    assert(columns("test.metric.histogram").`type` === "netflixHistogram")
-    assert(columns("test.dim.1").`type` === "STRING")
-    assert(columns("test.dim.1").`type` === "STRING")
+    assertEquals(columns("__time").`type`, "LONG")
+    assertEquals(columns("test.metric.counter").`type`, "LONG")
+    assertEquals(columns("test.metric.histogram").`type`, "netflixHistogram")
+    assertEquals(columns("test.dim.1").`type`, "STRING")
+    assertEquals(columns("test.dim.1").`type`, "STRING")
   }
 
   test("segmentMetadata aggregators") {
     val aggregators = executeSegmentMetadataRequest.head.aggregators
-    assert(aggregators.size === 2)
+    assertEquals(aggregators.size, 2)
 
     val expected = Set(
       "test.metric.counter",
       "test.metric.histogram"
     )
-    assert(aggregators.keySet === expected)
+    assertEquals(aggregators.keySet, expected)
   }
 
   private def executeGroupByRequest: List[GroupByDatapoint] = {
@@ -192,7 +191,7 @@ class DruidClientSuite extends AnyFunSuite with BeforeAndAfterAll {
 
   test("groupBy filter out null dimensions") {
     val datapoints = executeGroupByRequest
-    assert(datapoints.count(_.tags.isEmpty) === 2)
-    assert(datapoints.count(_.tags.nonEmpty) === 5)
+    assertEquals(datapoints.count(_.tags.isEmpty), 2)
+    assertEquals(datapoints.count(_.tags.nonEmpty), 5)
   }
 }

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
@@ -25,47 +25,47 @@ import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.QueryVocabulary
 import com.netflix.atlas.core.stacklang.Interpreter
 import com.netflix.atlas.druid.DruidClient._
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class DruidDatabaseActorSuite extends AnyFunSuite {
+class DruidDatabaseActorSuite extends FunSuite {
 
   import DruidDatabaseActor._
 
   test("dimension to spec no matches") {
     val spec = toDimensionSpec("key", Query.Equal("app", "www"))
     val expected = DefaultDimensionSpec("key", "key")
-    assert(spec === expected)
+    assertEquals(spec, expected)
   }
 
   test("dimension to spec: equal query") {
     val spec = toDimensionSpec("app", Query.Equal("app", "www"))
     val expected = ListFilteredDimensionSpec(DefaultDimensionSpec("app", "app"), List("www"))
-    assert(spec === expected)
+    assertEquals(spec, expected)
   }
 
   test("dimension to spec: in query") {
     val spec = toDimensionSpec("app", Query.In("app", List("a", "b", "c")))
     val expected =
       ListFilteredDimensionSpec(DefaultDimensionSpec("app", "app"), List("a", "b", "c"))
-    assert(spec === expected)
+    assertEquals(spec, expected)
   }
 
   test("dimension to spec: regex query") {
     val spec = toDimensionSpec("app", Query.Regex("app", "www"))
     val expected = RegexFilteredDimensionSpec(DefaultDimensionSpec("app", "app"), "^www.*")
-    assert(spec === expected)
+    assertEquals(spec, expected)
   }
 
   test("dimension to spec: has key query") {
     val spec = toDimensionSpec("app", Query.HasKey("app"))
     val expected = DefaultDimensionSpec("app", "app")
-    assert(spec === expected)
+    assertEquals(spec, expected)
   }
 
   test("dimension to spec: gt query") {
     val spec = toDimensionSpec("app", Query.GreaterThan("app", "www"))
     val expected = DefaultDimensionSpec("app", "app")
-    assert(spec === expected)
+    assertEquals(spec, expected)
   }
 
   test("dimension to spec: nested") {
@@ -86,62 +86,62 @@ class DruidDatabaseActorSuite extends AnyFunSuite {
       ),
       List("a", "b", "c")
     )
-    assert(spec === expected)
+    assertEquals(spec, expected)
   }
 
   test("exactTags: extract equal clauses") {
     val expected = Map("a" -> "1", "b" -> "2")
     val query = Query.And(Query.Equal("a", "1"), Query.Equal("b", "2"))
-    assert(exactTags(query) === expected)
+    assertEquals(exactTags(query), expected)
   }
 
   test("exactTags: ignore regex") {
     val expected = Map("b" -> "2")
     val query = Query.And(Query.Regex("a", "1"), Query.Equal("b", "2"))
-    assert(exactTags(query) === expected)
+    assertEquals(exactTags(query), expected)
   }
 
   test("exactTags: ignore OR subtree") {
     val expected = Map("a" -> "1")
     val query =
       Query.And(Query.Equal("a", "1"), Query.Or(Query.Equal("b", "2"), Query.Equal("c", "3")))
-    assert(exactTags(query) === expected)
+    assertEquals(exactTags(query), expected)
   }
 
   test("toAggregation: sum") {
     val expr = DataExpr.Sum(Query.Equal("a", "1"))
     val aggr = toAggregation("test", expr)
-    assert(aggr === Aggregation.sum("test"))
+    assertEquals(aggr, Aggregation.sum("test"))
   }
 
   test("toAggregation: count") {
     val expr = DataExpr.Count(Query.Equal("a", "1"))
     val aggr = toAggregation("test", expr)
-    assert(aggr === Aggregation.count("test"))
+    assertEquals(aggr, Aggregation.count("test"))
   }
 
   test("toAggregation: min") {
     val expr = DataExpr.Min(Query.Equal("a", "1"))
     val aggr = toAggregation("test", expr)
-    assert(aggr === Aggregation.min("test"))
+    assertEquals(aggr, Aggregation.min("test"))
   }
 
   test("toAggregation: max") {
     val expr = DataExpr.Max(Query.Equal("a", "1"))
     val aggr = toAggregation("test", expr)
-    assert(aggr === Aggregation.max("test"))
+    assertEquals(aggr, Aggregation.max("test"))
   }
 
   test("toAggregation: sum grouped") {
     val expr = DataExpr.GroupBy(DataExpr.Sum(Query.Equal("a", "1")), List("a"))
     val aggr = toAggregation("test", expr)
-    assert(aggr === Aggregation.sum("test"))
+    assertEquals(aggr, Aggregation.sum("test"))
   }
 
   test("toAggregation: max grouped") {
     val expr = DataExpr.GroupBy(DataExpr.Max(Query.Equal("a", "1")), List("a"))
     val aggr = toAggregation("test", expr)
-    assert(aggr === Aggregation.max("test"))
+    assertEquals(aggr, Aggregation.max("test"))
   }
 
   test("toAggregation: sum grouped max cf") {
@@ -150,7 +150,7 @@ class DruidDatabaseActorSuite extends AnyFunSuite {
       List("a")
     )
     val aggr = toAggregation("test", expr)
-    assert(aggr === Aggregation.sum("test"))
+    assertEquals(aggr, Aggregation.sum("test"))
   }
 
   test("toAggregation: all") {
@@ -168,7 +168,7 @@ class DruidDatabaseActorSuite extends AnyFunSuite {
         List("1")
       )
     )
-    assert(getDimensions(expr) === expected)
+    assertEquals(getDimensions(expr), expected)
   }
 
   test("getDimensions: regex sum") {
@@ -179,26 +179,26 @@ class DruidDatabaseActorSuite extends AnyFunSuite {
         "^1.*"
       )
     )
-    assert(getDimensions(expr) === expected)
+    assertEquals(getDimensions(expr), expected)
   }
 
   test("getDimensions: has sum") {
     val expr = DataExpr.GroupBy(DataExpr.Sum(Query.HasKey("a")), List("a"))
     val expected = List(DefaultDimensionSpec("a", "a"))
-    assert(getDimensions(expr) === expected)
+    assertEquals(getDimensions(expr), expected)
   }
 
   test("getDimensions: greater-than sum") {
     val expr = DataExpr.GroupBy(DataExpr.Sum(Query.GreaterThan("a", "1")), List("a"))
     val expected = List(DefaultDimensionSpec("a", "a"))
-    assert(getDimensions(expr) === expected)
+    assertEquals(getDimensions(expr), expected)
   }
 
   test("getDimensions: regex sum ignore special") {
     val expr =
       DataExpr.GroupBy(DataExpr.Sum(Query.Regex("nf.datasource", "1")), List("nf.datasource"))
     val expected = List.empty[DimensionSpec]
-    assert(getDimensions(expr) === expected)
+    assertEquals(getDimensions(expr), expected)
   }
 
   private val metadata = Metadata(
@@ -232,27 +232,27 @@ class DruidDatabaseActorSuite extends AnyFunSuite {
     val expr = DataExpr.Sum(Query.Equal("a", "1"))
     val queries = toDruidQueries(metadata, context, expr)
 
-    assert(queries.size === 4)
-    assert(queries.map(_._1("name")).toSet === Set("m1", "m2", "m3"))
-    assert(queries.map(_._1("nf.datasource")).toSet === Set("ds_1", "ds_2"))
+    assertEquals(queries.size, 4)
+    assertEquals(queries.map(_._1("name")).toSet, Set("m1", "m2", "m3"))
+    assertEquals(queries.map(_._1("nf.datasource")).toSet, Set("ds_1", "ds_2"))
   }
 
   test("toDruidQueries: unknown dimensions") {
     val expr = DataExpr.Sum(Query.HasKey("c"))
     val queries = toDruidQueries(metadata, context, expr)
 
-    assert(queries.size === 2)
-    assert(queries.map(_._1("name")).toSet === Set("m1", "m3"))
-    assert(queries.map(_._1("nf.datasource")).toSet === Set("ds_2"))
+    assertEquals(queries.size, 2)
+    assertEquals(queries.map(_._1("name")).toSet, Set("m1", "m3"))
+    assertEquals(queries.map(_._1("nf.datasource")).toSet, Set("ds_2"))
   }
 
   test("toDruidQueries: unknown dimensions missing") {
     val expr = DataExpr.Sum(Query.Not(Query.HasKey("c")))
     val queries = toDruidQueries(metadata, context, expr)
 
-    assert(queries.size === 4)
-    assert(queries.map(_._1("name")).toSet === Set("m1", "m2", "m3"))
-    assert(queries.map(_._1("nf.datasource")).toSet === Set("ds_1", "ds_2"))
+    assertEquals(queries.size, 4)
+    assertEquals(queries.map(_._1("name")).toSet, Set("m1", "m2", "m3"))
+    assertEquals(queries.map(_._1("nf.datasource")).toSet, Set("ds_1", "ds_2"))
   }
 
   test("toDruidQueries: or with one missing dimension") {
@@ -270,65 +270,65 @@ class DruidDatabaseActorSuite extends AnyFunSuite {
 
   test("simplifyExact: conjunctive clause") {
     val q = evalQuery("a,1,:eq,b,2,:eq,:and,c,3,:eq,:and")
-    assert(simplifyExact(q) === q)
+    assertEquals(simplifyExact(q), q)
   }
 
   test("simplifyExact: not eq clause") {
     val q = evalQuery("a,1,:eq,b,2,:eq,:and,c,3,:eq,:not,:and")
     val expected = evalQuery("a,1,:eq,b,2,:eq,:and")
-    assert(simplifyExact(q) === expected)
+    assertEquals(simplifyExact(q), expected)
   }
 
   test("simplifyExact: not re clause") {
     val q = evalQuery("a,1,:eq,b,2,:eq,:and,c,3,:re,:not,:and")
     val expected = evalQuery("a,1,:eq,b,2,:eq,:and")
-    assert(simplifyExact(q) === expected)
+    assertEquals(simplifyExact(q), expected)
   }
 
   test("simplifyExact: or clause") {
     val q = evalQuery("a,1,:eq,a,2,:eq,:or")
-    assert(simplifyExact(q) === Query.True)
+    assertEquals(simplifyExact(q), Query.True)
   }
 
   test("simplifyExact: or query as part of conjunctive clause") {
     val q = evalQuery("a,1,:eq,b,2,:eq,c,2,:eq,:or,:and")
     val expected = evalQuery("a,1,:eq")
-    assert(simplifyExact(q) === expected)
+    assertEquals(simplifyExact(q), expected)
   }
 
   test("createValueMapper: normalize rates, sum") {
     val expr = DataExpr.Sum(Query.Equal("a", "1"))
     val mapper = createValueMapper(true, context, expr)
-    assert(mapper(1.0) === 1.0 / 60)
+    assertEquals(mapper(1.0), 1.0 / 60)
   }
 
   test("createValueMapper: normalize rates, max") {
     val expr = DataExpr.Max(Query.Equal("a", "1"))
     val mapper = createValueMapper(true, context, expr)
-    assert(mapper(1.0) === 1.0 / 60)
+    assertEquals(mapper(1.0), 1.0 / 60)
   }
 
   test("createValueMapper: avg consolidation") {
     val expr = DataExpr.Sum(Query.Equal("a", "1"))
     val mapper = createValueMapper(false, context.copy(step = 300000), expr)
-    assert(mapper(1.0) === 1.0 / 5)
+    assertEquals(mapper(1.0), 1.0 / 5)
   }
 
   test("createValueMapper: max consolidation") {
     val expr = DataExpr.Max(Query.Equal("a", "1"))
     val mapper = createValueMapper(false, context.copy(step = 300000), expr)
-    assert(mapper(1.0) === 1.0)
+    assertEquals(mapper(1.0), 1.0)
   }
 
   test("createValueMapper: min consolidation") {
     val expr = DataExpr.Min(Query.Equal("a", "1"))
     val mapper = createValueMapper(false, context.copy(step = 300000), expr)
-    assert(mapper(1.0) === 1.0)
+    assertEquals(mapper(1.0), 1.0)
   }
 
   test("createValueMapper: sum consolidation") {
     val expr = DataExpr.Sum(Query.Equal("a", "1")).withConsolidation(ConsolidationFunction.Sum)
     val mapper = createValueMapper(false, context.copy(step = 300000), expr)
-    assert(mapper(1.0) === 1.0)
+    assertEquals(mapper(1.0), 1.0)
   }
 }

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidFilterSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidFilterSuite.scala
@@ -18,9 +18,9 @@ package com.netflix.atlas.druid
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.QueryVocabulary
 import com.netflix.atlas.core.stacklang.Interpreter
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class DruidFilterSuite extends AnyFunSuite {
+class DruidFilterSuite extends FunSuite {
 
   private val interpreter = new Interpreter(QueryVocabulary.allWords)
 
@@ -34,31 +34,31 @@ class DruidFilterSuite extends AnyFunSuite {
   test("forQuery - nf.datasource :eq") {
     val actual = DruidFilter.forQuery(eval("nf.datasource,foo,:eq"))
     val expected = None
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - nf.datasource :re") {
     val actual = DruidFilter.forQuery(eval("nf.datasource,foo,:re"))
     val expected = None
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - nf.datasource :has") {
     val actual = DruidFilter.forQuery(eval("nf.datasource,:has"))
     val expected = None
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - name :eq") {
     val actual = DruidFilter.forQuery(eval("name,foo,:eq"))
     val expected = None
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - :true") {
     val actual = DruidFilter.forQuery(eval(":true"))
     val expected = None
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("toFilter - :true") {
@@ -76,13 +76,13 @@ class DruidFilterSuite extends AnyFunSuite {
   test("forQuery - :eq") {
     val actual = DruidFilter.forQuery(eval("country,US,:eq"))
     val expected = Some(DruidFilter.Equal("country", "US"))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - :re") {
     val actual = DruidFilter.forQuery(eval("country,US,:re"))
     val expected = Some(DruidFilter.Regex("country", "^US"))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - :reic") {
@@ -90,55 +90,55 @@ class DruidFilterSuite extends AnyFunSuite {
     val actual = DruidFilter.forQuery(eval("country,US,:reic"))
     val expected =
       Some(DruidFilter.Regex("country", "(?i)^US"))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - :has") {
     val actual = DruidFilter.forQuery(eval("country,:has"))
     val expected = Some(DruidFilter.Not(DruidFilter.Equal("country", "")))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - :in") {
     val actual = DruidFilter.forQuery(eval("country,(,US,CA,),:in"))
     val expected = Some(DruidFilter.In("country", List("US", "CA")))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - :gt") {
     val actual = DruidFilter.forQuery(eval("country,US,:gt"))
     val expected = Some(DruidFilter.JavaScript("country", "function(x) { return x > 'US'; }"))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - :ge") {
     val actual = DruidFilter.forQuery(eval("country,US,:ge"))
     val expected = Some(DruidFilter.JavaScript("country", "function(x) { return x >= 'US'; }"))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - :lt") {
     val actual = DruidFilter.forQuery(eval("country,US,:lt"))
     val expected = Some(DruidFilter.JavaScript("country", "function(x) { return x < 'US'; }"))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - :le") {
     val actual = DruidFilter.forQuery(eval("country,US,:le"))
     val expected = Some(DruidFilter.JavaScript("country", "function(x) { return x <= 'US'; }"))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - :le sanitize single quote") {
     val actual = DruidFilter.forQuery(eval("country,US',:le"))
     val expected = Some(DruidFilter.JavaScript("country", "function(x) { return x <= 'US_'; }"))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - :le sanitize double quote") {
     val actual = DruidFilter.forQuery(eval("country,US\",:le"))
     val expected = Some(DruidFilter.JavaScript("country", "function(x) { return x <= 'US_'; }"))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - :and") {
@@ -151,7 +151,7 @@ class DruidFilterSuite extends AnyFunSuite {
         )
       )
     )
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - :or") {
@@ -164,12 +164,12 @@ class DruidFilterSuite extends AnyFunSuite {
         )
       )
     )
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("forQuery - :not") {
     val actual = DruidFilter.forQuery(eval("country,(,US,CA,),:in,:not"))
     val expected = Some(DruidFilter.Not(DruidFilter.In("country", List("US", "CA"))))
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 }

--- a/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/RollingFileWriterSuite.scala
+++ b/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/RollingFileWriterSuite.scala
@@ -25,23 +25,21 @@ import org.apache.avro.file.DataFileReader
 import org.apache.avro.generic.GenericDatumReader
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.util.Utf8
-import org.scalatest.BeforeAndAfter
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.collection.mutable.ListBuffer
 
-class RollingFileWriterSuite extends AnyFunSuite with BeforeAndAfter with BeforeAndAfterAll {
+class RollingFileWriterSuite extends FunSuite {
 
   private val outputDir = "./target/unitTestAvroOutput"
   private val registry = new NoopRegistry
 
-  before {
+  override def beforeEach(context: BeforeEach): Unit = {
     listFilesSorted(outputDir).foreach(_.delete()) // Clean up files if exits
     Files.createDirectories(Paths.get(outputDir))
   }
 
-  after {
+  override def afterEach(context: AfterEach): Unit = {
     listFilesSorted(outputDir).foreach(_.delete())
     Files.deleteIfExists(Paths.get(outputDir))
   }

--- a/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/S3CopySinkSuite.scala
+++ b/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/S3CopySinkSuite.scala
@@ -15,14 +15,12 @@
  */
 package com.netflix.atlas.persistence
 
-import org.scalatest.BeforeAndAfter
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class S3CopySinkSuite extends AnyFunSuite with BeforeAndAfter with BeforeAndAfterAll {
+class S3CopySinkSuite extends FunSuite {
   test("extractMinuteRange") {
-    assert(S3CopySink.extractMinuteRange("abc.tmp") === "61-61")
-    assert(S3CopySink.extractMinuteRange("abc.1200-1300") === "20-21")
-    assert(S3CopySink.extractMinuteRange("abc.0000-0123") === "00-02")
+    assertEquals(S3CopySink.extractMinuteRange("abc.tmp"), "61-61")
+    assertEquals(S3CopySink.extractMinuteRange("abc.1200-1300"), "20-21")
+    assertEquals(S3CopySink.extractMinuteRange("abc.0000-0123"), "00-02")
   }
 }

--- a/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/DynamoOpsSuite.scala
+++ b/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/DynamoOpsSuite.scala
@@ -19,9 +19,9 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.time.Duration
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class DynamoOpsSuite extends AnyFunSuite with DynamoOps {
+class DynamoOpsSuite extends FunSuite with DynamoOps {
 
   def mkByteBuffer(s: String): ByteBuffer = {
     ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8))
@@ -30,21 +30,21 @@ class DynamoOpsSuite extends AnyFunSuite with DynamoOps {
   test("compress and decompress") {
     val input = "Atlas Slotting Service"
     val compressed = Util.compress(input)
-    assert(input === Util.decompress(compressed))
+    assertEquals(input, Util.decompress(compressed))
   }
 
   test("active items spec") {
     val scanSpec = activeItemsScanRequest("test")
-    assert(scanSpec.filterExpression === "#a = :v1")
-    assert(scanSpec.expressionAttributeNames.toString === s"{#a=$Active}")
-    assert(scanSpec.expressionAttributeValues.toString === "{:v1=AttributeValue(BOOL=true)}")
+    assertEquals(scanSpec.filterExpression, "#a = :v1")
+    assertEquals(scanSpec.expressionAttributeNames.toString, s"{#a=$Active}")
+    assertEquals(scanSpec.expressionAttributeValues.toString, "{:v1=AttributeValue(BOOL=true)}")
   }
 
   test("old items spec") {
     val scanSpec = oldItemsScanRequest("test", Duration.ofDays(1))
-    assert(scanSpec.filterExpression === "#t < :v1")
-    assert(scanSpec.projectionExpression === "#n")
-    assert(scanSpec.expressionAttributeNames.toString === s"{#n=$Name, #t=$Timestamp}")
+    assertEquals(scanSpec.filterExpression, "#t < :v1")
+    assertEquals(scanSpec.projectionExpression, "#n")
+    assertEquals(scanSpec.expressionAttributeNames.toString, s"{#n=$Name, #t=$Timestamp}")
   }
 
   test("new asg item") {
@@ -60,22 +60,25 @@ class DynamoOpsSuite extends AnyFunSuite with DynamoOps {
     val oldData = mkByteBuffer("""{"name": "atlas_app-main-all-v001", "desiredCapacity": 3}""")
     val newData = mkByteBuffer("""{"name": "atlas_app-main-all-v001", "desiredCapacity": 6}""")
     val updateSpec = updateAsgItemRequest("test", "atlas_app-main-all-v001", oldData, newData)
-    assert(updateSpec.conditionExpression === "#d = :v1")
-    assert(updateSpec.updateExpression === s"set #d = :v2, #a = :v3, #t = :v4")
-    assert(updateSpec.expressionAttributeNames.toString === s"{#a=$Active, #d=data, #t=$Timestamp}")
+    assertEquals(updateSpec.conditionExpression, "#d = :v1")
+    assertEquals(updateSpec.updateExpression, s"set #d = :v2, #a = :v3, #t = :v4")
+    assertEquals(
+      updateSpec.expressionAttributeNames.toString,
+      s"{#a=$Active, #d=data, #t=$Timestamp}"
+    )
   }
 
   test("update timestamp spec") {
     val updateSpec = updateTimestampItemRequest("test", "atlas_app-main-all-v001", 1556568270713L)
-    assert(updateSpec.conditionExpression === "#t = :v1")
-    assert(updateSpec.updateExpression === s"set #a = :v2, #t = :v3")
-    assert(updateSpec.expressionAttributeNames.toString === s"{#a=$Active, #t=$Timestamp}")
+    assertEquals(updateSpec.conditionExpression, "#t = :v1")
+    assertEquals(updateSpec.updateExpression, s"set #a = :v2, #t = :v3")
+    assertEquals(updateSpec.expressionAttributeNames.toString, s"{#a=$Active, #t=$Timestamp}")
   }
 
   test("deactivate asg spec") {
     val updateSpec = deactivateAsgItemRequest("test", "atlas_app-main-all-v001")
-    assert(updateSpec.conditionExpression === "#a = :v1")
-    assert(updateSpec.updateExpression === s"set #a = :v2, #t = :v3")
-    assert(updateSpec.expressionAttributeNames.toString === s"{#a=$Active, #t=$Timestamp}")
+    assertEquals(updateSpec.conditionExpression, "#a = :v1")
+    assertEquals(updateSpec.updateExpression, s"set #a = :v2, #t = :v3")
+    assertEquals(updateSpec.expressionAttributeNames.toString, s"{#a=$Active, #t=$Timestamp}")
   }
 }

--- a/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/GroupingSuite.scala
+++ b/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/GroupingSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.slotting
 
 import java.time.Instant
 import com.netflix.atlas.json.Json
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 import software.amazon.awssdk.services.autoscaling.model.AutoScalingGroup
 import software.amazon.awssdk.services.autoscaling.model.{Instance => AsgInstance}
 import software.amazon.awssdk.services.ec2.model.{Instance => Ec2Instance}
@@ -25,7 +25,7 @@ import software.amazon.awssdk.services.ec2.model.{Instance => Ec2Instance}
 import scala.jdk.CollectionConverters._
 import scala.io.Source
 
-class GroupingSuite extends AnyFunSuite with Grouping {
+class GroupingSuite extends FunSuite with Grouping {
 
   test("get app") {
     val res = List(
@@ -34,7 +34,7 @@ class GroupingSuite extends AnyFunSuite with Grouping {
       "atlas_app-main-all-v003"
     ).map(getApp)
 
-    assert(res === List("atlas_app", "atlas_app", "atlas_app"))
+    assertEquals(res, List("atlas_app", "atlas_app", "atlas_app"))
   }
 
   test("get cluster") {
@@ -44,7 +44,7 @@ class GroupingSuite extends AnyFunSuite with Grouping {
       "atlas_app-main-all-v003"
     ).map(getCluster)
 
-    assert(res === List("atlas_app", "atlas_app-main", "atlas_app-main-all"))
+    assertEquals(res, List("atlas_app", "atlas_app-main", "atlas_app-main-all"))
   }
 
   test("make asg details") {
@@ -81,12 +81,12 @@ class GroupingSuite extends AnyFunSuite with Grouping {
 
     val asgDetails = mkAsgDetails(asg)
 
-    assert(asgDetails.name === "atlas_app-main-all-v001")
-    assert(asgDetails.cluster === "atlas_app-main-all")
-    assert(asgDetails.desiredCapacity === 3)
-    assert(asgDetails.maxSize === 6)
-    assert(asgDetails.minSize === 0)
-    assert(asgDetails.instances.map(_.instanceId) === List("i-001", "i-002", "i-003"))
+    assertEquals(asgDetails.name, "atlas_app-main-all-v001")
+    assertEquals(asgDetails.cluster, "atlas_app-main-all")
+    assertEquals(asgDetails.desiredCapacity, 3)
+    assertEquals(asgDetails.maxSize, 6)
+    assertEquals(asgDetails.minSize, 0)
+    assertEquals(asgDetails.instances.map(_.instanceId), List("i-001", "i-002", "i-003"))
   }
 
   test("make ec2 instance details") {
@@ -101,9 +101,9 @@ class GroupingSuite extends AnyFunSuite with Grouping {
 
     val details = mkEc2InstanceDetails(instance)
 
-    assert(details.imageId === "ami-001")
-    assert(details.instanceType === "r4.large")
-    assert(details.privateIpAddress === "192.168.1.1")
+    assertEquals(details.imageId, "ami-001")
+    assertEquals(details.instanceType, "r4.large")
+    assertEquals(details.privateIpAddress, "192.168.1.1")
   }
 
   test("make slotted instance details") {
@@ -133,9 +133,9 @@ class GroupingSuite extends AnyFunSuite with Grouping {
 
     val slotted = mkSlottedInstanceDetailsList(asgDetails, instanceInfo)
 
-    assert(slotted.map(_.instanceId) === List("i-001", "i-002", "i-003"))
-    assert(slotted.map(_.privateIpAddress) === List("192.168.1.1", "192.168.1.2", "192.168.1.3"))
-    assert(slotted.map(_.slot) === List(-1, -1, -1))
+    assertEquals(slotted.map(_.instanceId), List("i-001", "i-002", "i-003"))
+    assertEquals(slotted.map(_.privateIpAddress), List("192.168.1.1", "192.168.1.2", "192.168.1.3"))
+    assertEquals(slotted.map(_.slot), List(-1, -1, -1))
   }
 
   test("slotted asg details - too many instances") {
@@ -157,7 +157,7 @@ class GroupingSuite extends AnyFunSuite with Grouping {
       )
     }
 
-    assert(caught.getMessage === "requirement failed: instances.size (3) > desiredCapacity (2)")
+    assertEquals(caught.getMessage, "requirement failed: instances.size (3) > desiredCapacity (2)")
   }
 
   test("assign slots") {
@@ -187,9 +187,9 @@ class GroupingSuite extends AnyFunSuite with Grouping {
 
     val slotted = assignSlots(asgDetails, instanceInfo)
 
-    assert(slotted.map(_.instanceId) === List("i-001", "i-002", "i-003"))
-    assert(slotted.map(_.privateIpAddress) === List("192.168.1.1", "192.168.1.2", "192.168.1.3"))
-    assert(slotted.map(_.slot) === List(0, 1, 2))
+    assertEquals(slotted.map(_.instanceId), List("i-001", "i-002", "i-003"))
+    assertEquals(slotted.map(_.privateIpAddress), List("192.168.1.1", "192.168.1.2", "192.168.1.3"))
+    assertEquals(slotted.map(_.slot), List(0, 1, 2))
   }
 
   private def loadSlottedInstanceDetails(resource: String): SlottedInstanceDetails = {
@@ -242,9 +242,9 @@ class GroupingSuite extends AnyFunSuite with Grouping {
 
     val merged = mergeSlots(oldAsgSlotted, newAsgDetails, instanceInfo)
 
-    assert(merged.map(_.instanceId) === List("i-001", "i-004", "i-003"))
-    assert(merged.map(_.privateIpAddress) === List("192.168.1.1", "192.168.1.4", "192.168.1.3"))
-    assert(merged.map(_.slot) === List(0, 1, 2))
+    assertEquals(merged.map(_.instanceId), List("i-001", "i-004", "i-003"))
+    assertEquals(merged.map(_.privateIpAddress), List("192.168.1.1", "192.168.1.4", "192.168.1.3"))
+    assertEquals(merged.map(_.slot), List(0, 1, 2))
   }
 
   test("merge slots - too many instances") {
@@ -294,7 +294,7 @@ class GroupingSuite extends AnyFunSuite with Grouping {
       mergeSlots(oldAsgSlotted, newAsgDetails, instanceInfo)
     }
 
-    assert(caught.getMessage === "key not found: i-005")
+    assertEquals(caught.getMessage, "key not found: i-005")
   }
 
   test("merge slots - too many instances, no entry in instanceInfo") {
@@ -341,8 +341,8 @@ class GroupingSuite extends AnyFunSuite with Grouping {
 
     val merged = mergeSlots(oldAsgSlotted, newAsgDetails, instanceInfo)
 
-    assert(merged.map(_.instanceId) === List("i-001", "i-004", "i-003"))
-    assert(merged.map(_.privateIpAddress) === List("192.168.1.1", "192.168.1.4", "192.168.1.3"))
-    assert(merged.map(_.slot) === List(0, 1, 2))
+    assertEquals(merged.map(_.instanceId), List("i-001", "i-004", "i-003"))
+    assertEquals(merged.map(_.privateIpAddress), List("192.168.1.1", "192.168.1.4", "192.168.1.3"))
+    assertEquals(merged.map(_.slot), List(0, 1, 2))
   }
 }

--- a/atlas-stream/src/test/scala/com/netflix/atlas/stream/DataSourceValidatorSuite.scala
+++ b/atlas-stream/src/test/scala/com/netflix/atlas/stream/DataSourceValidatorSuite.scala
@@ -16,9 +16,9 @@
 package com.netflix.atlas.stream
 
 import com.netflix.atlas.eval.stream.Evaluator.DataSource
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class DataSourceValidatorSuite extends AnyFunSuite {
+class DataSourceValidatorSuite extends FunSuite {
 
   private val validateNoop: DataSource => Unit = _ => ()
   private val validateException: DataSource => Unit = _ => { throw new Exception("validate error") }
@@ -28,7 +28,7 @@ class DataSourceValidatorSuite extends AnyFunSuite {
       """[{"id":"abc", "step": 10, "uri":"http://local-dev/api/v1/graph?q=name,jvm.gc.pause,:eq,:sum&step=10s"}]"""
     val validator = DataSourceValidator(10, validateNoop)
     validator.validate(stringValid) match {
-      case Right(dss) => assert(dss.getSources.size() === 1)
+      case Right(dss) => assertEquals(dss.getSources.size(), 1)
       case Left(_)    => fail("validation should have passed")
     }
   }
@@ -37,7 +37,7 @@ class DataSourceValidatorSuite extends AnyFunSuite {
     val stringValid = "[]"
     val validator = DataSourceValidator(10, validateNoop)
     validator.validate(stringValid) match {
-      case Right(dss) => assert(dss.getSources.size() === 0)
+      case Right(dss) => assertEquals(dss.getSources.size(), 0)
       case Left(_)    => fail("validation should have passed")
     }
   }
@@ -53,11 +53,11 @@ class DataSourceValidatorSuite extends AnyFunSuite {
       case Right(_) =>
         fail("validation should have failed")
       case Left(errors) =>
-        assert(errors.size === 2)
+        assertEquals(errors.size, 2)
         assert(errors.head.error.contains("validate error"))
-        assert(errors.head.id === "1")
+        assertEquals(errors.head.id, "1")
         assert(errors.last.error.contains("validate error"))
-        assert(errors.last.id === "2")
+        assertEquals(errors.last.id, "2")
     }
   }
 
@@ -68,7 +68,7 @@ class DataSourceValidatorSuite extends AnyFunSuite {
       case Right(_) =>
         fail("validation should have failed")
       case Left(errors) =>
-        assert(errors.size === 1)
+        assertEquals(errors.size, 1)
         assert(errors.head.error.startsWith("failed to parse input: "))
     }
   }
@@ -81,9 +81,9 @@ class DataSourceValidatorSuite extends AnyFunSuite {
       case Right(_) =>
         fail("validation should have failed")
       case Left(errors) =>
-        assert(errors.size === 1)
+        assertEquals(errors.size, 1)
         assert(errors.head.error.startsWith("id cannot be empty"))
-        assert(errors.head.id === "<empty_id>")
+        assertEquals(errors.head.id, "<empty_id>")
     }
   }
 
@@ -95,9 +95,9 @@ class DataSourceValidatorSuite extends AnyFunSuite {
       case Right(_) =>
         fail("validation should have failed")
       case Left(errors) =>
-        assert(errors.size === 1)
+        assertEquals(errors.size, 1)
         assert(errors.head.error.startsWith("id cannot be null"))
-        assert(errors.head.id === "<null_id>")
+        assertEquals(errors.head.id, "<null_id>")
     }
   }
 
@@ -112,9 +112,9 @@ class DataSourceValidatorSuite extends AnyFunSuite {
       case Right(_) =>
         fail("validation should have failed")
       case Left(errors) =>
-        assert(errors.size === 1)
-        assert(errors.head.error === "id cannot be duplicated")
-        assert(errors.head.id === "111")
+        assertEquals(errors.size, 1)
+        assertEquals(errors.head.error, "id cannot be duplicated")
+        assertEquals(errors.head.id, "111")
     }
   }
 
@@ -124,7 +124,7 @@ class DataSourceValidatorSuite extends AnyFunSuite {
     )
     val validator = DataSourceValidator(10, validateNoop)
     validator.validate(dsList) match {
-      case Right(dss) => assert(dss.getSources.size() === 1)
+      case Right(dss) => assertEquals(dss.getSources.size(), 1)
       case Left(_)    => fail("validation should have passed")
     }
   }
@@ -145,8 +145,8 @@ class DataSourceValidatorSuite extends AnyFunSuite {
       case Right(_) =>
         fail("validation should have passed")
       case Left(errors) =>
-        assert(errors.head.error === "id cannot be duplicated")
-        assert(errors.head.id === "111")
+        assertEquals(errors.head.error, "id cannot be duplicated")
+        assertEquals(errors.head.id, "111")
     }
   }
 
@@ -166,8 +166,8 @@ class DataSourceValidatorSuite extends AnyFunSuite {
       case Right(_) =>
         fail("validation should have passed")
       case Left(errors) =>
-        assert(errors.head.error === "number of DataSources cannot exceed 1")
-        assert(errors.head.id === "_")
+        assertEquals(errors.head.error, "number of DataSources cannot exceed 1")
+        assertEquals(errors.head.id, "_")
     }
   }
 

--- a/atlas-stream/src/test/scala/com/netflix/atlas/stream/EvalFlowSuite.scala
+++ b/atlas-stream/src/test/scala/com/netflix/atlas/stream/EvalFlowSuite.scala
@@ -24,12 +24,12 @@ import com.netflix.atlas.eval.stream.Evaluator.DataSources
 import com.netflix.atlas.eval.stream.Evaluator.MessageEnvelope
 import com.netflix.spectator.api.NoopRegistry
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class EvalFlowSuite extends AnyFunSuite {
+class EvalFlowSuite extends FunSuite {
   private implicit val system = ActorSystem(getClass.getSimpleName)
   private val config = ConfigFactory.load
   private val registry = new NoopRegistry()
@@ -58,6 +58,6 @@ class EvalFlowSuite extends AnyFunSuite {
       .runWith(Sink.head)
     val messageEnvelope = Await.result(future, Duration.Inf)
 
-    assert(messageEnvelope.getId === "mockId")
+    assertEquals(messageEnvelope.getId, "mockId")
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val `atlas-aggregator` = project
 
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaTestkit % "test",
-    Dependencies.scalatest % "test"
+    Dependencies.munit % "test"
   ))
 
 lazy val `atlas-cloudwatch` = project
@@ -59,7 +59,7 @@ lazy val `atlas-cloudwatch` = project
     Dependencies.atlasWebApi % "test",
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaTestkit % "test",
-    Dependencies.scalatest % "test"
+    Dependencies.munit % "test"
   ))
 
 lazy val `atlas-druid` = project
@@ -108,7 +108,8 @@ lazy val `atlas-slotting` = project
 
       Dependencies.akkaHttpTestkit % "test",
       Dependencies.akkaTestkit % "test",
-      Dependencies.scalatest % "test"
+      Dependencies.atlasAkkaTestkit % "test",
+      Dependencies.munit % "test"
   ))
 
 lazy val `atlas-stream` = project
@@ -123,7 +124,7 @@ lazy val `atlas-stream` = project
 
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaTestkit % "test",
-    Dependencies.scalatest % "test"
+    Dependencies.munit % "test"
   ))
 
 lazy val `iep-archaius` = project
@@ -142,7 +143,8 @@ lazy val `iep-archaius` = project
 
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaTestkit % "test",
-    Dependencies.scalatest % "test"
+    Dependencies.atlasAkkaTestkit % "test",
+    Dependencies.munit % "test"
   ))
 
 lazy val `iep-atlas` = project
@@ -186,7 +188,8 @@ lazy val `iep-lwc-bridge` = project
 
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaTestkit % "test",
-    Dependencies.scalatest % "test"
+    Dependencies.atlasAkkaTestkit % "test",
+    Dependencies.munit % "test"
   ))
 
 lazy val `iep-lwc-cloudwatch-model` = project
@@ -210,7 +213,7 @@ lazy val `iep-lwc-cloudwatch` = project
 
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaTestkit % "test",
-    Dependencies.scalatest % "test"
+    Dependencies.munit % "test"
   ))
 
 lazy val `iep-lwc-fwding-admin` = project
@@ -232,7 +235,8 @@ lazy val `iep-lwc-fwding-admin` = project
 
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaTestkit % "test",
-    Dependencies.scalatest % "test"
+    Dependencies.atlasAkkaTestkit % "test",
+    Dependencies.munit % "test"
   ))
 
 
@@ -249,7 +253,7 @@ lazy val `iep-lwc-loadgen` = project
 
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaTestkit % "test",
-    Dependencies.scalatest % "test"
+    Dependencies.munit % "test"
   ))
 
 lazy val `iep-ses-monitor` = project
@@ -268,6 +272,6 @@ lazy val `iep-ses-monitor` = project
 
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaTestkit % "test",
-    Dependencies.scalatest % "test"
+    Dependencies.munit % "test"
   ))
 

--- a/iep-archaius/src/test/scala/com/netflix/iep/archaius/PropertiesApiSuite.scala
+++ b/iep-archaius/src/test/scala/com/netflix/iep/archaius/PropertiesApiSuite.scala
@@ -17,21 +17,19 @@ package com.netflix.iep.archaius
 
 import java.io.StringReader
 import java.util.Properties
-
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.testkit.RouteTestTimeout
-import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.netflix.atlas.akka.RequestHandler
+import com.netflix.atlas.akka.testkit.MUnitRouteSuite
 import com.netflix.atlas.json.Json
 import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.ManualClock
-import org.scalatest.funsuite.AnyFunSuite
 
-class PropertiesApiSuite extends AnyFunSuite with ScalatestRouteTest {
+class PropertiesApiSuite extends MUnitRouteSuite {
   import scala.concurrent.duration._
   implicit val routeTestTimeout = RouteTestTimeout(5.second)
 
@@ -42,17 +40,17 @@ class PropertiesApiSuite extends AnyFunSuite with ScalatestRouteTest {
   val routes = RequestHandler.standardOptions(endpoint.routes)
 
   private def assertJsonContentType(response: HttpResponse): Unit = {
-    assert(response.entity.contentType.mediaType === MediaTypes.`application/json`)
+    assertEquals(response.entity.contentType.mediaType, MediaTypes.`application/json`)
   }
 
   private def assertResponse(response: HttpResponse, expected: StatusCode): Unit = {
-    assert(response.status === expected)
+    assertEquals(response.status, expected)
     assertJsonContentType(response)
   }
 
   test("no asg") {
     Get("/api/v1/property") ~> routes ~> check {
-      assert(response.status === StatusCodes.BadRequest)
+      assertEquals(response.status, StatusCodes.BadRequest)
     }
   }
 
@@ -63,7 +61,7 @@ class PropertiesApiSuite extends AnyFunSuite with ScalatestRouteTest {
     routes ~>
     check {
       assertResponse(response, StatusCodes.OK)
-      assert(responseAs[String] === "[]")
+      assertEquals(responseAs[String], "[]")
     }
   }
 
@@ -76,12 +74,12 @@ class PropertiesApiSuite extends AnyFunSuite with ScalatestRouteTest {
       )
     )
     Get("/api/v1/property?asg=foo-main-v001") ~> routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
       val props = new Properties
       props.load(new StringReader(responseAs[String]))
-      assert(props.size === 2)
-      assert(props.getProperty("a") === "b")
-      assert(props.getProperty("1") === "2")
+      assertEquals(props.size, 2)
+      assertEquals(props.getProperty("a"), "b")
+      assertEquals(props.getProperty("1"), "2")
     }
   }
 
@@ -97,7 +95,7 @@ class PropertiesApiSuite extends AnyFunSuite with ScalatestRouteTest {
     check {
       assertResponse(response, StatusCodes.OK)
       val props = Json.decode[List[PropertiesApi.Property]](responseAs[String])
-      assert(props === List(PropertiesApi.Property("foo-main::a", "foo-main", "a", "b", 12345L)))
+      assertEquals(props, List(PropertiesApi.Property("foo-main::a", "foo-main", "a", "b", 12345L)))
     }
   }
 }

--- a/iep-archaius/src/test/scala/com/netflix/iep/archaius/PropertiesLoaderSuite.scala
+++ b/iep-archaius/src/test/scala/com/netflix/iep/archaius/PropertiesLoaderSuite.scala
@@ -18,23 +18,21 @@ package com.netflix.iep.archaius
 import akka.actor.ActorSystem
 import akka.testkit.ImplicitSender
 import akka.testkit.TestActorRef
-import akka.testkit.TestKit
+import akka.testkit.TestKitBase
 import com.netflix.atlas.json.Json
 import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.ManualClock
+import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuiteLike
+import munit.FunSuite
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse
 
-class PropertiesLoaderSuite
-    extends TestKit(ActorSystem())
-    with ImplicitSender
-    with AnyFunSuiteLike
-    with BeforeAndAfterAll {
+class PropertiesLoaderSuite extends FunSuite with TestKitBase with ImplicitSender {
 
-  val config = ConfigFactory.parseString("""
+  implicit val system: ActorSystem = ActorSystem()
+
+  val config: Config = ConfigFactory.parseString("""
       |netflix.iep.archaius.table = "test"
     """.stripMargin)
 
@@ -67,12 +65,13 @@ class PropertiesLoaderSuite
   test("init") {
     waitForUpdate()
     assert(propContext.initialized)
-    assert(
-      propContext.getAll === List(
-          PropertiesApi.Property("foo-main::a", "foo-main", "a", "b", 12345L),
-          PropertiesApi.Property("foo-main::1", "foo-main", "1", "2", 12345L),
-          PropertiesApi.Property("bar-main::c", "bar-main", "c", "d", 12345L)
-        )
+    assertEquals(
+      propContext.getAll,
+      List(
+        PropertiesApi.Property("foo-main::a", "foo-main", "a", "b", 12345L),
+        PropertiesApi.Property("foo-main::1", "foo-main", "1", "2", 12345L),
+        PropertiesApi.Property("bar-main::c", "bar-main", "c", "d", 12345L)
+      )
     )
   }
 
@@ -83,11 +82,12 @@ class PropertiesLoaderSuite
 
     waitForUpdate()
 
-    assert(
-      propContext.getAll === List(
-          PropertiesApi.Property("foo-main::a", "foo-main", "a", "b", 12345L),
-          PropertiesApi.Property("bar-main::c", "bar-main", "c", "d", 12345L)
-        )
+    assertEquals(
+      propContext.getAll,
+      List(
+        PropertiesApi.Property("foo-main::a", "foo-main", "a", "b", 12345L),
+        PropertiesApi.Property("bar-main::c", "bar-main", "c", "d", 12345L)
+      )
     )
   }
 

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExprUpdateServiceSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExprUpdateServiceSuite.scala
@@ -25,8 +25,7 @@ import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.ManualClock
 import com.netflix.spectator.api.patterns.PolledMeter
 import com.typesafe.config.ConfigFactory
-import org.scalatest.BeforeAndAfter
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
@@ -35,7 +34,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.util.Using
 
-class ExprUpdateServiceSuite extends AnyFunSuite with BeforeAndAfter {
+class ExprUpdateServiceSuite extends FunSuite {
 
   private implicit val system = ActorSystem()
 
@@ -54,7 +53,7 @@ class ExprUpdateServiceSuite extends AnyFunSuite with BeforeAndAfter {
     Await.ready(future, Duration.Inf)
   }
 
-  before {
+  override def beforeEach(context: BeforeEach): Unit = {
     clock.setWallTime(0)
     evaluator.clear()
   }
@@ -110,7 +109,7 @@ class ExprUpdateServiceSuite extends AnyFunSuite with BeforeAndAfter {
 
   test("valid update rebuilds index") {
     doValidUpdate()
-    assert(1 === evaluator.index.findMatches(Id.create("cpu")).size)
+    assertEquals(1, evaluator.index.findMatches(Id.create("cpu")).size)
   }
 
   test("valid update refreshes age metric") {
@@ -119,12 +118,12 @@ class ExprUpdateServiceSuite extends AnyFunSuite with BeforeAndAfter {
     doValidUpdate()
     PolledMeter.update(registry)
     val age = registry.gauge("lwc.expressionsAge").value()
-    assert(age === 0.0)
+    assertEquals(age, 0.0)
   }
 
   test("valid update compressed") {
     doValidUpdate(true)
-    assert(1 === evaluator.index.findMatches(Id.create("cpu")).size)
+    assertEquals(1, evaluator.index.findMatches(Id.create("cpu")).size)
   }
 
   test("invalid expression does not refresh age metric") {
@@ -133,6 +132,6 @@ class ExprUpdateServiceSuite extends AnyFunSuite with BeforeAndAfter {
     doInvalidUpdate()
     PolledMeter.update(registry)
     val age = registry.gauge("lwc.expressionsAge").value()
-    assert(age === 60.0)
+    assertEquals(age, 60.0)
   }
 }

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/StatsApiSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/StatsApiSuite.scala
@@ -20,16 +20,14 @@ import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.RouteTestTimeout
-import akka.http.scaladsl.testkit.ScalatestRouteTest
 import com.netflix.atlas.akka.RequestHandler
+import com.netflix.atlas.akka.testkit.MUnitRouteSuite
 import com.netflix.atlas.json.Json
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.atlas.impl.Subscription
 import com.typesafe.config.ConfigFactory
-import org.scalatest.BeforeAndAfter
-import org.scalatest.funsuite.AnyFunSuite
 
-class StatsApiSuite extends AnyFunSuite with ScalatestRouteTest with BeforeAndAfter {
+class StatsApiSuite extends MUnitRouteSuite {
 
   import scala.jdk.CollectionConverters._
   import scala.concurrent.duration._
@@ -42,22 +40,22 @@ class StatsApiSuite extends AnyFunSuite with ScalatestRouteTest with BeforeAndAf
   private val routes = RequestHandler.standardOptions(endpoint.routes)
 
   private def assertJsonContentType(response: HttpResponse): Unit = {
-    assert(response.entity.contentType.mediaType === MediaTypes.`application/json`)
+    assertEquals(response.entity.contentType.mediaType, MediaTypes.`application/json`)
   }
 
   private def assertResponse(response: HttpResponse, expected: StatusCode): Unit = {
-    assert(response.status === expected)
+    assertEquals(response.status, expected)
     assertJsonContentType(response)
   }
 
-  before {
+  override def beforeEach(context: BeforeEach): Unit = {
     evaluator.clear()
   }
 
   test("empty") {
     Get("/api/v1/stats") ~> routes ~> check {
       assertResponse(response, StatusCodes.OK)
-      assert(responseAs[String] === "[]")
+      assertEquals(responseAs[String], "[]")
     }
   }
 
@@ -84,8 +82,8 @@ class StatsApiSuite extends AnyFunSuite with ScalatestRouteTest with BeforeAndAf
     Get("/api/v1/stats") ~> routes ~> check {
       assertResponse(response, StatusCodes.OK)
       val stats = Json.decode[List[ExpressionsEvaluator.SubscriptionStats]](responseAs[String])
-      assert(stats.length === 1)
-      assert(stats.head.updateCount.get() === 2)
+      assertEquals(stats.length, 1)
+      assertEquals(stats.head.updateCount.get(), 2L)
     }
   }
 }

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ApiSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ApiSuite.scala
@@ -16,7 +16,6 @@
 package com.netflix.iep.lwc.fwd.admin
 
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
 import com.netflix.atlas.akka.StreamOps.SourceQueue
@@ -33,15 +32,11 @@ import com.typesafe.scalalogging.StrictLogging
 import ExpressionDetails._
 import akka.Done
 import akka.stream.Materializer
-import org.scalatest.funsuite.AnyFunSuite
+import com.netflix.atlas.akka.testkit.MUnitRouteSuite
 
 import scala.concurrent.Future
 
-class ApiSuite
-    extends AnyFunSuite
-    with ScalatestRouteTest
-    with CwForwardingTestConfig
-    with StrictLogging {
+class ApiSuite extends MUnitRouteSuite with CwForwardingTestConfig with StrictLogging {
 
   private val config = ConfigFactory.load()
 
@@ -79,7 +74,7 @@ class ApiSuite
     )
 
     postRequest ~> routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
     }
   }
 
@@ -101,7 +96,7 @@ class ApiSuite
     )
 
     postRequest ~> routes ~> check {
-      assert(response.status === StatusCodes.BadRequest)
+      assertEquals(response.status, StatusCodes.BadRequest)
       assert(
         entityAs[String]
           .contains(
@@ -130,8 +125,8 @@ class ApiSuite
     )
 
     postRequest ~> routes ~> check {
-      assert(response.status === StatusCodes.OK)
-      assert(markerService.result.result() === reports)
+      assertEquals(response.status, StatusCodes.OK)
+      assertEquals(markerService.result.result(), reports)
     }
   }
 
@@ -142,8 +137,8 @@ class ApiSuite
     )
 
     getRequest ~> routes ~> check {
-      assert(response.status === StatusCodes.OK)
-      assert(responseAs[String] === "[]")
+      assertEquals(response.status, StatusCodes.OK)
+      assertEquals(responseAs[String], "[]")
     }
   }
 
@@ -157,7 +152,7 @@ class ApiSuite
     )
 
     delRequest ~> routes ~> check {
-      assert(response.status === StatusCodes.OK)
+      assertEquals(response.status, StatusCodes.OK)
     }
   }
 

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/CwExprValidationMethodsSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/CwExprValidationMethodsSuite.scala
@@ -23,10 +23,10 @@ import com.netflix.iep.lwc.fwd.cw.ForwardingExpression
 import com.netflix.spectator.api.NoopRegistry
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 class CwExprValidationMethodsSuite
-    extends AnyFunSuite
+    extends FunSuite
     with TestAssertions
     with CwForwardingTestConfig
     with StrictLogging {

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/CwExprValidationsSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/CwExprValidationsSuite.scala
@@ -22,10 +22,10 @@ import com.netflix.atlas.json.Json
 import com.netflix.spectator.api.NoopRegistry
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 class CwExprValidationsSuite
-    extends AnyFunSuite
+    extends FunSuite
     with TestAssertions
     with CwForwardingTestConfig
     with StrictLogging {

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/CwForwardingConfigSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/CwForwardingConfigSuite.scala
@@ -20,9 +20,9 @@ import com.netflix.atlas.eval.stream.Evaluator
 import com.netflix.spectator.api.NoopRegistry
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class CwForwardingConfigSuite extends AnyFunSuite with CwForwardingTestConfig with StrictLogging {
+class CwForwardingConfigSuite extends FunSuite with CwForwardingTestConfig with StrictLogging {
 
   private val config = ConfigFactory.load()
   private val system = ActorSystem()

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ExprInterpreterSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ExprInterpreterSuite.scala
@@ -16,9 +16,9 @@
 package com.netflix.iep.lwc.fwd.admin
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ExprInterpreterSuite extends AnyFunSuite {
+class ExprInterpreterSuite extends FunSuite {
   val interpreter = new ExprInterpreter(ConfigFactory.load())
 
   test("Should be able to parse a valid expression") {

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ExpressionDetailsDaoSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ExpressionDetailsDaoSuite.scala
@@ -22,15 +22,14 @@ import com.netflix.iep.lwc.fwd.cw.FwdMetricInfo
 import com.netflix.spectator.api.NoopRegistry
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
-import org.scalatest.BeforeAndAfter
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 import java.net.URI
 import scala.concurrent.duration._
 
-class ExpressionDetailsDaoSuite extends AnyFunSuite with BeforeAndAfter with StrictLogging {
+class ExpressionDetailsDaoSuite extends FunSuite with StrictLogging {
 
   val dao = new ExpressionDetailsDaoImpl(
     ConfigFactory.load(),
@@ -54,7 +53,7 @@ class ExpressionDetailsDaoSuite extends AnyFunSuite with BeforeAndAfter with Str
     }
   }
 
-  after {
+  override def afterEach(context: AfterEach): Unit = {
     dao.scan().foreach(dao.delete)
   }
 
@@ -101,7 +100,7 @@ class ExpressionDetailsDaoSuite extends AnyFunSuite with BeforeAndAfter with Str
 
     dao.save(exprDetails)
     val actual = dao.read(id)
-    assert(actual === Some(exprDetails))
+    assertEquals(actual, Some(exprDetails))
 
   }
 
@@ -133,19 +132,19 @@ class ExpressionDetailsDaoSuite extends AnyFunSuite with BeforeAndAfter with Str
     exprDetailsList.foreach(dao.save)
     val actual = dao.queryPurgeEligible(timestampThen, List(NoDataFoundEvent))
 
-    assert(actual === List(id.copy(key = "config3")))
+    assertEquals(actual, List(id.copy(key = "config3")))
   }
 
   localTest("Fail querying purge eligible for unknown event markers") {
-    assertThrows[IllegalArgumentException](dao.queryPurgeEligible(0L, List("foo")))
+    intercept[IllegalArgumentException](dao.queryPurgeEligible(0L, List("foo")))
   }
 
   localTest("Fail querying purge eligible for no event markers") {
-    assertThrows[IllegalArgumentException](dao.queryPurgeEligible(0L, Nil))
+    intercept[IllegalArgumentException](dao.queryPurgeEligible(0L, Nil))
   }
 }
 
-class ExpressionDetailsSuite extends AnyFunSuite with StrictLogging {
+class ExpressionDetailsSuite extends FunSuite with StrictLogging {
   test("Purge eligible expression") {
     val reportTs = 1551820461000L
     val timestampThen = reportTs + 11.minutes.toMillis

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/MarkerServiceExprDetailsSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/MarkerServiceExprDetailsSuite.scala
@@ -22,11 +22,11 @@ import com.netflix.iep.lwc.fwd.cw.ExpressionId
 import com.netflix.iep.lwc.fwd.cw.ForwardingExpression
 import com.netflix.iep.lwc.fwd.cw.FwdMetricInfo
 import com.netflix.iep.lwc.fwd.cw.Report
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.duration._
 
-class MarkerServiceExprDetailsSuite extends AnyFunSuite {
+class MarkerServiceExprDetailsSuite extends FunSuite {
 
   import ExpressionDetails._
   import MarkerServiceImpl._
@@ -85,7 +85,7 @@ class MarkerServiceExprDetailsSuite extends AnyFunSuite {
       now.toEpochMilli
     )
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("NoDataFoundEvent: Report[data=yes]") {
@@ -97,14 +97,14 @@ class MarkerServiceExprDetailsSuite extends AnyFunSuite {
     val expected = Map(NoDataFoundEvent -> report.timestamp)
     val actual = toNoDataFoundEvent(report.copy(metric = None), None)
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("NoDataFoundEvent: Report[data=no] Saved[data=yes]") {
     val expected = Map(NoDataFoundEvent -> report.timestamp)
     val actual = toNoDataFoundEvent(report.copy(metric = None), Some(prevExprDetails))
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("NoDataFoundEvent: Report[data=no] Saved[data=no]") {
@@ -114,7 +114,7 @@ class MarkerServiceExprDetailsSuite extends AnyFunSuite {
       Some(prevExprDetails.copy(events = Map(NoDataFoundEvent -> prevExprDetails.timestamp)))
     )
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("NoScalingPolicyFoundEvent: Report[sp=unknown]") {
@@ -131,7 +131,7 @@ class MarkerServiceExprDetailsSuite extends AnyFunSuite {
     val actual = toNoScalingPolicyFoundEvent(report, ScalingPolicyStatus(false, None), None)
     val expected = Map(NoScalingPolicyFoundEvent -> report.timestamp)
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("NoScalingPolicyFoundEvent: Report[sp=no] Saved[sp=yes]") {
@@ -143,7 +143,7 @@ class MarkerServiceExprDetailsSuite extends AnyFunSuite {
       )
     val expected = Map(NoScalingPolicyFoundEvent -> report.timestamp)
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("NoScalingPolicyFoundEvent: Report[sp=no] Saved[sp=no]") {
@@ -159,7 +159,7 @@ class MarkerServiceExprDetailsSuite extends AnyFunSuite {
       )
     val expected = Map(NoScalingPolicyFoundEvent -> prevExprDetails.timestamp)
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("Make Forwarded Metrics: Report[data=yes] Saved[None]") {
@@ -171,7 +171,7 @@ class MarkerServiceExprDetailsSuite extends AnyFunSuite {
       now.toEpochMilli
     )
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("Make Forwarded Metrics: Report[data=yes] Saved[data=yes]") {
@@ -192,7 +192,7 @@ class MarkerServiceExprDetailsSuite extends AnyFunSuite {
       now.toEpochMilli
     )
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("Make Forwarded Metrics: Purge old data") {
@@ -221,7 +221,7 @@ class MarkerServiceExprDetailsSuite extends AnyFunSuite {
       now.toEpochMilli
     )
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("Make Forwarded Metrics: Report[data=no] Saved[None]") {
@@ -243,7 +243,7 @@ class MarkerServiceExprDetailsSuite extends AnyFunSuite {
       List(metricInfo)
     )
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("Make Scaling Policies: Report[sp=yes] Saved[sp=yes]") {
@@ -267,7 +267,7 @@ class MarkerServiceExprDetailsSuite extends AnyFunSuite {
       List(metric1, metric2)
     )
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("Make Scaling Policies: Purge old data") {
@@ -286,6 +286,6 @@ class MarkerServiceExprDetailsSuite extends AnyFunSuite {
       List(metric1)
     )
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 }

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/MarkerServiceSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/MarkerServiceSuite.scala
@@ -26,12 +26,12 @@ import com.netflix.iep.lwc.fwd.cw.ForwardingExpression
 import com.netflix.iep.lwc.fwd.cw.FwdMetricInfo
 import com.netflix.iep.lwc.fwd.cw.Report
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class MarkerServiceSuite extends AnyFunSuite {
+class MarkerServiceSuite extends FunSuite {
 
   import MarkerServiceImpl._
 
@@ -66,7 +66,7 @@ class MarkerServiceSuite extends AnyFunSuite {
       .via(readExprDetails(exprDetailsDao))
       .runWith(Sink.head)
     val actual = Await.result(future, Duration.Inf)
-    assert(actual === Some(data))
+    assertEquals(actual, Some(data))
   }
 
   test("Read errors should be filtered out from the stream") {
@@ -99,7 +99,7 @@ class MarkerServiceSuite extends AnyFunSuite {
       .runWith(Sink.seq)
     val actual = Await.result(future, Duration.Inf)
 
-    assert(actual === List(None))
+    assertEquals(actual, List(None))
   }
 
   test("Lookup scaling policy") {
@@ -133,7 +133,7 @@ class MarkerServiceSuite extends AnyFunSuite {
       false,
       Some(ScalingPolicy("ec2Policy1", ScalingPolicy.Ec2, "metric1", Nil))
     )
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("Unknown scaling policy for no data") {
@@ -163,7 +163,7 @@ class MarkerServiceSuite extends AnyFunSuite {
       .runWith(Sink.head)
     val actual = Await.result(future, Duration.Inf)
     val expected = ScalingPolicyStatus(true, None)
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("Unknown scaling policy for dao errors") {
@@ -199,7 +199,7 @@ class MarkerServiceSuite extends AnyFunSuite {
       .runWith(Sink.head)
     val actual = Await.result(future, Duration.Inf)
     val expected = ScalingPolicyStatus(true, None)
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("Save ExpressionDetails using a dedicated dispatcher") {
@@ -232,8 +232,8 @@ class MarkerServiceSuite extends AnyFunSuite {
       .runWith(Sink.head)
     val result = Await.result(future, Duration.Inf)
 
-    assert(result === NotUsed)
-    assert(saved.result() === List(exprDetails))
+    assertEquals(result, NotUsed)
+    assertEquals(saved.result(), List(exprDetails))
   }
 
   test("Save errors should be filtered out") {
@@ -264,6 +264,6 @@ class MarkerServiceSuite extends AnyFunSuite {
       .runWith(Sink.headOption)
     val result = Await.result(future, Duration.Inf)
 
-    assert(result === None)
+    assertEquals(result, None)
   }
 }

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/PurgerSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/PurgerSuite.scala
@@ -27,14 +27,14 @@ import com.netflix.atlas.json.Json
 import com.netflix.iep.lwc.fwd.cw.ClusterConfig
 import com.netflix.iep.lwc.fwd.cw.ExpressionId
 import com.netflix.iep.lwc.fwd.cw.ForwardingExpression
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration._
 import scala.util.Success
 
-class PurgerSuite extends AnyFunSuite {
+class PurgerSuite extends FunSuite {
 
   import ExpressionDetails._
   import PurgerImpl._
@@ -82,7 +82,7 @@ class PurgerSuite extends AnyFunSuite {
     val actual = Await.result(future, Duration.Inf)
     val expected = data.filter(_.expressionId.key == "cluster1").groupBy(_.expressionId.key).toSeq
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("Read cluster config") {
@@ -111,7 +111,7 @@ class PurgerSuite extends AnyFunSuite {
 
     val actual = Await.result(future, Duration.Inf)
 
-    assert(actual === cfgPayload)
+    assertEquals(actual, cfgPayload)
   }
 
   test("Read cluster config that is not found") {
@@ -133,7 +133,7 @@ class PurgerSuite extends AnyFunSuite {
 
     val actual = Await.result(future, Duration.Inf)
 
-    assert(actual === None)
+    assertEquals(actual, None)
   }
 
   test("Update cluster config") {
@@ -161,7 +161,7 @@ class PurgerSuite extends AnyFunSuite {
 
     val expected = ClusterConfig("", expressions.filterNot(_.atlasUri == "uri1"))
 
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("Send out POST req for purging expr in cluster config") {
@@ -189,8 +189,8 @@ class PurgerSuite extends AnyFunSuite {
 
     val result = Await.result(future, Duration.Inf)
 
-    assert(result === NotUsed)
-    assert(requests.result() === List(expected))
+    assertEquals(result, NotUsed)
+    assertEquals(requests.result(), List(expected))
   }
 
   test("Remove expression details") {
@@ -211,7 +211,7 @@ class PurgerSuite extends AnyFunSuite {
       .runWith(Sink.head)
 
     val actual = Await.result(future, Duration.Inf)
-    assert(actual === NotUsed)
+    assertEquals(actual, NotUsed)
   }
 
 }

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ScalingPoliciesDaoSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ScalingPoliciesDaoSuite.scala
@@ -23,7 +23,7 @@ import akka.stream.scaladsl.Source
 import com.netflix.atlas.akka.AccessLogger
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
 import scala.concurrent.Await
 import scala.concurrent.Future
@@ -32,7 +32,7 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-class ScalingPoliciesDaoSuite extends AnyFunSuite {
+class ScalingPoliciesDaoSuite extends FunSuite {
   val config = ConfigFactory.load()
   private implicit val system = ActorSystem()
 
@@ -85,7 +85,7 @@ class ScalingPoliciesDaoSuite extends AnyFunSuite {
         List(MetricDimension("AutoScalingGroupName", "asg1"))
       )
     )
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("Lookup Titus scaling policies of type Target tracking") {
@@ -129,7 +129,7 @@ class ScalingPoliciesDaoSuite extends AnyFunSuite {
         List(MetricDimension("AutoScalingGroupName", "asg1"))
       )
     )
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("Lookup Titus scaling policies of type Step scaling") {
@@ -178,7 +178,7 @@ class ScalingPoliciesDaoSuite extends AnyFunSuite {
         List(MetricDimension("AutoScalingGroupName", "asg1"))
       )
     )
-    assert(actual === expected)
+    assertEquals(actual, expected)
   }
 
   test("Fail when a downstream call fails") {
@@ -191,7 +191,7 @@ class ScalingPoliciesDaoSuite extends AnyFunSuite {
     val dao = new LocalScalingPoliciesDaoTestImpl(data, config, system)
     val future = getScalingPolicies(dao, EddaEndpoint("123", "us-east-1", "test"))
 
-    assertThrows[NoSuchElementException](Await.result(future, Duration.Inf))
+    intercept[NoSuchElementException](Await.result(future, Duration.Inf))
   }
 
   test("Fail when status is not ok") {
@@ -202,7 +202,7 @@ class ScalingPoliciesDaoSuite extends AnyFunSuite {
     }
     val future = getScalingPolicies(dao, EddaEndpoint("123", "us-east-1", "test"))
 
-    assertThrows[NoSuchElementException](Await.result(future, Duration.Inf))
+    intercept[NoSuchElementException](Await.result(future, Duration.Inf))
   }
 
   def getScalingPolicies(

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/SchemaValidationSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/SchemaValidationSuite.scala
@@ -17,9 +17,9 @@ package com.netflix.iep.lwc.fwd.admin
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.netflix.atlas.json.Json
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class SchemaValidationSuite extends AnyFunSuite with TestAssertions with CwForwardingTestConfig {
+class SchemaValidationSuite extends FunSuite with TestAssertions with CwForwardingTestConfig {
 
   val schemaValidation = new SchemaValidation
 

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/TestAssertions.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/TestAssertions.scala
@@ -15,7 +15,7 @@
  */
 package com.netflix.iep.lwc.fwd.admin
 
-import org.scalatest.Assertions
+import munit.Assertions
 
 trait TestAssertions extends Assertions {
 

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/TimerSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/TimerSuite.scala
@@ -17,9 +17,10 @@ package com.netflix.iep.lwc.fwd.admin
 
 import com.netflix.iep.lwc.fwd.admin.Timer._
 import com.netflix.spectator.api.ManualClock
-import org.scalatest.funsuite.AnyFunSuiteLike
+import munit.FunSuite
 
-class TimerSuite extends AnyFunSuiteLike {
+class TimerSuite extends FunSuite {
+
   test("Measure time for calls that succeed") {
     val clock = new ManualClock()
     clock.setMonotonicTime(1)
@@ -50,11 +51,11 @@ class TimerSuite extends AnyFunSuiteLike {
 
     val timer = new TestTimer()
 
-    assertThrows[RuntimeException](
+    intercept[RuntimeException](
       measure(work(), "workTimer", clock, timer.record)
     )
     assert(timer.name == "workTimer")
-    assert(timer.tags === List("exception", "RuntimeException"))
+    assertEquals(timer.tags, List("exception", "RuntimeException"))
     assert(timer.duration == 1)
 
   }

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ValidationSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ValidationSuite.scala
@@ -18,9 +18,9 @@ package com.netflix.iep.lwc.fwd.admin
 import com.netflix.atlas.core.model.StyleExpr
 import com.netflix.iep.lwc.fwd.cw.ForwardingDimension
 import com.netflix.iep.lwc.fwd.cw.ForwardingExpression
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class ValidationSuite extends AnyFunSuite with TestAssertions with CwForwardingTestConfig {
+class ValidationSuite extends FunSuite with TestAssertions with CwForwardingTestConfig {
   test("Perform a required validation") {
 
     val validation = Validation(

--- a/iep-lwc-loadgen/src/test/scala/com/netflix/iep/loadgen/LoadGenServiceSuite.scala
+++ b/iep-lwc-loadgen/src/test/scala/com/netflix/iep/loadgen/LoadGenServiceSuite.scala
@@ -17,26 +17,26 @@ package com.netflix.iep.loadgen
 
 import java.time.Duration
 
-import org.scalatest.funsuite.AnyFunSuite
+import munit.FunSuite
 
-class LoadGenServiceSuite extends AnyFunSuite {
+class LoadGenServiceSuite extends FunSuite {
   test("extract step from uri") {
     val actual = LoadGenService.extractStep("/graph?q=name,foo,:eq&step=60s")
-    assert(actual === Some(Duration.ofSeconds(60)))
+    assertEquals(actual, Some(Duration.ofSeconds(60)))
   }
 
   test("extract step from uri, not present") {
     val actual = LoadGenService.extractStep("/graph?q=name,foo,:eq")
-    assert(actual === None)
+    assertEquals(actual, None)
   }
 
   test("extract step from uri, invalid uri") {
     val actual = LoadGenService.extractStep("/graph?q=name,{{ .SpinnakerApp }},:eq")
-    assert(actual === None)
+    assertEquals(actual, None)
   }
 
   test("extract step from uri, invalid step") {
     val actual = LoadGenService.extractStep("/graph?q=name,foo,:eq&step=bad")
-    assert(actual === None)
+    assertEquals(actual, None)
   }
 }

--- a/iep-ses-monitor/src/test/scala/com/netflix/iep/ses/SesMonitoringServiceSuite.scala
+++ b/iep-ses-monitor/src/test/scala/com/netflix/iep/ses/SesMonitoringServiceSuite.scala
@@ -28,9 +28,7 @@ import com.netflix.spectator.api.Functions
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.typesafe.config.ConfigFactory
-import org.scalatest.BeforeAndAfterEach
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.matchers.should.Matchers
+import munit.FunSuite
 import software.amazon.awssdk.core.exception.SdkClientException
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.GetQueueUrlResponse
@@ -39,7 +37,7 @@ import software.amazon.awssdk.services.sqs.model.Message
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAndAfterEach {
+class SesMonitoringServiceSuite extends FunSuite {
 
   private implicit val system: ActorSystem = ActorSystem()
 
@@ -52,7 +50,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
   private var sesMonitoringService: SesMonitoringService = _
   private var metricRegistry: Registry = _
 
-  override def beforeEach(): Unit = {
+  override def beforeEach(context: BeforeEach): Unit = {
     setup(new DefaultRegistry(), _ => ())
   }
 
@@ -79,7 +77,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       10.seconds
     )
 
-    processed.getClass shouldEqual classOf[MessageAction.Delete]
+    assert(processed.getClass == classOf[MessageAction.Delete])
   }
 
   test(
@@ -97,7 +95,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()
 
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     Await.result(
       Source
@@ -107,7 +105,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    counter.count() shouldEqual 1
+    assertEquals(counter.count(), 1L)
   }
 
   test(
@@ -133,7 +131,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()
 
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     Await.result(
       Source
@@ -143,7 +141,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    counter.count() shouldEqual 1
+    assertEquals(counter.count(), 1L)
   }
 
   test(
@@ -169,7 +167,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()
 
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     Await.result(
       Source
@@ -179,7 +177,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    counter.count() shouldEqual 1
+    assertEquals(counter.count(), 1L)
   }
 
   test(
@@ -206,7 +204,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()
 
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     Await.result(
       Source
@@ -216,7 +214,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.minutes
     )
 
-    counter.count() shouldEqual 1
+    assertEquals(counter.count(), 1L)
   }
 
   test(
@@ -246,8 +244,8 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()
 
-    engineerCounter.count() shouldEqual 0
-    managerCounter.count() shouldEqual 0
+    assertEquals(engineerCounter.count(), 0L)
+    assertEquals(managerCounter.count(), 0L)
 
     Await.result(
       Source
@@ -257,8 +255,8 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    engineerCounter.count() shouldEqual 1
-    managerCounter.count() shouldEqual 1
+    assertEquals(engineerCounter.count(), 1L)
+    assertEquals(managerCounter.count(), 1L)
   }
 
   test(
@@ -285,7 +283,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()
 
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     Await.result(
       Source(
@@ -301,7 +299,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    counter.count() shouldEqual 5
+    assertEquals(counter.count(), 5L)
   }
 
   test(
@@ -328,7 +326,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()
 
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     Await.result(
       Source
@@ -338,7 +336,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    counter.count() shouldEqual 1
+    assertEquals(counter.count(), 1L)
   }
 
   test(
@@ -364,7 +362,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()
 
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     Await.result(
       Source
@@ -374,7 +372,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    counter.count() shouldEqual 1
+    assertEquals(counter.count(), 1L)
   }
 
   test(
@@ -400,7 +398,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()
 
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     Await.result(
       Source(
@@ -414,7 +412,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    counter.count() shouldEqual 3
+    assertEquals(counter.count(), 3L)
   }
 
   test(
@@ -440,7 +438,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()
 
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     Await.result(
       Source
@@ -450,7 +448,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    counter.count() shouldEqual 1
+    assertEquals(counter.count(), 1L)
   }
 
   test(
@@ -475,7 +473,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()
 
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     Await.result(
       Source
@@ -485,7 +483,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    counter.count() shouldEqual 1
+    assertEquals(counter.count(), 1L)
   }
 
   test(
@@ -510,7 +508,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()
 
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     Await.result(
       Source(
@@ -527,7 +525,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    counter.count() shouldEqual 6
+    assertEquals(counter.count(), 6L)
   }
 
   test(
@@ -552,7 +550,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()
 
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     Await.result(
       Source
@@ -562,7 +560,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    counter.count() shouldEqual 1
+    assertEquals(counter.count(), 1L)
   }
 
   test("the raw notification message body should be logged") {
@@ -587,7 +585,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()
 
-    loggerCalled shouldEqual false
+    assertEquals(loggerCalled, false)
 
     Await.result(
       Source
@@ -597,8 +595,8 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    loggerCalled shouldEqual true
-    notificationBody shouldEqual bounceNotification
+    assertEquals(loggerCalled, true)
+    assertEquals(notificationBody, bounceNotification)
   }
 
   test(
@@ -622,7 +620,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
 
     val messageProcessingFlow = sesMonitoringService.createMessageProcessingFlow()
 
-    loggerCalled shouldEqual false
+    assertEquals(loggerCalled, false)
 
     Await.result(
       Source
@@ -632,7 +630,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    assert(loggerCalled === false, msg)
+    assertEquals(loggerCalled, false, msg)
   }
 
   test(
@@ -653,7 +651,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
         .createId("ses.monitor.deserializationFailure")
         .withTag("reason", "JsonEOFException")
     )
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     Await.result(
       Source
@@ -663,13 +661,13 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    counter.count() shouldEqual 1
+    assertEquals(counter.count(), 1L)
     val notificationLoggingFailureCount = metricRegistry
       .counters()
       .filter(Functions.nameEquals("ses.monitor.notificationLoggingFailure"))
       .mapToLong(_.count)
       .reduce(0L, (left: Long, right: Long) => left + right)
-    notificationLoggingFailureCount shouldEqual 0
+    assertEquals(notificationLoggingFailureCount, 0L)
 
   }
 
@@ -694,7 +692,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
         .createId("ses.monitor.notificationLoggingFailure")
         .withTag("reason", "EmptyJsonDocument")
     )
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     Await.result(
       Source
@@ -704,13 +702,13 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    counter.count() shouldEqual 1
+    assertEquals(counter.count(), 1L)
     val deserializationFailureCount = metricRegistry
       .counters()
       .filter(Functions.nameEquals("ses.monitor.deserializationFailure"))
       .mapToLong(_.count)
       .reduce(0L, (left: Long, right: Long) => left + right)
-    deserializationFailureCount shouldEqual 0
+    assertEquals(deserializationFailureCount, 0L)
   }
 
   test(
@@ -737,7 +735,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
         .createId("ses.monitor.notificationLoggingFailure")
         .withTag("reason", "IllegalStateException")
     )
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     Await.result(
       Source
@@ -747,7 +745,7 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
       2.seconds
     )
 
-    counter.count() shouldEqual 1
+    assertEquals(counter.count(), 1L)
   }
 
   test("sqs queue uri is returned on success") {
@@ -755,13 +753,13 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
     val queueUrl = "queueUrl"
     responseBuilder.queueUrl(queueUrl)
     val counter = metricRegistry.counter(metricRegistry.createId("ses.monitor.getQueueUrlFailure"))
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     val response = responseBuilder.build()
     val uriString = sesMonitoringService.getSqsQueueUrl(response, JTDuration.ofMillis(0))
 
-    counter.count() shouldEqual 0
-    uriString shouldEqual queueUrl
+    assertEquals(counter.count(), 0L)
+    assertEquals(uriString, queueUrl)
   }
 
   test(
@@ -788,13 +786,13 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
         .withTag("cause", "UnknownHostException")
     )
 
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     val uriString = sesMonitoringService.getSqsQueueUrl(getUrlSpy, JTDuration.ofMillis(10))
 
-    counter.count() shouldEqual 2
-    attempts shouldEqual 3
-    uriString shouldEqual queueUrl
+    assertEquals(counter.count(), 2L)
+    assertEquals(attempts, 3)
+    assertEquals(uriString, queueUrl)
   }
 
   test(
@@ -815,14 +813,14 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
         .withTag("cause", "NullPointerException")
     )
 
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     intercept[SdkClientException] {
       sesMonitoringService.getSqsQueueUrl(getUrlSpy, JTDuration.ofMillis(10))
     }
 
-    counter.count() shouldEqual 1
-    attempts shouldEqual 1
+    assertEquals(counter.count(), 1L)
+    assertEquals(attempts, 1)
   }
 
   test(
@@ -842,14 +840,14 @@ class SesMonitoringServiceSuite extends AnyFunSuite with Matchers with BeforeAnd
         .withTag("exception", "NullPointerException")
     )
 
-    counter.count() shouldEqual 0
+    assertEquals(counter.count(), 0L)
 
     intercept[NullPointerException] {
       sesMonitoringService.getSqsQueueUrl(getUrlSpy, JTDuration.ofMillis(10))
     }
 
-    counter.count() shouldEqual 1
-    attempts shouldEqual 1
+    assertEquals(counter.count(), 1L)
+    assertEquals(attempts, 1)
   }
 
   private def createNotificationMessage(messageBody: String): Message = {

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -50,7 +50,8 @@ object BuildSettings {
       "Build-Date"   -> java.time.Instant.now().toString,
       "Build-Number" -> sys.env.getOrElse("GITHUB_RUN_ID", "unknown"),
       "Commit"       -> sys.env.getOrElse("GITHUB_SHA", "unknown")
-    )
+    ),
+    testFrameworks += new TestFramework("munit.Framework")
   )
 
   val commonDeps = Seq(
@@ -59,7 +60,7 @@ object BuildSettings {
     Dependencies.slf4jApi,
     Dependencies.spectatorApi,
     Dependencies.typesafeConfig,
-    Dependencies.scalatest % "test")
+    Dependencies.munit % "test")
 
   val resolvers = Seq(
     Resolver.mavenLocal,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,6 +30,7 @@ object Dependencies {
   val akkaSlf4j          = "com.typesafe.akka" %% "akka-slf4j" % akka
   val akkaTestkit        = "com.typesafe.akka" %% "akka-testkit" % akka
   val alpakkaSqs         = "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % "3.0.3"
+  val atlasAkkaTestkit   = "com.netflix.atlas_v1" %% "atlas-akka-testkit" % atlas
   val atlasCore          = "com.netflix.atlas_v1" %% "atlas-core" % atlas
   val atlasEval          = "com.netflix.atlas_v1" %% "atlas-eval" % atlas
   val atlasJson          = "com.netflix.atlas_v1" %% "atlas-json" % atlas
@@ -63,11 +64,11 @@ object Dependencies {
   val log4jJcl           = "org.apache.logging.log4j" % "log4j-jcl" % log4j
   val log4jJul           = "org.apache.logging.log4j" % "log4j-jul" % log4j
   val log4jSlf4j         = "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4j
+  val munit              = "org.scalameta" %% "munit" % "0.7.29"
   val scalaCompiler      = "org.scala-lang" % "scala-compiler" % scala
   val scalaLibrary       = "org.scala-lang" % "scala-library" % scala
   val scalaLogging       = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4"
   val scalaReflect       = "org.scala-lang" % "scala-reflect" % scala
-  val scalatest          = "org.scalatest" %% "scalatest" % "3.2.10"
   val servoCore          = "com.netflix.servo" % "servo-core" % servo
   val slf4jApi           = "org.slf4j" % "slf4j-api" % slf4j
   val slf4jLog4j         = "org.slf4j" % "slf4j-log4j12" % slf4j


### PR DESCRIPTION
MUnit is used internally as it is easier to use with
gradle. Switching this project so the test frameworks
will be consistent.