### PR TITLE
druid: setting for metadata interval

### DIFF
--- a/atlas-druid/src/main/resources/application.conf
+++ b/atlas-druid/src/main/resources/application.conf
@@ -5,6 +5,10 @@ atlas {
   druid {
     //uri = "http://localhost:7103/druid/v2"
 
+    // Interval used when fetching metadata about data sources that are available
+    metadata-interval = 21d
+
+    // Interval used for tag queries
     tags-interval = 6h
 
     // Maximum size for intermediate data response. If it is exceeded, then the


### PR DESCRIPTION
Adds a configuration setting that allows the metadata
interval to be different from the tag query interval.
This can be useful in some cases data is being migrated
from one datasource to another and thus would not have
recent data.