### PR TITLE
fix aws direct connect metrics

### DIFF
--- a/atlas-cloudwatch/src/main/resources/dx.conf
+++ b/atlas-cloudwatch/src/main/resources/dx.conf
@@ -27,7 +27,7 @@ atlas {
         {
           name = "ConnectionBpsEgress"
           alias = "aws.dx.connectionBytes"
-          conversion = "sum,rate",
+          conversion = "avg",
           tags = [
             {
               key = "id"
@@ -38,7 +38,7 @@ atlas {
         {
           name = "ConnectionBpsIngress"
           alias = "aws.dx.connectionBytes"
-          conversion = "sum,rate",
+          conversion = "avg",
           tags = [
             {
               key = "id"
@@ -49,7 +49,7 @@ atlas {
         {
           name = "ConnectionPpsEgress"
           alias = "aws.dx.connectionPackets"
-          conversion = "sum,rate",
+          conversion = "avg",
           tags = [
             {
               key = "id"
@@ -60,7 +60,7 @@ atlas {
         {
           name = "ConnectionPpsIngress"
           alias = "aws.dx.connectionPackets"
-          conversion = "sum,rate",
+          conversion = "avg",
           tags = [
             {
               key = "id"
@@ -123,7 +123,7 @@ atlas {
         {
           name = "VirtualInterfaceBpsEgress"
           alias = "aws.dx.virtualInterfaceBytes"
-          conversion = "sum,rate"
+          conversion = "avg"
           tags = [
             {
               key = "id"
@@ -134,7 +134,7 @@ atlas {
         {
           name = "VirtualInterfaceBpsIngress"
           alias = "aws.dx.virtualInterfaceBytes"
-          conversion = "sum,rate"
+          conversion = "avg"
           tags = [
             {
               key = "id"
@@ -145,7 +145,7 @@ atlas {
         {
           name = "VirtualInterfacePpsEgress"
           alias = "aws.dx.virtualInterfacePackets"
-          conversion = "sum,rate"
+          conversion = "avg"
           tags = [
             {
               key = "id"
@@ -156,7 +156,7 @@ atlas {
         {
           name = "VirtualInterfacePpsIngress"
           alias = "aws.dx.virtualInterfacePackets"
-          conversion = "sum,rate"
+          conversion = "avg"
           tags = [
             {
               key = "id"


### PR DESCRIPTION
The affected metrics are all reported as aggregates (averages) over a five minute period by default.

The `sum,rate` conversion did not result in values that matched the AWS Console. Pulling individual data points and following how the poller calculates values, the `avg` conversion should return values that match the AWS Console.