### PR TITLE
add memorydb metrics

### DIFF
--- a/atlas-cloudwatch/src/main/resources/elasticache.conf
+++ b/atlas-cloudwatch/src/main/resources/elasticache.conf
@@ -2,7 +2,12 @@
 atlas {
   cloudwatch {
 
-    // http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheMetrics.html
+    // -- elasticache for memcached --
+    // https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheMetrics.Memcached.html
+    // https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/CacheMetrics.HostLevel.html
+    // -- elasticache for redis --
+    // https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.Redis.html
+    // https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.HostLevel.html
     elasticache = {
       namespace = "AWS/ElastiCache"
       period = 1m
@@ -13,7 +18,7 @@ atlas {
       ]
 
       metrics = [
-        // http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheMetrics.HostLevel.html
+        // memcached and redis host-level metrics
         {
           name = "CPUUtilization"
           alias = "aws.elasticache.cpuUtilization"
@@ -52,7 +57,7 @@ atlas {
           conversion = "max"
         },
 
-        // Both memcache and redis
+        // memcached and redis cache metrics
         {
           name = "Evictions"
           alias = "aws.elasticache.itemsRemoved"
@@ -92,7 +97,7 @@ atlas {
         },
 
 
-        // http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheMetrics.Memcached.html
+        // memcached cache metrics
         {
           name = "NewItems"
           alias = "aws.elasticache.items"
@@ -387,7 +392,7 @@ atlas {
           ]
         },
 
-        // http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/CacheMetrics.Redis.html
+        // redis cache metrics
         {
           name = "CacheHits"
           alias = "aws.elasticache.requests"

--- a/atlas-cloudwatch/src/main/resources/memorydb.conf
+++ b/atlas-cloudwatch/src/main/resources/memorydb.conf
@@ -1,0 +1,280 @@
+
+atlas {
+  cloudwatch {
+
+    // https://docs.aws.amazon.com/memorydb/latest/devguide/metrics.memorydb.html
+    // https://docs.aws.amazon.com/memorydb/latest/devguide/metrics.HostLevel.html
+    memorydb = {
+      namespace = "AWS/MemoryDB"
+      period = 1m
+
+      dimensions = [
+        "ClusterName",
+        "NodeId"
+      ]
+
+      metrics = [
+        // host-level metrics
+        {
+          name = "CPUUtilization"
+          alias = "aws.memorydb.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "FreeableMemory"
+          alias = "aws.memorydb.memoryFree"
+          conversion = "max"
+        },
+        {
+          name = "NetworkBytesIn"
+          alias = "aws.memorydb.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "NetworkBytesOut"
+          alias = "aws.memorydb.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "SwapUsage"
+          alias = "aws.memorydb.swapUsage"
+          conversion = "max"
+        },
+
+        // cache metrics
+        {
+          name = "BytesUsedForMemoryDB"
+          alias = "aws.memorydb.memoryUsed"
+          conversion = "max"
+        },
+        {
+          name = "CurrConnections"
+          alias = "aws.memorydb.numConnections"
+          conversion = "max"
+        },
+        {
+          name = "CurrItems"
+          alias = "aws.memorydb.numItems"
+          conversion = "max"
+        },
+        {
+          name = "Evictions"
+          alias = "aws.memorydb.itemsRemoved"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "evicted"
+            }
+          ]
+        },
+        {
+          name = "KeyspaceHits"
+          alias = "aws.memorydb.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "hit"
+            }
+          ]
+        },
+        {
+          name = "KeyspaceMisses"
+          alias = "aws.memorydb.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "miss"
+            }
+          ]
+        },
+        {
+          name = "NewConnections"
+          alias = "aws.memorydb.connections"
+          conversion = "sum,rate"
+        },
+        {
+          name = "Reclaimed"
+          alias = "aws.memorydb.itemsRemoved"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "reclaimed"
+            }
+          ]
+        },
+        {
+          name = "ReplicationBytes"
+          alias = "aws.memorydb.replicationThroughput"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ReplicationLag"
+          alias = "aws.memorydb.replicationLag"
+          conversion = "max"
+        },
+
+
+        // commandstats
+        {
+          name = "EvalBasedCmds"
+          alias = "aws.memorydb.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "evalBased"
+            }
+          ]
+        },
+        {
+          name = "GeoSpatialBasedCmds"
+          alias = "aws.memorydb.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "geoSpatialBased"
+            }
+          ]
+        },
+        {
+          name = "GetTypeCmds"
+          alias = "aws.memorydb.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "getType"
+            }
+          ]
+        },
+        {
+          name = "HashBasedCmds"
+          alias = "aws.memorydb.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "hashBased"
+            }
+          ]
+        },
+        {
+          name = "HyperLogLogBasedCmds"
+          alias = "aws.memorydb.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "hyperLogLogBased"
+            }
+          ]
+        },
+        {
+          name = "KeyBasedCmds"
+          alias = "aws.memorydb.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "keyBased"
+            }
+          ]
+        },
+        {
+          name = "ListBasedCmds"
+          alias = "aws.memorydb.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "listBased"
+            }
+          ]
+        },
+        {
+          name = "PubSubBasedCmds"
+          alias = "aws.memorydb.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "pubSubBased"
+            }
+          ]
+        },
+        {
+          name = "SetBasedCmds"
+          alias = "aws.memorydb.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "setBased"
+            }
+          ]
+        },
+        {
+          name = "SetTypeCmds"
+          alias = "aws.memorydb.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "setType"
+            }
+          ]
+        },
+        {
+          name = "SortedSetBasedCmds"
+          alias = "aws.memorydb.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "sortedSetBased"
+            }
+          ]
+        },
+        {
+          name = "StringBasedCmds"
+          alias = "aws.memorydb.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "stringBased"
+            }
+          ]
+        },
+        {
+          name = "StreamBasedCmds"
+          alias = "aws.memorydb.commands"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "streamBased"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -369,6 +369,7 @@ atlas {
       "kinesis",
       "lambda",
       "lambda-fn-res",
+      "memorydb",
       "nat-gateway",
       "neptune-instance",
       "neptune-cluster-role",
@@ -411,6 +412,7 @@ include "events.conf"
 include "iot.conf"
 include "kinesis.conf"
 include "lambda.conf"
+include "memorydb.conf"
 include "nat-gateway.conf"
 include "neptune.conf"
 include "nlb.conf"


### PR DESCRIPTION
This implementation is similar the the elasticache redis metrics, with
metrics selection and naming following the existing conventions.
    
This covers the most useful host-level and cache metrics, and all of
the commandstats metrics.
