### PR TITLE
Atlas Cloud Watch: Add the PublishQueue class to replace the Client A…

### DIFF
--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -84,6 +84,24 @@ atlas {
 
   cloudwatch {
 
+    // Handles routing data points to the proper publish proxy instance for the given stack. Uses the account ID of the
+    // Cloud Watch data to map to stacks.
+    account.routing {
+      queue {
+        // The upper limit for each queue to buffer before rejecting data points.
+        queueSize = 100000
+
+        // The maximum number of data points to collate into a single flush.
+        batchSize = 1000
+
+        // How long to wait for a group of data to reach the batch size or be flushed.
+        batchTimeout = 5s
+
+        // How many times to retry a batch if downstream returns a backoff or an exception occurs.
+        maxRetries = 1
+      }
+    }
+
     // Batch size for flushing data back to the poller manager
     batch-size = 1000
 

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishQueue.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishQueue.scala
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.HttpMethods
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.HttpResponse
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Sink
+import akka.util.ByteString
+import com.netflix.atlas.akka.AkkaHttpClient
+import com.netflix.atlas.akka.CustomMediaTypes
+import com.netflix.atlas.akka.StreamOps
+import com.netflix.atlas.json.Json
+import com.netflix.atlas.poller.Messages
+import com.netflix.atlas.poller.Messages.MetricsPayload
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+
+import java.time.Duration
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Failure
+import scala.util.Success
+
+/**
+  * Simple queue for batching data points to be sent to publish proxy. Retries occur only on 429s, 504s or exceptions
+  * from the client.
+  */
+class PublishQueue(
+  config: Config,
+  registry: Registry,
+  val stack: String,
+  val uri: String,
+  httpClient: AkkaHttpClient,
+  scheduler: ScheduledExecutorService
+)(implicit system: ActorSystem)
+    extends StrictLogging {
+
+  private implicit val executionContext = system.dispatcher
+
+  private val datapointsDropped =
+    registry.createId("atlas.cloudwatch.queue.dps.dropped", "stack", stack)
+  private val datapointsSent = registry.counter("atlas.cloudwatch.queue.dps.sent", "stack", stack)
+  private val retryAttempts = registry.counter("atlas.cloudwatch.queue.retries", "stack", stack)
+  private val droppedFull = registry.counter(datapointsDropped.withTags("reason", "queueFull"))
+  private val droppedRetries = registry.counter(datapointsDropped.withTags("reason", "maxRetries"))
+
+  private val maxRetries = getSetting("maxRetries")
+  private val queueSize = getSetting("queueSize")
+  private val batchSize = getSetting("batchSize")
+  private val batchTimeout = getDurationSetting("batchTimeout")
+
+  private[cloudwatch] val publishQueue = StreamOps
+    .blockingQueue[AtlasDatapoint](registry, s"${stack}PubQueue", queueSize)
+    .groupedWithin(batchSize, FiniteDuration.apply(batchTimeout.getSeconds, TimeUnit.SECONDS))
+    .map(publish)
+    .toMat(Sink.ignore)(Keep.left)
+    .run()
+
+  /**
+    * Adds the data point to the queue if there is room. Increments a metric if not.
+    *
+    * @param datapoint
+    *     The non-null data point to enqueue.
+    */
+  def enqueue(datapoint: AtlasDatapoint): Unit = {
+    if (!publishQueue.offer(datapoint)) {
+      droppedFull.increment()
+    }
+  }
+
+  private[cloudwatch] def publish(datapoints: Seq[AtlasDatapoint]): Unit = {
+    val size = datapoints.size
+    val payload = Json.smileEncode(MetricsPayload(Map.empty, datapoints))
+    datapointsSent.increment(size)
+    publish(payload, 0, size)
+  }
+
+  private[cloudwatch] def publish(payload: Array[Byte], retries: Int, size: Int): Unit = {
+    val request = HttpRequest(
+      HttpMethods.POST,
+      uri = uri,
+      entity = HttpEntity(
+        CustomMediaTypes.`application/x-jackson-smile`,
+        ByteString.fromArrayUnsafe(payload)
+      )
+    )
+    httpClient.singleRequest(request).onComplete {
+      case Success(response) =>
+        response.status.intValue() match {
+          case 200 => // All is well
+            response.discardEntityBytes()
+          case 202 | 206 => // Partial failure
+            val id = datapointsDropped.withTag("reason", "partialFailure")
+            incrementFailureCount(id, response, size)
+          case 400 => // Bad message, all data dropped
+            val id = datapointsDropped.withTag("reason", "completeFailure")
+            incrementFailureCount(id, response, size)
+          case 429 | 504 => // backoff
+            retry(payload, retries, size)
+          case v => // Unexpected, assume all dropped
+            response.discardEntityBytes()
+            val id = datapointsDropped.withTag("reason", s"status_$v")
+            registry.counter(id).increment(size)
+        }
+
+      case Failure(ex) =>
+        logger.error(s"Failed publishing to ${uri} for ${stack}", ex)
+        incrementException(ex)
+        retry(payload, retries, size)
+    }
+  }
+
+  private def incrementFailureCount(id: Id, response: HttpResponse, size: Int): Unit = {
+    response.entity.dataBytes.runReduce(_ ++ _).onComplete {
+      case Success(bs) =>
+        try {
+          val msg = Json.decode[Messages.FailureResponse](bs.toArray)
+          msg.message.headOption.foreach { reason =>
+            logger.warn("failed to validate some datapoints, first reason: {}", reason)
+          }
+          registry.counter(id).increment(msg.errorCount)
+        } catch {
+          case ex: Throwable =>
+            logger.warn("Failed to pub proxy response", ex)
+        }
+      case Failure(_) =>
+        registry.counter(id).increment(size)
+    }
+  }
+
+  private def incrementException(t: Throwable): Unit = {
+    registry
+      .counter("atlas.cloudwatch.queue.exception", "stack", stack, "ex", t.getClass.getSimpleName)
+      .increment()
+  }
+
+  private def getSetting(setting: String): Int = {
+    config.hasPath(s"queue.${stack}.${setting}") match {
+      case false => config.getInt(s"queue.${setting}")
+      case true  => config.getInt(s"queue.${stack}.${setting}")
+    }
+  }
+
+  private def getDurationSetting(setting: String): Duration = {
+    config.hasPath(s"queue.${stack}.${setting}") match {
+      case false => config.getDuration(s"queue.${setting}")
+      case true  => config.getDuration(s"queue.${stack}.${setting}")
+    }
+  }
+
+  private def retry(payload: Array[Byte], retries: Int, size: Int): Unit = {
+    if (retries >= maxRetries) {
+      droppedRetries.increment(size)
+      return
+    }
+
+    val numRetries = retries + 1
+    val delay: Long = 50 + (1 << numRetries) // exponential backoff starting at 52ms
+    val run: Runnable = () => publish(payload, numRetries, size)
+    scheduler.schedule(run, delay, TimeUnit.MILLISECONDS)
+    retryAttempts.increment()
+  }
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/poller/Messages.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/poller/Messages.scala
@@ -42,7 +42,10 @@ object Messages {
     * @param metrics
     *     Metrics collected by the poller.
     */
-  case class MetricsPayload(tags: Map[String, String] = Map.empty, metrics: List[Datapoint] = Nil)
+  case class MetricsPayload(
+    tags: Map[String, String] = Map.empty,
+    metrics: Iterable[Datapoint] = Nil
+  )
 
   /**
     * Represents a failure response message from the publish endpoint.

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/PublishQueueSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/PublishQueueSuite.scala
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import akka.actor.ActorSystem
+import akka.http.javadsl.model.ContentType
+import akka.http.scaladsl.model.ContentTypes
+import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.ResponseEntity
+import akka.http.scaladsl.model.StatusCode
+import akka.http.scaladsl.model.StatusCodes
+import akka.testkit.TestKitBase
+import com.netflix.atlas.akka.AkkaHttpClient
+import com.netflix.atlas.akka.CustomMediaTypes
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.atlas.json.Json
+import com.netflix.atlas.poller.Messages.MetricsPayload
+import com.netflix.atlas.webapi.PublishApi.FailureMessage
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.ConfigFactory
+import munit.FunSuite
+import org.mockito.ArgumentMatchersSugar.any
+import org.mockito.ArgumentMatchersSugar.anyLong
+import org.mockito.MockitoSugar.mock
+import org.mockito.MockitoSugar.never
+import org.mockito.MockitoSugar.times
+import org.mockito.MockitoSugar.verify
+import org.mockito.MockitoSugar.when
+import org.mockito.captor.ArgCaptor
+
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.Future
+
+class PublishQueueSuite extends FunSuite with TestKitBase {
+
+  override implicit def system: ActorSystem = ActorSystem(getClass.getSimpleName)
+
+  var registry: Registry = null
+  var httpClient = mock[AkkaHttpClient]
+  var httpCaptor = ArgCaptor[HttpRequest]
+  var scheduler = mock[ScheduledExecutorService]
+  val timestamp = 1672531200000L
+  val config = ConfigFactory.load().getConfig("atlas.cloudwatch.account.routing")
+  val threadSleep = 300
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    registry = new DefaultRegistry()
+    httpClient = mock[AkkaHttpClient]
+    httpCaptor = ArgCaptor[HttpRequest]
+    scheduler = mock[ScheduledExecutorService]
+  }
+
+  test("publish success") {
+    mockResponse(StatusCodes.OK)
+    val queue =
+      new PublishQueue(config, registry, "main", "http://localhost", httpClient, scheduler)
+    queue.publish(
+      Seq(
+        Datapoint(Map("k1" -> "v1"), timestamp, 42.5),
+        Datapoint(Map("k2" -> "v2"), timestamp, 24.1)
+      )
+    )
+
+    Thread.sleep(threadSleep)
+    assertCounters(2)
+    verify(httpClient, times(1)).singleRequest(httpCaptor)
+    assertEquals(
+      CustomMediaTypes.`application/x-jackson-smile`.toContentType.asInstanceOf[ContentType],
+      httpCaptor.value.entity.getContentType()
+    )
+  }
+
+  test("publish 202") {
+    mockResponse(StatusCodes.Accepted, Json.encode(FailureMessage("foo", 1, List("Err"))))
+    val queue =
+      new PublishQueue(config, registry, "main", "http://localhost", httpClient, scheduler)
+    queue.publish(
+      Seq(
+        Datapoint(Map("k1" -> "v1"), timestamp, 42.5),
+        Datapoint(Map("k2" -> "v2"), timestamp, 24.1)
+      )
+    )
+
+    Thread.sleep(threadSleep)
+    assertCounters(2, droppedPartial = 1)
+    verify(httpClient, times(1)).singleRequest(httpCaptor)
+    assertEquals(
+      CustomMediaTypes.`application/x-jackson-smile`.toContentType.asInstanceOf[ContentType],
+      httpCaptor.value.entity.getContentType()
+    )
+  }
+
+  test("publish 400") {
+    mockResponse(StatusCodes.BadRequest, Json.encode(FailureMessage("foo", 2, List("Err"))))
+    val queue =
+      new PublishQueue(config, registry, "main", "http://localhost", httpClient, scheduler)
+    queue.publish(
+      Seq(
+        Datapoint(Map("k1" -> "v1"), timestamp, 42.5),
+        Datapoint(Map("k2" -> "v2"), timestamp, 24.1)
+      )
+    )
+
+    Thread.sleep(threadSleep)
+    assertCounters(2, droppedComplete = 2)
+    verify(httpClient, times(1)).singleRequest(httpCaptor)
+    assertEquals(
+      CustomMediaTypes.`application/x-jackson-smile`.toContentType.asInstanceOf[ContentType],
+      httpCaptor.value.entity.getContentType()
+    )
+  }
+
+  test("publish 500") {
+    mockResponse(StatusCodes.InternalServerError)
+    val queue =
+      new PublishQueue(config, registry, "main", "http://localhost", httpClient, scheduler)
+    queue.publish(
+      Seq(
+        Datapoint(Map("k1" -> "v1"), timestamp, 42.5),
+        Datapoint(Map("k2" -> "v2"), timestamp, 24.1)
+      )
+    )
+
+    Thread.sleep(threadSleep)
+    assertCounters(2, dropped500 = 2)
+    verify(httpClient, times(1)).singleRequest(httpCaptor)
+    assertEquals(
+      CustomMediaTypes.`application/x-jackson-smile`.toContentType.asInstanceOf[ContentType],
+      httpCaptor.value.entity.getContentType()
+    )
+  }
+
+  test("publish 429") {
+    mockResponse(StatusCodes.TooManyRequests)
+    val queue =
+      new PublishQueue(config, registry, "main", "http://localhost", httpClient, scheduler)
+    queue.publish(
+      Seq(
+        Datapoint(Map("k1" -> "v1"), timestamp, 42.5),
+        Datapoint(Map("k2" -> "v2"), timestamp, 24.1)
+      )
+    )
+
+    Thread.sleep(threadSleep)
+    assertCounters(2, retries = 1)
+    verify(httpClient, times(1)).singleRequest(httpCaptor)
+    assertEquals(
+      CustomMediaTypes.`application/x-jackson-smile`.toContentType.asInstanceOf[ContentType],
+      httpCaptor.value.entity.getContentType()
+    )
+    verify(scheduler, times(1)).schedule(any[Runnable], anyLong, any[TimeUnit])
+  }
+
+  test("publish 429 too many attempts") {
+    mockResponse(StatusCodes.TooManyRequests)
+    val queue =
+      new PublishQueue(config, registry, "main", "http://localhost", httpClient, scheduler)
+    val payload = Json.smileEncode(
+      MetricsPayload(
+        Map.empty,
+        Seq(
+          Datapoint(Map("k1" -> "v1"), timestamp, 42.5),
+          Datapoint(Map("k2" -> "v2"), timestamp, 24.1)
+        )
+      )
+    )
+    queue.publish(payload, 1, 2)
+
+    Thread.sleep(threadSleep)
+    assertCounters(droppedRetries = 2)
+    verify(httpClient, times(1)).singleRequest(httpCaptor)
+    assertEquals(
+      CustomMediaTypes.`application/x-jackson-smile`.toContentType.asInstanceOf[ContentType],
+      httpCaptor.value.entity.getContentType()
+    )
+    verify(scheduler, never).schedule(any[Runnable], anyLong, any[TimeUnit])
+  }
+
+  test("publish exception") {
+    mockResponse(StatusCodes.OK, t = new UTException("UT"))
+    val queue =
+      new PublishQueue(config, registry, "main", "http://localhost", httpClient, scheduler)
+    queue.publish(
+      Seq(
+        Datapoint(Map("k1" -> "v1"), timestamp, 42.5),
+        Datapoint(Map("k2" -> "v2"), timestamp, 24.1)
+      )
+    )
+
+    Thread.sleep(threadSleep)
+    assertCounters(2, exceptions = 1, retries = 1)
+    verify(httpClient, times(1)).singleRequest(httpCaptor)
+    assertEquals(
+      CustomMediaTypes.`application/x-jackson-smile`.toContentType.asInstanceOf[ContentType],
+      httpCaptor.value.entity.getContentType()
+    )
+    verify(scheduler, times(1)).schedule(any[Runnable], anyLong, any[TimeUnit])
+  }
+
+  def assertCounters(
+    sent: Long = 0,
+    retries: Long = 0,
+    droppedPartial: Long = 0,
+    droppedComplete: Long = 0,
+    dropped500: Long = 0,
+    droppedQueueFull: Long = 0,
+    droppedRetries: Long = 0,
+    exceptions: Long = 0
+  ): Unit = {
+    assertEquals(registry.counter("atlas.cloudwatch.queue.dps.sent", "stack", "main").count, sent)
+    assertEquals(registry.counter("atlas.cloudwatch.queue.retries", "stack", "main").count, retries)
+    assertEquals(
+      registry
+        .counter("atlas.cloudwatch.queue.dps.dropped", "stack", "main", "reason", "partialFailure")
+        .count,
+      droppedPartial
+    )
+    assertEquals(
+      registry
+        .counter("atlas.cloudwatch.queue.dps.dropped", "stack", "main", "reason", "completeFailure")
+        .count,
+      droppedComplete
+    )
+    assertEquals(
+      registry
+        .counter("atlas.cloudwatch.queue.dps.dropped", "stack", "main", "reason", "status_500")
+        .count,
+      dropped500
+    )
+    assertEquals(
+      registry
+        .counter("atlas.cloudwatch.queue.dps.dropped", "stack", "main", "reason", "queueFull")
+        .count,
+      droppedQueueFull
+    )
+    assertEquals(
+      registry
+        .counter("atlas.cloudwatch.queue.dps.dropped", "stack", "main", "reason", "maxRetries")
+        .count,
+      droppedRetries
+    )
+    assertEquals(
+      registry
+        .counter("atlas.cloudwatch.queue.exception", "stack", "main", "ex", "UTException")
+        .count,
+      exceptions
+    )
+  }
+
+  def mockResponse(statusCode: StatusCode, content: String = null, t: Throwable = null): Unit = {
+    val httpEntity: ResponseEntity = if (content != null) {
+      HttpEntity(ContentTypes.`application/json`, content)
+    } else HttpEntity.Empty
+    if (t == null)
+      when(httpClient.singleRequest(any[HttpRequest])).thenAnswer(
+        Future.successful(
+          HttpResponse(
+            statusCode,
+            entity = httpEntity
+          )
+        )
+      )
+    else {
+      val called = new AtomicBoolean()
+      when(httpClient.singleRequest(any[HttpRequest]))
+        .thenAnswer(
+          if (called.get()) {
+            Future.successful(
+              HttpResponse(
+                statusCode,
+                entity = httpEntity
+              )
+            )
+          } else {
+            called.set(true)
+            Future.failed(t)
+          }
+        )
+    }
+  }
+
+  class UTException(msg: String) extends RuntimeException(msg)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,8 @@ lazy val `atlas-cloudwatch` = project
     Dependencies.atlasWebApi % "test",
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaTestkit % "test",
+    Dependencies.mockitoCore % "test",
+    Dependencies.mockitoScala % "test",
     Dependencies.munit % "test"
   ))
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,6 +68,8 @@ object Dependencies {
   val log4jJcl           = "org.apache.logging.log4j" % "log4j-jcl" % log4j
   val log4jJul           = "org.apache.logging.log4j" % "log4j-jul" % log4j
   val log4jSlf4j         = "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4j
+  val mockitoCore        = "org.mockito" % "mockito-core" % "3.12.4"
+  val mockitoScala       = "org.mockito" % "mockito-scala_2.13" % "1.10.4"
   val munit              = "org.scalameta" %% "munit" % "0.7.29"
   val openHFT            = "net.openhft" % "zero-allocation-hashing" % "0.16"
   val scalaCompiler      = "org.scala-lang" % "scala-compiler" % scala


### PR DESCRIPTION
…ctor

grouping and flushing data points to Publish Proxy instances. A queue will be instantiated for each stack and a router (in the next PR) wil use the AWS account to route data points to the proper queue.