### PR TITLE
avoid computing ids for persistence

### DIFF
--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/HourlyRollingWriter.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/HourlyRollingWriter.scala
@@ -15,11 +15,12 @@
  */
 package com.netflix.atlas.persistence
 
+import com.netflix.atlas.core.model.Datapoint
+
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
-import com.netflix.atlas.core.model.DatapointTuple
 import com.netflix.spectator.api.Registry
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.avro.file.CodecFactory
@@ -81,11 +82,11 @@ class HourlyRollingWriter(
     writer
   }
 
-  def write(dps: List[DatapointTuple]): Unit = {
+  def write(dps: List[Datapoint]): Unit = {
     dps.foreach(writeDp)
   }
 
-  private def writeDp(dp: DatapointTuple): Unit = {
+  private def writeDp(dp: Datapoint): Unit = {
     val now = System.currentTimeMillis()
     checkHourRollover(now)
     checkPrevHourExpiration(now)

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
@@ -29,7 +29,7 @@ import akka.stream.scaladsl.RestartFlow
 import akka.stream.scaladsl.Sink
 import com.netflix.atlas.akka.StreamOps
 import com.netflix.atlas.akka.StreamOps.SourceQueue
-import com.netflix.atlas.core.model.DatapointTuple
+import com.netflix.atlas.core.model.Datapoint
 import com.netflix.iep.service.AbstractService
 import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
@@ -74,13 +74,13 @@ class LocalFilePersistService @Inject()(
     fileConfig.getInt("avro-syncInterval")
   )
 
-  private var queue: SourceQueue[List[DatapointTuple]] = _
+  private var queue: SourceQueue[List[Datapoint]] = _
   private var flowComplete: Future[Done] = _
 
   override def startImpl(): Unit = {
     logger.info("Starting service")
     val (q, f) = StreamOps
-      .blockingQueue[List[DatapointTuple]](registry, "LocalFilePersistService", queueSize)
+      .blockingQueue[List[Datapoint]](registry, "LocalFilePersistService", queueSize)
       .via(balancer(getRollingFileFlow, writeWorkerSize))
       .toMat(Sink.ignore)(Keep.both)
       .run()
@@ -98,7 +98,7 @@ class LocalFilePersistService @Inject()(
     Math.max(1, cores / 2)
   }
 
-  private def getRollingFileFlow(workerId: Int): Flow[List[DatapointTuple], NotUsed, NotUsed] = {
+  private def getRollingFileFlow(workerId: Int): Flow[List[Datapoint], NotUsed, NotUsed] = {
     import scala.concurrent.duration._
     RestartFlow.withBackoff(
       RestartSettings(
@@ -144,7 +144,7 @@ class LocalFilePersistService @Inject()(
     logger.info("Stopped service")
   }
 
-  def persist(dp: List[DatapointTuple]): Unit = {
+  def persist(dp: List[Datapoint]): Unit = {
     queue.offer(dp)
   }
 }

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/PersistenceApi.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/PersistenceApi.scala
@@ -22,7 +22,7 @@ import akka.http.scaladsl.server.Route
 import com.netflix.atlas.akka.CustomDirectives._
 import com.netflix.atlas.akka.DiagnosticMessage
 import com.netflix.atlas.akka.WebApi
-import com.netflix.atlas.core.model.DatapointTuple
+import com.netflix.atlas.core.model.Datapoint
 import com.netflix.atlas.webapi.PublishPayloads
 
 class PersistenceApi(localFileService: LocalFilePersistService) extends WebApi {
@@ -41,9 +41,9 @@ class PersistenceApi(localFileService: LocalFilePersistService) extends WebApi {
   }
 
   private def handleReq: Route = {
-    parseEntity(customJson(p => PublishPayloads.decodeBatch(p))) {
+    parseEntity(customJson(p => PublishPayloads.decodeBatchDatapoints(p))) {
       case Nil => complete(DiagnosticMessage.error(StatusCodes.BadRequest, "empty payload"))
-      case dps: List[DatapointTuple] =>
+      case dps: List[Datapoint] =>
         if (localFileService.isHealthy) {
           localFileService.persist(dps)
           complete(HttpResponse(StatusCodes.OK))

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/RollingFileFlow.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/RollingFileFlow.scala
@@ -27,7 +27,7 @@ import akka.stream.stage.GraphStageLogic
 import akka.stream.stage.InHandler
 import akka.stream.stage.OutHandler
 import akka.stream.stage.TimerGraphStageLogic
-import com.netflix.atlas.core.model.DatapointTuple
+import com.netflix.atlas.core.model.Datapoint
 import com.netflix.spectator.api.Registry
 import com.typesafe.scalalogging.StrictLogging
 
@@ -38,12 +38,12 @@ class RollingFileFlow(
   val rollingConf: RollingConfig,
   val registry: Registry,
   val id: Int
-) extends GraphStage[FlowShape[List[DatapointTuple], NotUsed]]
+) extends GraphStage[FlowShape[List[Datapoint], NotUsed]]
     with StrictLogging {
 
-  private val in = Inlet[List[DatapointTuple]]("RollingFileSink.in")
+  private val in = Inlet[List[Datapoint]]("RollingFileSink.in")
   private val out = Outlet[NotUsed]("RollingFileSink.out")
-  override val shape = FlowShape[List[DatapointTuple], NotUsed](in, out)
+  override val shape = FlowShape[List[Datapoint], NotUsed](in, out)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
 

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/RollingFileWriter.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/RollingFileWriter.scala
@@ -20,7 +20,6 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 import com.netflix.atlas.core.model.Datapoint
-import com.netflix.atlas.core.model.DatapointTuple
 import com.netflix.atlas.core.util.SmallHashMap
 import com.netflix.spectator.api.Registry
 import com.typesafe.scalalogging.StrictLogging
@@ -62,11 +61,11 @@ class RollingFileWriter(
 
   def initialize(): Unit = newWriter()
 
-  def shouldAccept(dp: DatapointTuple): Boolean = {
+  def shouldAccept(dp: Datapoint): Boolean = {
     dp.timestamp >= startTime && dp.timestamp < endTime
   }
 
-  def write(dp: DatapointTuple): Unit = {
+  def write(dp: Datapoint): Unit = {
     if (shouldRollOver) {
       rollOver()
       newWriter()
@@ -107,7 +106,7 @@ class RollingFileWriter(
     currEndTimeSeen = startTime
   }
 
-  private def writeImpl(dp: DatapointTuple): Unit = {
+  private def writeImpl(dp: Datapoint): Unit = {
     try {
       currWriter.append(toAvro(dp))
       avroWriteCount.increment()
@@ -188,7 +187,7 @@ class RollingFileWriter(
     Random.alphanumeric.take(6).mkString
   }
 
-  private def toAvro(dp: DatapointTuple): GenericRecord = {
+  private def toAvro(dp: Datapoint): GenericRecord = {
     import scala.jdk.CollectionConverters._
     // Use custom wrapper for SmallHashMap if possible as it avoids allocations when
     // iterating across the entries.
@@ -207,8 +206,8 @@ class RollingFileWriter(
 object RollingFileWriter {
   val TmpFileSuffix: String = ".tmp"
   // A special Datapoint used solely for triggering rollover check
-  val RolloverCheckDatapoint: DatapointTuple = Datapoint(Map.empty, 0, 0).toTuple
-  val RolloverCheckDatapointList: List[DatapointTuple] = List(RolloverCheckDatapoint)
+  val RolloverCheckDatapoint: Datapoint = Datapoint(Map.empty, 0, 0)
+  val RolloverCheckDatapointList: List[Datapoint] = List(RolloverCheckDatapoint)
 
   val AvroSchema: Schema =
     new Parser().parse(Using.resource(Source.fromResource("datapoint.avsc"))(_.mkString))

--- a/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/RollingFileWriterSuite.scala
+++ b/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/RollingFileWriterSuite.scala
@@ -19,7 +19,6 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 import com.netflix.atlas.core.model.Datapoint
-import com.netflix.atlas.core.model.DatapointTuple
 import com.netflix.spectator.api.NoopRegistry
 import org.apache.avro.file.DataFileReader
 import org.apache.avro.generic.GenericDatumReader
@@ -70,7 +69,7 @@ class RollingFileWriterSuite extends FunSuite {
         )
       writer.initialize()
       createData(hourStart, 0, 1, 2).foreach(writer.write)
-      writer.write(Datapoint(Map.empty, hourEnd, 3).toTuple) // out of range, should be ignored
+      writer.write(Datapoint(Map.empty, hourEnd, 3)) // out of range, should be ignored
       writer.close()
 
       // Check num of files
@@ -97,14 +96,14 @@ class RollingFileWriterSuite extends FunSuite {
     }
   }
 
-  private def createData(startTime: Long, values: Double*): List[DatapointTuple] = {
+  private def createData(startTime: Long, values: Double*): List[Datapoint] = {
     values.toList.zipWithIndex.map {
       case (v, i) =>
         val tags = Map(
           "name" -> "cpu",
           "node" -> s"$i"
         )
-        Datapoint(tags, startTime + i * 1000, v, 60000).toTuple
+        Datapoint(tags, startTime + i * 1000, v, 60000)
     }
   }
 

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ScalingPoliciesSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ScalingPoliciesSuite.scala
@@ -21,7 +21,6 @@ import akka.actor.Props
 import akka.pattern.AskTimeoutException
 import akka.pattern.ask
 import akka.stream.scaladsl.Flow
-import akka.testkit.DefaultTimeout
 import akka.testkit.ImplicitSender
 import akka.testkit.TestActorRef
 import akka.testkit.TestKitBase


### PR DESCRIPTION
Do not computes ids when decoding the payloads for
persistence.