### PR TITLE
aggr: ensure publisher future completes

### DIFF
--- a/atlas-aggregator/src/main/resources/application.conf
+++ b/atlas-aggregator/src/main/resources/application.conf
@@ -22,6 +22,10 @@ atlas.aggregator {
     }
   ]
 
+  publisher {
+    queue-size = 10000
+  }
+
   // Determines whether or not to include the aggregator node as a tag on counters.
   // If false it will use atlas.dstype=sum instead.
   include-aggr-tag = false

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AggrConfig.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AggrConfig.scala
@@ -28,7 +28,7 @@ import com.netflix.spectator.impl.Cache
 import com.typesafe.config.Config
 
 class AggrConfig(
-  config: Config,
+  val config: Config,
   registry: Registry,
   system: ActorSystem
 ) extends AtlasConfig


### PR DESCRIPTION
Make the publisher queue size configurable. Adjust future to ensure it will always be completed even if the stream gets restarted. Now it will be completed when returned and treated as successful if it was enqueued. This avoids problems with the upstream hanging if the stream is restarted and some of the returned futures are never completed.