### PR TITLE
Atlas Cloud Watch: Add a protobuf definition file for storing the cached

### DIFF
--- a/atlas-cloudwatch/src/main/protobuf/CloudWatchMetric.proto
+++ b/atlas-cloudwatch/src/main/protobuf/CloudWatchMetric.proto
@@ -1,0 +1,28 @@
+syntax = "proto2";
+
+package com.netflix.atlas.cloudwatch;
+
+option java_multiple_files = true;
+option java_package = "com.netflix.atlas.cloudwatch";
+option java_outer_classname = "CloudWatchMetric";
+
+message CloudWatchDimension {
+  required string name = 1;
+  required string value = 2;
+}
+
+message CloudWatchValue {
+  required int64 timestamp = 1;
+  optional double sum = 2;
+  optional double min = 3;
+  optional double max = 4;
+  optional double count = 5;
+}
+
+message CloudWatchCacheEntry {
+  required string namespace = 1;
+  required string metric = 2;
+  required string unit = 3;
+  repeated CloudWatchDimension dimensions = 4;
+  repeated CloudWatchValue data = 5;
+}

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ lazy val `atlas-aggregator` = project
 
 lazy val `atlas-cloudwatch` = project
   .configure(BuildSettings.profile)
+  .enablePlugins(ProtobufPlugin)
   .settings(libraryDependencies ++= Seq(
     Dependencies.atlasCore,
     Dependencies.atlasJson,
@@ -55,6 +56,7 @@ lazy val `atlas-cloudwatch` = project
     Dependencies.log4jCore,
     Dependencies.log4jSlf4j,
     Dependencies.openHFT,
+    Dependencies.protobuf,
 
     Dependencies.atlasWebApi % "test",
     Dependencies.akkaHttpTestkit % "test",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,6 +72,7 @@ object Dependencies {
   val mockitoScala       = "org.mockito" % "mockito-scala_2.13" % "1.10.4"
   val munit              = "org.scalameta" %% "munit" % "0.7.29"
   val openHFT            = "net.openhft" % "zero-allocation-hashing" % "0.16"
+  val protobuf           = "com.google.protobuf" % "protobuf-java" % "3.22.0"
   val scalaCompiler      = "org.scala-lang" % "scala-compiler" % scala
   val scalaLibrary       = "org.scala-lang" % "scala-library" % scala
   val scalaLogging       = "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,5 +7,8 @@ addSbtPlugin("com.typesafe.sbt"          % "sbt-native-packager"  % "1.3.12")
 
 addSbtPlugin("org.scalameta"             % "sbt-scalafmt"         % "2.4.6")
 
+// for compiling protobuf in the Cloud Watch module
+addSbtPlugin("com.github.sbt"            % "sbt-protobuf"         % "0.7.1")
+
 // Convenient helpers, not required
 addSbtPlugin("com.timushev.sbt"          % "sbt-updates"          % "0.6.4")


### PR DESCRIPTION
firehose metrics in a sorted list in a backing store like Redis. Add the protobuf complication SBT plugin to generate source code on package build.