### PR TITLE
lwc-cloudwatch: reduce frequency of config updates

### DIFF
--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
@@ -233,8 +233,8 @@ object ForwardingService extends StrictLogging {
       .via(Framing.delimiter(ByteString("\n"), MaxFrameLength, allowTruncation = true))
       .map(_.decodeString(StandardCharsets.UTF_8))
       .filter(s => s.trim.nonEmpty)
-      .map(s => Message(s))
-      .filter { msg =>
+      .map { s =>
+        val msg = Message(s)
         logger.debug(s"message [${msg.str}]")
 
         msg match {
@@ -248,7 +248,7 @@ object ForwardingService extends StrictLogging {
           case _                =>
         }
 
-        msg.isUpdate
+        msg
       }
       .via(new ConfigManager)
   }


### PR DESCRIPTION
When syncing the configs, there will be many updates in a short window. Before the config manager would forward the complete set of data sources for each message that is received. This has a large overhead downstream. Now it will only push the updated set of data sources when it receives a done or hearbeat message and there are pending changes.