### PR TITLE
aggr: reduce allocations for encoding batches

### DIFF
--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AggrConfig.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AggrConfig.scala
@@ -71,6 +71,6 @@ class AggrConfig(
   override def validTagCharacters(): String = null
 
   override def publisher(): Publisher = {
-    new AkkaPublisher(this, system)
+    new AkkaPublisher(registry, this, system)
   }
 }


### PR DESCRIPTION
Avoid creating a copy of the payload array when creating the ByteString object. Also uses a dedicated pool for encoding the payload.