### PR TITLE
fix build deprecation warnings

### DIFF
--- a/iep-atlas/build.sbt
+++ b/iep-atlas/build.sbt
@@ -6,4 +6,4 @@ packageSummary := "Atlas packaging example."
 packageDescription := """Example for how to create a package based on
   the Atlas jars."""
 
-mainClass in Compile := Some("com.netflix.iep.guice.Main")
+Compile / mainClass := Some("com.netflix.iep.guice.Main")

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -41,12 +41,12 @@ object BuildSettings {
 
     // Evictions: https://github.com/sbt/sbt/issues/1636
     // Linting: https://github.com/sbt/sbt/pull/5153
-    (evictionWarningOptions in update).withRank(KeyRanks.Invisible) := EvictionWarningOptions.empty,
+    (update / evictionWarningOptions).withRank(KeyRanks.Invisible) := EvictionWarningOptions.empty,
 
     checkLicenseHeaders := License.checkLicenseHeaders(streams.value.log, sourceDirectory.value),
     formatLicenseHeaders := License.formatLicenseHeaders(streams.value.log, sourceDirectory.value),
 
-    packageOptions in (Compile, packageBin) += Package.ManifestAttributes(
+    packageBin / packageOptions += Package.ManifestAttributes(
       "Build-Date"   -> java.time.Instant.now().toString,
       "Build-Number" -> sys.env.getOrElse("GITHUB_RUN_ID", "unknown"),
       "Commit"       -> sys.env.getOrElse("GITHUB_SHA", "unknown")

--- a/project/GitVersion.scala
+++ b/project/GitVersion.scala
@@ -54,7 +54,7 @@ object GitVersion {
   }
 
   lazy val settings: Seq[Def.Setting[_]] = Seq(
-    version in ThisBuild := {
+    ThisBuild / version := {
       val branch = extractBranchName(git.gitCurrentBranch.value)
       val branchVersion = if (branch == "master") baseVersion else branch
       git.gitDescribedVersion.value getOrElse "0.1-SNAPSHOT" match {


### PR DESCRIPTION
Replace in with [slash syntax].

[slash syntax]: https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash