### PR TITLE
aggr: tune evaluation settings

### DIFF
--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/CaffeineCache.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/CaffeineCache.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.aggregator
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.netflix.atlas.core.index.QueryIndex
+import com.netflix.spectator.impl.Cache
+
+/** Cache implementation to use with the query index. */
+class CaffeineCache[T] extends Cache[String, java.util.List[QueryIndex[T]]] {
+
+  private val delegate = Caffeine
+    .newBuilder()
+    .maximumSize(10_000)
+    .build[String, java.util.List[QueryIndex[T]]]()
+
+  override def get(key: String): java.util.List[QueryIndex[T]] = {
+    delegate.getIfPresent(key)
+  }
+
+  override def peek(key: String): java.util.List[QueryIndex[T]] = {
+    throw new UnsupportedOperationException()
+  }
+
+  override def put(key: String, value: java.util.List[QueryIndex[T]]): Unit = {
+    delegate.put(key, value)
+  }
+
+  override def computeIfAbsent(
+    key: String,
+    f: java.util.function.Function[String, java.util.List[QueryIndex[T]]]
+  ): java.util.List[QueryIndex[T]] = {
+    delegate.get(key, f)
+  }
+
+  override def clear(): Unit = {
+    delegate.invalidateAll()
+  }
+
+  override def size(): Int = {
+    delegate.estimatedSize().toInt
+  }
+
+  override def asMap(): java.util.Map[String, java.util.List[QueryIndex[T]]] = {
+    java.util.Collections.emptyMap()
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ lazy val `atlas-aggregator` = project
     Dependencies.atlasJson,
     Dependencies.atlasSpringAkka,
     Dependencies.atlasSpringEval,
+    Dependencies.caffeine,
     Dependencies.iepDynConfig,
     Dependencies.iepSpring,
     Dependencies.iepSpringAdmin,

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -49,7 +49,11 @@ object BuildSettings {
     Dependencies.typesafeConfig,
     Dependencies.munit % "test")
 
-  val resolvers = Seq(Resolver.mavenLocal, Resolver.mavenCentral) ++ Resolver.sonatypeOssRepos("snapshots")
+  val resolvers = Seq(
+    Resolver.mavenLocal,
+    Resolver.mavenCentral,
+    "NetflixOSS Snapshots" at "https://artifacts-oss.netflix.net/maven-oss-snapshots"
+  ) ++ Resolver.sonatypeOssRepos("snapshots")
 
   // Don't create root.jar, from:
   // http://stackoverflow.com/questions/20747296/producing-no-artifact-for-root-project-with-package-under-multi-project-build-in

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val scala      = "2.13.10"
     val servo      = "0.13.2"
     val slf4j      = "1.7.36"
-    val spectator  = "1.5.4"
+    val spectator  = "1.6.0-SNAPSHOT"
     val spring     = "6.0.5"
     val avroV      = "1.11.1"
 
@@ -49,6 +49,7 @@ object Dependencies {
   val aws2EC2            = "software.amazon.awssdk" % "ec2" % aws2
   val aws2S3             = "software.amazon.awssdk" % "s3" % aws2
   val aws2SQS            = "software.amazon.awssdk" % "sqs" % aws2
+  val caffeine           = "com.github.ben-manes.caffeine" % "caffeine" % "3.1.4"
   val frigga             = "com.netflix.frigga" % "frigga" % "0.26.0"
   val iepDynConfig       = "com.netflix.iep" % "iep-dynconfig" % iep
   val iepLeaderApi       = "com.netflix.iep" % "iep-leader-api" % iep


### PR DESCRIPTION
Enable parallel polling of the meters and use a custom cache with a larger size than the default.