### PR TITLE
druid: fix pagination for tag keys

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -130,6 +130,7 @@ class DruidDatabaseActor(config: Config) extends Actor with StrictLogging {
       .flatMap { ds =>
         ds.metricTags.flatMap(_.keys) ::: ds.datasource.dimensions
       }
+      .filter(_ > tq.offset)
       .distinct
       .sorted
     ref ! KeyListResponse(vs)


### PR DESCRIPTION
Before the offset was being ignored which could result in an endless loop for a user trying to paginate.