### PR TITLE
Atlas Cloud Watch: Move the Tagger function type into a Trait that in…

### DIFF
--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -115,6 +115,21 @@ atlas {
     tagger = {
       class = "com.netflix.atlas.cloudwatch.NetflixTagger"
 
+      // Characters that are allowed in metric names
+      valid-tag-characters = "-._A-Za-z0-9"
+
+      // Overrides to be more permissive for the values of some keys
+      valid-tag-value-characters = ${?atlas.poller.valid-tag-value-characters} [
+        {
+          key = "nf.cluster"
+          value = "-._A-Za-z0-9^~"
+        },
+        {
+          key = "nf.asg"
+          value = "-._A-Za-z0-9^~"
+        }
+      ]
+
       // Enables extracting a substring of a dimension value using a regex.
       // Only one capture group is supported, so only capture group 1 will
       // be used. If no match is found, the unaltered original value is

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/Tagger.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/Tagger.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.netflix.atlas.core.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+
+trait Tagger {
+
+  /**
+    * Converts a list of cloudwatch dimensions into a tag map that can be used
+    * for Atlas.
+    */
+  def apply(dimensions: List[Dimension]): Map[String, String]
+
+  /**
+    * Applies the approved character set to the given data point in preparation for publishing.
+    */
+  def fixTags(d: Datapoint): Datapoint
+
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/package.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/package.scala
@@ -26,12 +26,6 @@ package object cloudwatch {
   type Tags = Map[String, String]
 
   /**
-    * Converts a list of cloudwatch dimensions into a tag map that can be used
-    * for Atlas.
-    */
-  type Tagger = List[Dimension] => Tags
-
-  /**
     * Converts a cloudwatch datapoint to a floating point value. The conversion is
     * based on the corresponding [[MetricDefinition]]. The full metadata is passed
     * in to allow access to other information that can be useful, such as the period

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
@@ -51,6 +51,8 @@ class DefaultTaggerSuite extends FunSuite {
         |    value = "bar"
         |  }
         |]
+        |valid-tag-characters = "-._A-Za-z0-9"
+        |valid-tag-value-characters = []
       """.stripMargin)
 
     val expected = Map(
@@ -75,6 +77,8 @@ class DefaultTaggerSuite extends FunSuite {
         |  }
         |]
         |common-tags = []
+        |valid-tag-characters = "-._A-Za-z0-9"
+        |valid-tag-value-characters = []
       """.stripMargin)
 
     val expected = Map(
@@ -110,6 +114,8 @@ class DefaultTaggerSuite extends FunSuite {
         |]
         |mappings = []
         |common-tags = []
+        |valid-tag-characters = "-._A-Za-z0-9"
+        |valid-tag-value-characters = []
       """.stripMargin)
 
     val expected = Map(
@@ -137,6 +143,8 @@ class DefaultTaggerSuite extends FunSuite {
         |]
         |mappings = []
         |common-tags = []
+        |valid-tag-characters = "-._A-Za-z0-9"
+        |valid-tag-value-characters = []
       """.stripMargin)
 
     intercept[PatternSyntaxException] {
@@ -158,6 +166,8 @@ class DefaultTaggerSuite extends FunSuite {
         |]
         |mappings = []
         |common-tags = []
+        |valid-tag-characters = "-._A-Za-z0-9"
+        |valid-tag-value-characters = []
       """.stripMargin)
 
     intercept[ConfigException.Missing] {
@@ -179,6 +189,8 @@ class DefaultTaggerSuite extends FunSuite {
         |]
         |mappings = []
         |common-tags = []
+        |valid-tag-characters = "-._A-Za-z0-9"
+        |valid-tag-value-characters = []
       """.stripMargin)
 
     val expected = Map(
@@ -215,6 +227,8 @@ class DefaultTaggerSuite extends FunSuite {
         |]
         |mappings = []
         |common-tags = []
+        |valid-tag-characters = "-._A-Za-z0-9"
+        |valid-tag-value-characters = []
       """.stripMargin)
 
     val expected = Map(
@@ -248,6 +262,8 @@ class DefaultTaggerSuite extends FunSuite {
         |  }
         |]
         |common-tags = []
+        |valid-tag-characters = "-._A-Za-z0-9"
+        |valid-tag-value-characters = []
       """.stripMargin)
 
     val expected = Map(
@@ -281,6 +297,8 @@ class DefaultTaggerSuite extends FunSuite {
         |]
         |mappings = []
         |common-tags = []
+        |valid-tag-characters = "-._A-Za-z0-9"
+        |valid-tag-value-characters = []
       """.stripMargin)
 
     val expected = Map(
@@ -309,6 +327,8 @@ class DefaultTaggerSuite extends FunSuite {
         |    value = "bar"
         |  }
         |]
+        |valid-tag-characters = "-._A-Za-z0-9"
+        |valid-tag-value-characters = []
       """.stripMargin)
 
     val expected = Map(


### PR DESCRIPTION
…cludes the

`fixTags()` method. This allows us to move the `fixTags()` from the Client Actor into the DefaultTagger for re-use when the actor goes away. Also copy the default valid tag key and value character configs from the sink to the tagger section in reference.conf as we'll remove the sink section later.