### PR TITLE
remove usage of javax annotations

### DIFF
--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AtlasAggregatorService.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AtlasAggregatorService.scala
@@ -23,11 +23,7 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spectator.atlas.AtlasRegistry
 import com.typesafe.config.Config
 
-import javax.inject.Inject
-import javax.inject.Singleton
-
-@Singleton
-class AtlasAggregatorService @Inject() (
+class AtlasAggregatorService(
   config: Config,
   clock: Clock,
   registry: Registry,

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/UpdateApi.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/UpdateApi.scala
@@ -15,7 +15,6 @@
  */
 package com.netflix.atlas.aggregator
 
-import javax.inject.Inject
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.HttpResponse
@@ -30,7 +29,7 @@ import com.netflix.atlas.core.validation.ValidationResult
 import com.netflix.atlas.eval.stream.Evaluator
 import com.typesafe.scalalogging.StrictLogging
 
-class UpdateApi @Inject() (
+class UpdateApi(
   evaluator: Evaluator,
   aggrService: AtlasAggregatorService
 ) extends WebApi

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
@@ -40,16 +40,13 @@ import java.nio.file.attribute.FileTime
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
-import javax.inject.Inject
-import javax.inject.Singleton
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.util.Using
 
-@Singleton
-class LocalFilePersistService @Inject() (
+class LocalFilePersistService(
   val config: Config,
   val registry: Registry,
   // S3CopyService is actually NOT used by this service, it is here just to guarantee that the

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopyService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopyService.scala
@@ -29,14 +29,11 @@ import com.netflix.iep.service.AbstractService
 import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
-import javax.inject.Inject
-import javax.inject.Singleton
 
 import scala.concurrent.duration._
 import scala.util.Using
 
-@Singleton
-class S3CopyService @Inject() (
+class S3CopyService(
   val config: Config,
   val registry: Registry,
   implicit val system: ActorSystem

--- a/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/SlottingApi.scala
+++ b/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/SlottingApi.scala
@@ -36,11 +36,10 @@ import com.netflix.atlas.akka.CustomDirectives._
 import com.netflix.atlas.akka.WebApi
 import com.netflix.atlas.json.Json
 import com.typesafe.scalalogging.StrictLogging
-import javax.inject.Inject
 
 import scala.util.matching.Regex
 
-class SlottingApi @Inject() (system: ActorSystem, slottingCache: SlottingCache)
+class SlottingApi(system: ActorSystem, slottingCache: SlottingCache)
     extends WebApi
     with StrictLogging {
 

--- a/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/SlottingCache.scala
+++ b/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/SlottingCache.scala
@@ -15,11 +15,8 @@
  */
 package com.netflix.atlas.slotting
 
-import javax.inject.Singleton
-
 import scala.collection.immutable.SortedMap
 
-@Singleton
 class SlottingCache() {
 
   @volatile

--- a/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/SlottingService.scala
+++ b/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/SlottingService.scala
@@ -33,14 +33,11 @@ import software.amazon.awssdk.services.ec2.Ec2Client
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest
 import software.amazon.awssdk.services.ec2.model.InstanceStateName
 
-import javax.inject.Inject
-import javax.inject.Singleton
 import scala.jdk.CollectionConverters._
 import scala.jdk.StreamConverters._
 import scala.collection.immutable.SortedMap
 
-@Singleton
-class SlottingService @Inject() (
+class SlottingService(
   config: Config,
   registry: Registry,
   asgClient: AutoScalingClient,

--- a/atlas-stream/src/main/scala/com/netflix/atlas/stream/EvalService.scala
+++ b/atlas-stream/src/main/scala/com/netflix/atlas/stream/EvalService.scala
@@ -36,7 +36,6 @@ import com.netflix.iep.service.AbstractService
 import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
-import javax.inject.Inject
 import org.reactivestreams.Publisher
 
 import scala.concurrent.duration._
@@ -44,7 +43,7 @@ import scala.jdk.CollectionConverters._
 import scala.util.Failure
 import scala.util.Success
 
-class EvalService @Inject() (
+class EvalService(
   val config: Config,
   val registry: Registry,
   val evaluator: Evaluator,

--- a/iep-archaius/src/main/scala/com/netflix/iep/archaius/DynamoService.scala
+++ b/iep-archaius/src/main/scala/com/netflix/iep/archaius/DynamoService.scala
@@ -17,8 +17,6 @@ package com.netflix.iep.archaius
 
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
-import javax.inject.Inject
-import javax.inject.Singleton
 import com.netflix.iep.service.AbstractService
 import com.typesafe.config.Config
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
@@ -36,8 +34,7 @@ import scala.concurrent.Future
   * }
   * ```
   */
-@Singleton
-class DynamoService @Inject() (client: DynamoDbClient, config: Config) extends AbstractService {
+class DynamoService(client: DynamoDbClient, config: Config) extends AbstractService {
 
   private val nextId = new AtomicLong()
 

--- a/iep-archaius/src/main/scala/com/netflix/iep/archaius/PropertiesContext.scala
+++ b/iep-archaius/src/main/scala/com/netflix/iep/archaius/PropertiesContext.scala
@@ -18,8 +18,6 @@ package com.netflix.iep.archaius
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
-import javax.inject.Inject
-import javax.inject.Singleton
 
 import com.netflix.spectator.api.Functions
 import com.netflix.spectator.api.Registry
@@ -31,8 +29,7 @@ import com.typesafe.scalalogging.StrictLogging
   * asynchronously updated so that local access to properties does not need to result
   * into a separate call to the storage layer.
   */
-@Singleton
-class PropertiesContext @Inject() (registry: Registry) extends StrictLogging {
+class PropertiesContext(registry: Registry) extends StrictLogging {
 
   private val clock = registry.clock()
 

--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExprUpdateService.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExprUpdateService.scala
@@ -48,7 +48,6 @@ import com.typesafe.scalalogging.StrictLogging
 
 import java.io.InputStream
 import java.util.zip.GZIPInputStream
-import javax.inject.Inject
 import scala.concurrent.Future
 import scala.util.Success
 import scala.util.Using
@@ -56,7 +55,7 @@ import scala.util.Using
 /**
   * Refresh the set of expressions from the LWC service.
   */
-class ExprUpdateService @Inject() (
+class ExprUpdateService(
   config: Config,
   registry: Registry,
   evaluator: ExpressionsEvaluator,

--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExpressionsEvaluator.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExpressionsEvaluator.scala
@@ -29,16 +29,12 @@ import com.netflix.spectator.atlas.impl.TagsValuePair
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
 
-import javax.inject.Inject
-import javax.inject.Singleton
-
 /**
   * Evaluate a set of data expressions from the LWC API service. This performs the same
   * basic role as the Evaluator class from the Spectator Atlas registry, but leverages the
   * query index from Atlas so it can scale to a much larger set of expressions.
   */
-@Singleton
-class ExpressionsEvaluator @Inject() (config: Config, registry: Registry) extends StrictLogging {
+class ExpressionsEvaluator(config: Config, registry: Registry) extends StrictLogging {
 
   import ExpressionsEvaluator._
 

--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
@@ -60,7 +60,6 @@ import java.time.Instant
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicInteger
-import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -68,7 +67,7 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-class ForwardingService @Inject() (
+class ForwardingService(
   config: Config,
   registry: Registry,
   evaluator: Evaluator,

--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/ExpressionDetailsDao.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/ExpressionDetailsDao.scala
@@ -28,8 +28,6 @@ import software.amazon.awssdk.services.dynamodb.model.GetItemRequest
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest
 
-import javax.inject.Inject
-
 trait ExpressionDetailsDao {
 
   def save(exprDetails: ExpressionDetails): Unit
@@ -40,7 +38,7 @@ trait ExpressionDetailsDao {
   def isPurgeEligible(ed: ExpressionDetails, now: Long): Boolean
 }
 
-class ExpressionDetailsDaoImpl @Inject() (
+class ExpressionDetailsDaoImpl(
   config: Config,
   dynamoDBClient: DynamoDbClient,
   registry: Registry

--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/MarkerService.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/MarkerService.scala
@@ -34,7 +34,6 @@ import com.netflix.iep.service.AbstractService
 import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
-import javax.inject.Inject
 
 import scala.util.Failure
 import scala.util.Success
@@ -50,7 +49,7 @@ trait MarkerService {
   var queue: SourceQueue[Report]
 }
 
-class MarkerServiceImpl @Inject() (
+class MarkerServiceImpl(
   config: Config,
   registry: Registry,
   expressionDetailsDao: ExpressionDetailsDao,

--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/Purger.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/Purger.scala
@@ -34,7 +34,6 @@ import com.netflix.atlas.json.Json
 import com.netflix.iep.lwc.fwd.cw._
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
-import javax.inject.Inject
 
 import scala.concurrent.Future
 import scala.util.Failure
@@ -45,7 +44,7 @@ trait Purger {
   def purge(expressions: List[ExpressionId]): Future[Done]
 }
 
-class PurgerImpl @Inject() (
+class PurgerImpl(
   config: Config,
   expressionDetailsDao: ExpressionDetailsDao,
   implicit val system: ActorSystem

--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/ScalingPoliciesDao.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/ScalingPoliciesDao.scala
@@ -32,7 +32,6 @@ import com.netflix.atlas.json.Json
 import com.netflix.iep.lwc.fwd.cw.FwdMetricInfo
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
-import javax.inject.Inject
 
 import scala.util.Failure
 import scala.util.Success
@@ -41,7 +40,7 @@ trait ScalingPoliciesDao {
   def getScalingPolicies: Flow[EddaEndpoint, List[ScalingPolicy], NotUsed]
 }
 
-class ScalingPoliciesDaoImpl @Inject() (
+class ScalingPoliciesDaoImpl(
   config: Config,
   implicit val system: ActorSystem
 ) extends ScalingPoliciesDao

--- a/iep-lwc-loadgen/src/main/scala/com/netflix/iep/loadgen/LoadGenService.scala
+++ b/iep-lwc-loadgen/src/main/scala/com/netflix/iep/loadgen/LoadGenService.scala
@@ -16,7 +16,6 @@
 package com.netflix.iep.loadgen
 
 import akka.NotUsed
-import javax.inject.Inject
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
 import akka.stream.AbruptTerminationException
@@ -44,7 +43,7 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-class LoadGenService @Inject() (
+class LoadGenService(
   config: Config,
   registry: Registry,
   evaluator: Evaluator,

--- a/iep-lwc-loadgen/src/main/scala/com/netflix/iep/loadgen/LoadGenWsService.scala
+++ b/iep-lwc-loadgen/src/main/scala/com/netflix/iep/loadgen/LoadGenWsService.scala
@@ -40,13 +40,12 @@ import com.netflix.iep.service.AbstractService
 import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 import com.typesafe.scalalogging.StrictLogging
-import javax.inject.Inject
 
 import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
 
-class LoadGenWsService @Inject() (
+class LoadGenWsService(
   config: Config,
   registry: Registry,
   evaluator: Evaluator,


### PR DESCRIPTION
These have been moved to jakarta in later versions. With the way we are using Spring, the annotations are not necessary.