### PR TITLE
use batch increment for received counter

### DIFF
--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/BridgeApi.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/BridgeApi.scala
@@ -88,13 +88,11 @@ class BridgeApi(
     * to the LWC service.
     */
   private def process(values: List[BridgeDatapoint]): Unit = {
-    val now = registry.clock().wallTime()
-    values.foreach { v =>
-      numReceivedCounter.record(now - v.timestamp)
-    }
-
     if (values.nonEmpty) {
       val timestamp = fixTimestamp(values.head.timestamp)
+      val now = registry.clock().wallTime()
+      numReceivedCounter.increment(now - timestamp, values.size)
+
       val payload = evaluator.eval(timestamp, values)
       if (!payload.getMetrics.isEmpty || !payload.getMessages.isEmpty) {
         val entity = HttpEntity(MediaTypes.`application/json`, Json.encode(payload))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
     val scala      = "2.13.8"
     val servo      = "0.13.2"
     val slf4j      = "1.7.36"
-    val spectator  = "1.1.2"
+    val spectator  = "1.2.2"
     val avroV      = "1.11.0"
 
     val crossScala = Seq(scala)


### PR DESCRIPTION
Assume all datapoints in the incoming payload have the
same timestamp and perform a single increment on the
counter.