### PR TITLE
add aws.memorydb tag

### DIFF
--- a/atlas-cloudwatch/src/main/resources/memorydb.conf
+++ b/atlas-cloudwatch/src/main/resources/memorydb.conf
@@ -70,6 +70,11 @@ atlas {
           conversion = "max"
         },
         {
+          name = "EngineCPUUtilization"
+          alias = "aws.memorydb.engineCpuUtilization"
+          conversion = "max"
+        },
+        {
           name = "Evictions"
           alias = "aws.memorydb.itemsRemoved"
           conversion = "sum,rate"

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -164,7 +164,7 @@ atlas {
         },
         {
           name = "CacheNodeId"
-          alias = "aws.node"
+          alias = "nf.node"
         },
         {
           name = "ClientId"
@@ -173,6 +173,10 @@ atlas {
         {
           name = "ClusterIdentifier"
           alias = "aws.redshift"
+        },
+        {
+          name = "ClusterName"
+          alias = "aws.memorydb"
         },
         {
           name = "ConnectionId"


### PR DESCRIPTION
This maps the ClusterName dimension to the aws.memorydb tag. The NodeId
dimension is already mapped to the nf.node tag.

Considering this mapping, the elasticache aws.node dimension is better
represented by nf.node, which is more in-line with existing common tags.

Add the EngineCPUUtilization metric, which is recommended for use when
there are four or more vCPU.
