### PR TITLE
Atlas Cloud Watch: add a dimension matching function to MetricCategory

### DIFF
--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
@@ -16,11 +16,12 @@
 package com.netflix.atlas.cloudwatch
 
 import java.time.Duration
-
 import com.netflix.atlas.core.model.Query
 import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
+import junit.framework.TestCase.assertFalse
 import munit.FunSuite
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
 
 class MetricCategorySuite extends FunSuite {
 
@@ -184,5 +185,74 @@ class MetricCategorySuite extends FunSuite {
     intercept[IllegalStateException] {
       MetricCategory.fromConfig(cfg)
     }
+  }
+
+  test("category with monotonic") {
+    val cfg = ConfigFactory.parseString("""
+        namespace = "AWS/ELB"
+        |period = 1 m
+        |dimensions = ["LoadBalancerName"]
+        |metrics = [
+        |  {
+        |    name = "RequestCount"
+        |    alias = "aws.elb.requests"
+        |    conversion = "sum,rate",
+        |    monotonic = true
+        |  }
+        |]
+        |filter = "name,RequestCount,:eq"
+      """.stripMargin)
+
+    val category = MetricCategory.fromConfig(cfg)
+    assert(category.hasMonotonic)
+  }
+
+  test("dimensionsMatch true") {
+    val cfg = ConfigFactory.parseString("""
+        |namespace = "AWS/ELB"
+        |period = 1 m
+        |dimensions = ["LoadBalancerName"]
+        |metrics = []
+      """.stripMargin)
+
+    val category = MetricCategory.fromConfig(cfg)
+    assert(
+      category.dimensionsMatch(
+        List(
+          Dimension.builder().name("LoadBalancerName").value("UT").build()
+        )
+      )
+    )
+  }
+
+  test("dimensionsMatch too few") {
+    val cfg = ConfigFactory.parseString("""
+        |namespace = "AWS/ELB"
+        |period = 1 m
+        |dimensions = ["LoadBalancerName"]
+        |metrics = []
+      """.stripMargin)
+
+    val category = MetricCategory.fromConfig(cfg)
+    assertFalse(category.dimensionsMatch(List.empty))
+  }
+
+  test("dimensionsMatch too many") {
+    val cfg = ConfigFactory.parseString("""
+        |namespace = "AWS/ELB"
+        |period = 1 m
+        |dimensions = ["LoadBalancerName"]
+        |metrics = []
+      """.stripMargin)
+
+    val category = MetricCategory.fromConfig(cfg)
+    assertFalse(
+      category.dimensionsMatch(
+        List(
+          Dimension.builder().name("LoadBalancerName").value("UT").build(),
+          Dimension.builder().name("ExtraDimension").value("UT").build()
+        )
+      )
+    )
   }
 }


### PR DESCRIPTION
to determine if a value received from the Cloud Watch firehose has an exact match on the tags required in the configuration.