### PR TITLE
switch from Manifest to JavaTypeable

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -33,6 +33,7 @@ import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.module.scala.JavaTypeable
 import com.netflix.atlas.akka.AccessLogger
 import com.netflix.atlas.akka.ByteStringInputStream
 import com.netflix.atlas.json.Json
@@ -88,7 +89,7 @@ class DruidClient(
     new IOException(s"request failed with status ${res.status.intValue()}")
   }
 
-  private def mkRequest[T: Manifest](data: T): HttpRequest = {
+  private def mkRequest[T: JavaTypeable](data: T): HttpRequest = {
     val json = Json.encode(data)
     logger.trace(s"raw request payload: $json")
     val entity = HttpEntity(MediaTypes.`application/json`, json)

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
@@ -18,7 +18,6 @@ package com.netflix.atlas.druid
 import java.io.IOException
 import java.net.ConnectException
 import java.nio.charset.StandardCharsets
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.HttpRequest
@@ -30,6 +29,7 @@ import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.module.scala.JavaTypeable
 import com.netflix.atlas.akka.AccessLogger
 import com.netflix.atlas.json.Json
 import com.typesafe.config.ConfigFactory
@@ -58,7 +58,7 @@ class DruidClientSuite extends FunSuite {
     new DruidClient(config, system, client)
   }
 
-  private def ok[T: Manifest](data: T): HttpResponse = {
+  private def ok[T: JavaTypeable](data: T): HttpResponse = {
     val json = Json.encode(data).getBytes(StandardCharsets.UTF_8)
     HttpResponse(StatusCodes.OK, entity = json)
   }


### PR DESCRIPTION
Manifest doesn't work in scala3. Switch to using the
JavaTypeable helper from jackson-module-scala.