### PR TITLE
Atlas Cloud Watch: Change the ASL query filter in MetricCategory to b…

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/ListMetricsActor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/ListMetricsActor.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.cloudwatch
 
 import akka.actor.Actor
+import com.netflix.atlas.core.model.Query
 import com.typesafe.scalalogging.StrictLogging
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
 import software.amazon.awssdk.services.cloudwatch.model.CloudWatchException
@@ -61,7 +62,7 @@ class ListMetricsActor(client: CloudWatchClient, tagger: Tagger) extends Actor w
         }
         logger.debug(s"before filtering, found ${candidates.size} metrics for $mname")
         val after = candidates.filter { m =>
-          category.filter.matches(tagger(m.dimensions))
+          category.filter.getOrElse(Query.True).matches(tagger(m.dimensions))
         }
         logger.debug(s"after filtering, found ${after.size} metrics for $mname")
         after

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricCategory.scala
@@ -75,7 +75,7 @@ case class MetricCategory(
   timeout: Option[Duration],
   dimensions: List[String],
   metrics: List[MetricDefinition],
-  filter: Query
+  filter: Option[Query]
 ) {
 
   /**
@@ -146,9 +146,9 @@ object MetricCategory extends StrictLogging {
     import scala.jdk.CollectionConverters._
     val metrics = config.getConfigList("metrics").asScala.toList
     val filter =
-      if (!config.hasPath("filter")) Query.True
+      if (!config.hasPath("filter")) None
       else {
-        parseQuery(config.getString("filter"))
+        Some(parseQuery(config.getString("filter")))
       }
     val timeout = if (config.hasPath("timeout")) Some(config.getDuration("timeout")) else None
     val endPeriodOffset =

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
@@ -79,7 +79,7 @@ class ConversionsSuite extends FunSuite {
   test("rate") {
     val cnv = Conversions.fromName("sum,rate")
     val meta = MetricMetadata(
-      MetricCategory("NFLX/Test", 300, 1, 3, None, Nil, Nil, Query.True),
+      MetricCategory("NFLX/Test", 300, 1, 3, None, Nil, Nil, Some(Query.True)),
       MetricDefinition("test", "test-alias", cnv, false, Map.empty),
       Nil
     )
@@ -90,7 +90,7 @@ class ConversionsSuite extends FunSuite {
   test("rate already") {
     val cnv = Conversions.fromName("sum,rate")
     val meta = MetricMetadata(
-      MetricCategory("NFLX/Test", 300, 1, 3, None, Nil, Nil, Query.True),
+      MetricCategory("NFLX/Test", 300, 1, 3, None, Nil, Nil, Some(Query.True)),
       MetricDefinition("test", "test-alias", cnv, false, Map.empty),
       Nil
     )

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
@@ -119,7 +119,7 @@ class MetricCategorySuite extends FunSuite {
     assertEquals(category.namespace, "AWS/ELB")
     assertEquals(category.period, 60)
     assertEquals(category.toListRequests.size, 2)
-    assertEquals(category.filter, Query.True)
+    assertEquals(category.filter, None)
   }
 
   test("category without timeout") {
@@ -164,7 +164,7 @@ class MetricCategorySuite extends FunSuite {
       """.stripMargin)
 
     val category = MetricCategory.fromConfig(cfg)
-    assertEquals(category.filter, Query.Equal("name", "RequestCount"))
+    assertEquals(category.filter, Some(Query.Equal("name", "RequestCount")))
   }
 
   test("config with invalid filter") {

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDataSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDataSuite.scala
@@ -28,7 +28,16 @@ class MetricDataSuite extends FunSuite {
     MetricDefinition("test", "alias", Conversions.fromName("sum"), false, Map.empty)
 
   private val category =
-    MetricCategory("namespace", 60, 1, 5, None, List("dimension"), List(definition), Query.True)
+    MetricCategory(
+      "namespace",
+      60,
+      1,
+      5,
+      None,
+      List("dimension"),
+      List(definition),
+      Some(Query.True)
+    )
   private val metadata = MetricMetadata(category, definition, Nil)
 
   private val monotonicMetadata = metadata.copy(definition = definition.copy(monotonicValue = true))

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
@@ -27,7 +27,7 @@ import java.time.Instant
 class MetricDefinitionSuite extends FunSuite {
 
   private val meta = MetricMetadata(
-    MetricCategory("AWS/ELB", 60, 1, 5, None, Nil, Nil, Query.True),
+    MetricCategory("AWS/ELB", 60, 1, 5, None, Nil, Nil, Some(Query.True)),
     null,
     Nil
   )
@@ -248,7 +248,7 @@ class MetricDefinitionSuite extends FunSuite {
       .build()
 
     val metadata = MetricMetadata(
-      MetricCategory("AWS/RDS", 60, 1, 5, None, Nil, Nil, Query.True),
+      MetricCategory("AWS/RDS", 60, 1, 5, None, Nil, Nil, Some(Query.True)),
       definition,
       Nil
     )


### PR DESCRIPTION
…e an

Option[Query] so that for the firehose streaming, we only instantiate tag maps for query evaluation if the filter is explicitly set.