### PR TITLE
atlas-persistence: Support common str compression

### DIFF
--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/HourlyRollingWriter.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/HourlyRollingWriter.scala
@@ -151,7 +151,8 @@ case class RollingConfig(
   maxLateDurationMs: Long,
   codec: String,
   compressionLevel: Int,
-  syncInterval: Int
+  syncInterval: Int,
+  commonStrings: Map[String, Int]
 ) {
   // Doing config checks here to fail early for invalid values
   require(maxRecords > 0)

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/RollingFileWriter.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/RollingFileWriter.scala
@@ -20,7 +20,6 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 import com.netflix.atlas.core.model.Datapoint
-import com.netflix.atlas.core.util.SmallHashMap
 import com.netflix.spectator.api.Registry
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.avro.Schema
@@ -188,19 +187,33 @@ class RollingFileWriter(
   }
 
   private def toAvro(dp: Datapoint): GenericRecord = {
-    import scala.jdk.CollectionConverters._
     // Use custom wrapper for SmallHashMap if possible as it avoids allocations when
     // iterating across the entries.
-    val tags = dp.tags match {
-      case m: SmallHashMap[String, String] => m.asJavaMap
-      case m                               => m.asJava
-    }
+    val tags = toCompressedJavaMap(dp.tags)
     val record = new GenericData.Record(RollingFileWriter.AvroSchema)
     record.put("tags", tags)
     record.put("timestamp", dp.timestamp)
     record.put("value", dp.value)
     record
   }
+
+  private def compressStr(str: String): String = rollingConf.commonStrings.get(str) match {
+    case Some(idx) =>
+      val cp = (idx + 128).asInstanceOf[Char]
+      Character.toString(cp)
+    case None => str
+  }
+
+  private def toCompressedJavaMap(tags: Map[String, String]): java.util.Map[String, String] = {
+    val res = new java.util.HashMap[String, String](tags.size)
+    for { (k, v) <- tags } {
+      val compressedK = compressStr(k)
+      val compressedV = compressStr(v)
+      res.put(compressedK, compressedV)
+    }
+    res
+  }
+
 }
 
 object RollingFileWriter {
@@ -211,4 +224,5 @@ object RollingFileWriter {
 
   val AvroSchema: Schema =
     new Parser().parse(Using.resource(Source.fromResource("datapoint.avsc"))(_.mkString))
+
 }

--- a/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/RollingFileWriterSuite.scala
+++ b/atlas-persistence/src/test/scala/com/netflix/atlas/persistence/RollingFileWriterSuite.scala
@@ -32,6 +32,7 @@ class RollingFileWriterSuite extends FunSuite {
 
   private val outputDir = "./target/unitTestAvroOutput"
   private val registry = new NoopRegistry
+  private val commonStrings = Map("name" -> 0, "node" -> 1)
 
   override def beforeEach(context: BeforeEach): Unit = {
     listFilesSorted(outputDir).foreach(_.delete()) // Clean up files if exits
@@ -55,7 +56,7 @@ class RollingFileWriterSuite extends FunSuite {
   // Write 3 datapoints, first 2 is written in file 1, rollover, and 3rd one is written in file 2
   private def testWriterWithCodec(codec: String): Unit = {
     test(s"avro writer rollover by max records - codec=$codec") {
-      val rollingConf = RollingConfig(2, 12000, 12000, codec, 9, 64000)
+      val rollingConf = RollingConfig(2, 12000, 12000, codec, 9, 64000, commonStrings)
       val hourStart = 3600000
       val hourEnd = 7200000
       val writer =
@@ -80,19 +81,19 @@ class RollingFileWriterSuite extends FunSuite {
       val file1 = files.head
       assert(file1.getName.endsWith(".0000-0001"))
       val dpArray1 = readAvro(file1)
-      assert(dpArray1.size == 2)
+      assert(dpArray1.length == 2)
       assert(dpArray1(0).value == 0)
-      assert(dpArray1(0).tags.get("node").get == "0")
+      assert(dpArray1(0).tags("\u0081") == "0")
       assert(dpArray1(1).value == 1)
-      assert(dpArray1(1).tags.get("node").get == "1")
+      assert(dpArray1(1).tags("\u0081") == "1")
 
       // Check file 2 records
       val file2 = files.last
       assert(file2.getName.endsWith(".0002-0002"))
       val dpArray2 = readAvro(file2)
-      assert(dpArray2.size == 1)
+      assert(dpArray2.length == 1)
       assert(dpArray2(0).value == 2)
-      assert(dpArray2(0).tags.get("node").get == "2")
+      assert(dpArray2(0).tags("\u0081") == "2")
     }
   }
 


### PR DESCRIPTION
This adds support for encoding the keys and values in tags as single character values starting at codepoint 128.

Atlas keys and values are restricted to a subset of the ASCII set so we can take advantage of this by encoding the most commonly seen strings in a single unicode character.

If the resource `common-strings.json` is missing we preserve the previous behavior.