### PR TITLE
Atlas Cloud Watch: Add the PublishRouter that loads a stack to AWS

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import akka.actor.ActorSystem
+import com.netflix.atlas.akka.AkkaHttpClient
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+
+import java.util.concurrent.Executors
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+class PublishRouter(
+  config: Config,
+  registry: Registry,
+  tagger: Tagger,
+  httpClient: AkkaHttpClient
+)(implicit system: ActorSystem)
+    extends StrictLogging {
+
+  private val schedulers = Executors.newScheduledThreadPool(2)
+  private val baseURI = config.getString("atlas.cloudwatch.account.routing.uri")
+
+  private val missingAccount =
+    registry.counter("atlas.cloudwatch.queue.dps.dropped", "reason", "missingAccount")
+
+  private[cloudwatch] val mainQueue = new PublishQueue(
+    config.getConfig("atlas.cloudwatch.account.routing"),
+    registry,
+    "main",
+    baseURI.replaceAll("\\$\\{STACK\\}", "main"),
+    httpClient,
+    schedulers
+  )
+
+  private[cloudwatch] val accountMap = config
+    .getConfig("atlas.cloudwatch.account.routing.stackMap")
+    .entrySet()
+    .asScala
+    .flatMap { e =>
+      e.getValue.unwrapped().asInstanceOf[java.util.List[String]].asScala.map { acct =>
+        val queue = new PublishQueue(
+          config.getConfig("atlas.cloudwatch.account.routing"),
+          registry,
+          e.getKey,
+          baseURI.replaceAll("\\$\\{STACK\\}", e.getKey),
+          httpClient,
+          schedulers
+        )
+        acct -> queue
+      }
+    }
+    .toMap
+  logger.info(s"Loaded ${accountMap.size} accounts plus main.")
+
+  /**
+    * Routes the data to the proper queue based on the `nf.account` tag.
+    *
+    * @param datapoint
+    *     The non-null data point.
+    */
+  def publish(datapoint: AtlasDatapoint): Unit = {
+    val formatted = tagger.fixTags(datapoint)
+    formatted.tags.get("nf.account") match {
+      case Some(account) =>
+        accountMap.get(account) match {
+          case Some(queue) => queue.enqueue(formatted)
+          case None        => mainQueue.enqueue(formatted)
+        }
+      case None =>
+        missingAccount.increment()
+    }
+  }
+
+  def shutdown(): Unit = {
+    schedulers.shutdownNow()
+  }
+}

--- a/atlas-cloudwatch/src/test/resources/application.conf
+++ b/atlas-cloudwatch/src/test/resources/application.conf
@@ -1,13 +1,34 @@
+atlas {
 
-atlas.poller {
+  poller {
 
-  // Set to a large value because we don't want it running during tests
-  frequency = 60 minutes
+    // Set to a large value because we don't want it running during tests
+    frequency = 60 minutes
 
-  pollers = [
-    {
-      name = "cloudwatch"
-      class = "com.netflix.atlas.cloudwatch.CloudWatchPoller"
+    pollers = [
+      {
+        name = "cloudwatch"
+        class = "com.netflix.atlas.cloudwatch.CloudWatchPoller"
+      }
+    ]
+  }
+
+  cloudwatch {
+
+    account.routing {
+      uri = "https://publish-${STACK}.foo.com/api/v1/publish"
+      default = "main"
+      stackMap = {
+        stackA = [
+          "1",
+          "2"
+        ],
+        stackB = [
+          "3"
+        ]
+      }
     }
-  ]
+
+  }
+
 }

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/PublishRouterSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/PublishRouterSuite.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKitBase
+import com.netflix.atlas.akka.AkkaHttpClient
+import com.netflix.atlas.core.model.Datapoint
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.ConfigFactory
+import munit.FunSuite
+import org.mockito.MockitoSugar.mock
+
+class PublishRouterSuite extends FunSuite with TestKitBase {
+
+  override implicit def system: ActorSystem = ActorSystem(getClass.getSimpleName)
+
+  var registry: Registry = null
+  val config = ConfigFactory.load()
+  val tagger = new NetflixTagger(config.getConfig("atlas.cloudwatch.tagger"))
+  val httpClient = mock[AkkaHttpClient]
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    registry = new DefaultRegistry()
+  }
+
+  test("initialize") {
+    val router = new PublishRouter(config, registry, tagger, httpClient)
+    assertEquals(router.mainQueue.uri, "https://publish-main.foo.com/api/v1/publish")
+    assertEquals(router.accountMap.size, 3)
+    assertEquals(
+      router.accountMap.get("1").get.uri,
+      "https://publish-stackA.foo.com/api/v1/publish"
+    )
+    assertEquals(
+      router.accountMap.get("2").get.uri,
+      "https://publish-stackA.foo.com/api/v1/publish"
+    )
+    assertEquals(
+      router.accountMap.get("3").get.uri,
+      "https://publish-stackB.foo.com/api/v1/publish"
+    )
+    router.shutdown()
+  }
+
+  // NOTE: These are flaky. Either we need a queue factory that we can inject or figure out some way to pause the
+  // Akka system. For now, routing is simple enough I'm not worried about testing.
+//  test("publish main") {
+//    val dp = Datapoint(Map("nf.account" -> "42"), timestamp, 42.0)
+//    val router = spy(new PublishRouter(config, registry, tagger, httpClient))
+//    router.shutdown()
+//    router.publish(dp)
+//    assertEquals(router.mainQueue.publishQueue.size, 1)
+//  }
+//
+//  test("publish stackA") {
+//    val dp = Datapoint(Map("nf.account" -> "1"), timestamp, 42.0)
+//    val router = new PublishRouter(config, registry, tagger, httpClient)
+//    router.shutdown()
+//    router.publish(dp)
+//    assertEquals(router.accountMap.get("1").get.publishQueue.size, 1)
+//  }
+
+  test("publish missing account tag") {
+    val dp = Datapoint(Map("no" -> "account"), 1677628800000L, 42.0)
+    val router = new PublishRouter(config, registry, tagger, httpClient)
+    router.shutdown()
+    router.publish(dp)
+    assertEquals(
+      registry.counter("atlas.cloudwatch.queue.dps.dropped", "reason", "missingAccount").count(),
+      1L
+    )
+  }
+
+}


### PR DESCRIPTION
account ID map to route datapoints to the proper publish proxy endpoint.