### PR TITLE
lwc-bridge: prefer tags on metric to common tags

### DIFF
--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/BridgeDatapoint.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/BridgeDatapoint.scala
@@ -87,17 +87,13 @@ class BridgeDatapoint(
     if (name == null)
       name = commonName
     if (length > 0) {
-      if (tags.length >= n + length) {
-        System.arraycopy(commonTags, 0, tags, n, length)
-        n += length
-      } else {
-        // expand array if needed for merge
-        val tagsArray = new Array[String](n + length)
-        System.arraycopy(tags, 0, tagsArray, 0, n)
-        System.arraycopy(commonTags, 0, tagsArray, n, length)
-        tags = tagsArray
-        n += length
-      }
+      // Common tags must come first for deduping to give precedence to the tags on the
+      // local metric.
+      val tagsArray = new Array[String](n + length)
+      System.arraycopy(commonTags, 0, tagsArray, 0, length)
+      System.arraycopy(tags, 0, tagsArray, length, n)
+      tags = tagsArray
+      n += length
     }
   }
 

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/BridgeApiSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/BridgeApiSuite.scala
@@ -192,6 +192,24 @@ class BridgeApiSuite extends MUnitRouteSuite {
     assertEquals(datapoints.head.id, Id.create("bar").withTags("a", "b", "c", "d"))
   }
 
+  test("parse conflicting apps") {
+    val json = s"""{
+        "tags": {"nf.app": "foo", "c": "d"},
+        "metrics": [
+          {
+            "tags": {"name": "cpu", "nf.app": "bar", "a": "b"},
+            "timestamp": ${System.currentTimeMillis()},
+            "value": 42.0
+          }
+        ]
+      }"""
+    val datapoints = BridgeApi.decodeBatch(json)
+    assertEquals(
+      datapoints.head.id,
+      Id.create("cpu").withTags("a", "b", "c", "d", "nf.app", "bar")
+    )
+  }
+
   test("publish too many tags") {
     val tags = (0 until 20).map(i => s""""$i":"$i"""").mkString(",")
     val json = s"""{


### PR DESCRIPTION
If there is a conflict between the common tags and the
tags on a metric for a batch payload, then prefer the
tags local to the metric. This matches the precedence
behavior for the backends.