### PR TITLE
druid: fix UOE when using not clauses

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidFilter.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidFilter.scala
@@ -62,7 +62,7 @@ object DruidFilter {
       case kq: KeyQuery if kq.k == "nf.datasource" => Query.True
       case kq: KeyQuery if kq.k == "name"          => Query.True
     }
-    Query.simplify(newQuery.asInstanceOf[Query])
+    Query.simplify(newQuery.asInstanceOf[Query], true)
   }
 
   private def js(k: String, op: String, v: String): JavaScript = {

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidFilterSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidFilterSuite.scala
@@ -49,8 +49,20 @@ class DruidFilterSuite extends FunSuite {
     assertEquals(actual, expected)
   }
 
+  test("forQuery - nf.datasource :not") {
+    val actual = DruidFilter.forQuery(eval("nf.datasource,foo,:eq,:not"))
+    val expected = None
+    assertEquals(actual, expected)
+  }
+
   test("forQuery - name :eq") {
     val actual = DruidFilter.forQuery(eval("name,foo,:eq"))
+    val expected = None
+    assertEquals(actual, expected)
+  }
+
+  test("forQuery - name :not") {
+    val actual = DruidFilter.forQuery(eval("name,foo,:eq,:not"))
     val expected = None
     assertEquals(actual, expected)
   }


### PR DESCRIPTION
Fixes UnsupportedOperationException when using NOT clauses with either the `nf.datasource` or `name` dimensions.