### PR TITLE
Atlas Cloudwatch: Add the FirehoseMetric case class for storing info

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/FirehoseMetric.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/FirehoseMetric.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.netflix.atlas.util.XXHasher
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+
+/**
+  * Container to hold a metric parsed from a Firehose Cloud Watch metric.
+  */
+case class FirehoseMetric(
+  metricStreamName: String,
+  namespace: String,
+  metricName: String,
+  dimensions: List[Dimension],
+  datapoint: Datapoint
+) {
+
+  def xxHash: Long = {
+    var hash = XXHasher.hash(namespace)
+    hash = XXHasher.updateHash(hash, metricName)
+    dimensions.sortBy(_.name()).foreach { d =>
+      hash = XXHasher.updateHash(hash, d.name())
+      hash = XXHasher.updateHash(hash, d.value())
+    }
+    hash
+  }
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/util/XXHasher.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/util/XXHasher.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.util
+
+import net.openhft.hashing.LongHashFunction
+
+/**
+  * Simple wrapper and utility functions for hashing with the OpenHFT XXHash implementation.
+  */
+object XXHasher {
+
+  private val hasher = LongHashFunction.xx
+
+  def hash(value: Array[Byte]): Long = hasher.hashBytes(value)
+
+  def hash(value: Array[Byte], offset: Int, length: Int): Long =
+    hasher.hashBytes(value, offset, length)
+
+  def hash(value: String): Long = hasher.hashChars(value)
+
+  def updateHash(hash: Long, value: Array[Byte]): Long = 2251 * hash ^ 37 * hasher.hashBytes(value)
+
+  def updateHash(hash: Long, value: Array[Byte], offset: Int, length: Int): Long =
+    2251 * hash ^ 37 * hasher.hashBytes(value, offset, length)
+
+  def updateHash(hash: Long, value: String): Long = 2251 * hash ^ 37 * hasher.hashChars(value)
+
+  def combineHashes(hash_a: Long, hash_b: Long): Long = 2251 * hash_a ^ 37 * hash_b
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/util/XXHasherSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/util/XXHasherSuite.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.util
+
+import munit.FunSuite
+
+class XXHasherSuite extends FunSuite {
+
+  test("hash byte array") {
+    assertEquals(XXHasher.hash("Hello World".getBytes("UTF-8")), 7148569436472236994L)
+  }
+
+  test("hash byte array empty") {
+    assertEquals(XXHasher.hash(new Array[Byte](0)), -1205034819632174695L)
+  }
+
+  test("hash byte array null") {
+    intercept[NullPointerException] {
+      XXHasher.hash(null.asInstanceOf[Array[Byte]])
+    }
+  }
+
+  test("hash byte array offset") {
+    assertEquals(XXHasher.hash("Hello World".getBytes("UTF-8"), 1, 5), -4877171975935371781L)
+  }
+
+  test("hash byte string") {
+    assertEquals(XXHasher.hash("Hello World"), -7682288509216370722L)
+  }
+
+  test("updateHash byte array") {
+    val hash = XXHasher.hash("Hello World".getBytes("UTF-8"))
+    assertEquals(XXHasher.updateHash(hash, " from Atlas!".getBytes("UTF-8")), 6820347041909772079L)
+  }
+
+  test("updateHash byte array offset") {
+    val hash = XXHasher.hash("Hello World".getBytes("UTF-8"))
+    assertEquals(
+      XXHasher.updateHash(hash, " from Atlas!".getBytes("UTF-8"), 1, 8),
+      -2548206119163337765L
+    )
+  }
+
+  test("updateHash string") {
+    val hash = XXHasher.hash("Hello World")
+    assertEquals(XXHasher.updateHash(hash, " from Atlas!"), -5099163101293074982L)
+  }
+
+  test("combineHashes") {
+    val hashA = XXHasher.hash("Hello World")
+    val hashB = XXHasher.hash(" from Atlas!")
+    assertEquals(XXHasher.combineHashes(hashA, hashB), -5099163101293074982L)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,7 @@ lazy val `atlas-cloudwatch` = project
     Dependencies.log4jApi,
     Dependencies.log4jCore,
     Dependencies.log4jSlf4j,
+    Dependencies.openHFT,
 
     Dependencies.atlasWebApi % "test",
     Dependencies.akkaHttpTestkit % "test",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,6 +69,7 @@ object Dependencies {
   val log4jJul           = "org.apache.logging.log4j" % "log4j-jul" % log4j
   val log4jSlf4j         = "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4j
   val munit              = "org.scalameta" %% "munit" % "0.7.29"
+  val openHFT            = "net.openhft" % "zero-allocation-hashing" % "0.16"
   val scalaCompiler      = "org.scala-lang" % "scala-compiler" % scala
   val scalaLibrary       = "org.scala-lang" % "scala-library" % scala
   val scalaLogging       = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"


### PR DESCRIPTION
parsed from the firehose Cloud Watch stream.
Also add an OpenHFT XXHash implementation utility for quickly calculating a unique hash on the Cloud Watch metric for caching.