### PR TITLE
add isDisabled flag to asg details

### DIFF
--- a/atlas-slotting/README.md
+++ b/atlas-slotting/README.md
@@ -176,8 +176,11 @@ export NETFLIX_STACK="local"
 
 ```
 sbt "project atlas-slotting" clean compile test
-sbt "project atlas-slotting" run
 ```
+
+Using `sbt` to `run` the project no longer works for version > 1.5.6, due to [sbt/issues/6767](https://github.com/sbt/sbt/issues/6767).
+
+Run the project from an IDE, setting env vars as needed.
 
 ```
 curl http://localhost:7101

--- a/atlas-slotting/iamrole-example.md
+++ b/atlas-slotting/iamrole-example.md
@@ -109,6 +109,10 @@ aws --profile $PROFILE_NAME iam get-role-policy --role-name $ROLE_NAME --policy-
 
 Allow the instance to use EC2 DescribeInstances calls for any instance in the account.
 
+```bash
+aws --profile $PROFILE_NAME iam get-role-policy --role-name $ROLE_NAME --policy-name EC2
+```
+
 ```json
 {
   "RoleName": "$ROLE_NAME",

--- a/atlas-slotting/src/main/resources/log4j2.xml
+++ b/atlas-slotting/src/main/resources/log4j2.xml
@@ -20,6 +20,7 @@
     <Logger name="com.netflix.atlas.slotting" level="debug"/>
     <Logger name="com.netflix.iep" level="warn"/>
     <Logger name="com.netflix.spectator" level="debug"/>
+    <Logger name="com.netflix.spectator.ipc.IpcLogger" level="info"/>
 
     <Root level="info">
       <AppenderRef ref="STDERR"/>

--- a/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/GroupingSuite.scala
+++ b/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/GroupingSuite.scala
@@ -19,6 +19,7 @@ import java.time.Instant
 import com.netflix.atlas.json.Json
 import munit.FunSuite
 import software.amazon.awssdk.services.autoscaling.model.AutoScalingGroup
+import software.amazon.awssdk.services.autoscaling.model.SuspendedProcess
 import software.amazon.awssdk.services.autoscaling.model.{Instance => AsgInstance}
 import software.amazon.awssdk.services.ec2.model.{Instance => Ec2Instance}
 
@@ -89,6 +90,22 @@ class GroupingSuite extends FunSuite with Grouping {
     assertEquals(asgDetails.instances.map(_.instanceId), List("i-001", "i-002", "i-003"))
   }
 
+  test("make isDisabled flag") {
+    val asgNoSuspended = AutoScalingGroup
+      .builder()
+      .build()
+
+    val asgLaunchSuspended = AutoScalingGroup
+      .builder()
+      .suspendedProcesses(
+        SuspendedProcess.builder().processName("Launch").build()
+      )
+      .build()
+
+    assertEquals(mkIsDisabled(asgNoSuspended), false)
+    assertEquals(mkIsDisabled(asgLaunchSuspended), true)
+  }
+
   test("make ec2 instance details") {
     val instance = Ec2Instance
       .builder()
@@ -122,6 +139,7 @@ class GroupingSuite extends FunSuite with Grouping {
       3,
       6,
       0,
+      isDisabled = false,
       asgInstances
     )
 
@@ -153,6 +171,7 @@ class GroupingSuite extends FunSuite with Grouping {
         2,
         4,
         0,
+        isDisabled = false,
         instances
       )
     }
@@ -176,6 +195,7 @@ class GroupingSuite extends FunSuite with Grouping {
       3,
       6,
       0,
+      isDisabled = false,
       asgInstances
     )
 
@@ -215,6 +235,7 @@ class GroupingSuite extends FunSuite with Grouping {
       3,
       6,
       0,
+      isDisabled = false,
       oldAsgInstances
     )
 
@@ -231,6 +252,7 @@ class GroupingSuite extends FunSuite with Grouping {
       3,
       6,
       0,
+      isDisabled = false,
       newAsgInstances
     )
 
@@ -263,6 +285,7 @@ class GroupingSuite extends FunSuite with Grouping {
       3,
       6,
       0,
+      isDisabled = false,
       oldAsgInstances
     )
 
@@ -280,6 +303,7 @@ class GroupingSuite extends FunSuite with Grouping {
       3,
       6,
       0,
+      isDisabled = false,
       newAsgInstances
     )
 
@@ -313,6 +337,7 @@ class GroupingSuite extends FunSuite with Grouping {
       3,
       6,
       0,
+      isDisabled = false,
       oldAsgInstances
     )
 
@@ -330,6 +355,7 @@ class GroupingSuite extends FunSuite with Grouping {
       3,
       6,
       0,
+      isDisabled = false,
       newAsgInstances
     )
 


### PR DESCRIPTION
This flag reports whether or not the ASG is disabled, according to Netflix operational standards. The Launch process must be suspended on the ASG for this to be true.

Since we are adding one field to the ASG details, there will be a difference between data stored in DynamoDB and newly crawled data. This will trigger a merge on the first startup of the new code, which will preserve slot numbers for all existing instances. Future starts of the new code will update timestamps for unchanged ASGs.