### PR TITLE
Atlas Cloud Watch: Add the CloudWatchMetricsProcessor, an abstract class

### DIFF
--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -102,6 +102,16 @@ atlas {
       }
     }
 
+    // TEMP: Used while testing cloud watch streaming to prepend "TEST." to metrics in order to compare against
+    // the poller.
+    testMode = true
+
+    // How often to run the publish thread.
+    step = 60s
+
+    // How long to wait after the top of the step (usually minute) before starting the scrape.
+    publishOffset = 5s
+
     // Batch size for flushing data back to the poller manager
     batch-size = 1000
 

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
@@ -1,0 +1,556 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import akka.actor.ActorSystem
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.expirationSeconds
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.newValue
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.normalize
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.toAWSDatapoint
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.toAWSDimensions
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.toTagMap
+import com.netflix.atlas.core.util.SmallHashMap
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+
+import java.time.Instant
+import java.util
+import java.util.concurrent.TimeUnit
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * Base class for a processor that evaluates incoming CloudWatch metrics against the configured rule set and passes
+  * them on to a cache that will sort and publish the data at the appropriate time.
+  *
+  * Note that the base class schedules publishing based on the configured step interval (default of 60 seconds).
+  *
+  * Also note that we store only the base tags and data from Cloudwatch, not the enriched or converted values. This allows
+  * us to store a bit less data in the cache. However we do validate the data twice through the rules. This also give us
+  * the ability to update rules and clear out anything from the cache that is no longer relevant.
+  *
+  * @param config
+  *     Non-null config to pull settings from.
+  * @param registry
+  *     Non-null registry to report metrics.
+  * @param rules
+  *     Non-null rules set to use for matching incoming data.
+  * @param system
+  *     The Akka system we use for scheduling.
+  */
+abstract class CloudWatchMetricsProcessor(
+  config: Config,
+  registry: Registry,
+  rules: CloudWatchRules,
+  tagger: Tagger,
+  publishRouter: PublishRouter
+)(implicit val system: ActorSystem)
+    extends StrictLogging {
+
+  /** The number of data points received by the processor from cloud watch.  */
+  private[cloudwatch] val received = registry.counter("atlas.cloudwatch.datapoints.received")
+
+  /** The number of data points filtered out before caching due to not having a namespace config. */
+  private[cloudwatch] val filteredNS =
+    registry.counter("atlas.cloudwatch.datapoints.filtered", "reason", "namespace")
+
+  /** The number of data points filtered out before caching due to not having a metric config. */
+  private[cloudwatch] val filteredMetric =
+    registry.counter("atlas.cloudwatch.datapoints.filtered", "reason", "metric")
+
+  /** The number of data points filtered out before caching due to missing or extraneous tags not definied in the category. */
+  private[cloudwatch] val filteredTags =
+    registry.counter("atlas.cloudwatch.datapoints.filtered", "reason", "tags")
+
+  /** The number of data points filtered out before caching due to a query filter. */
+  private[cloudwatch] val filteredQuery =
+    registry.counter("atlas.cloudwatch.datapoints.filtered", "reason", "query")
+
+  /** The number of data points overwriting a duplicate value. */
+  private[cloudwatch] val dupes = registry.createId("atlas.cloudwatch.datapoints.dupes")
+
+  /** The number of data points dropped due to being older than the period count. */
+  private[cloudwatch] val droppedOld =
+    registry.createId("atlas.cloudwatch.datapoints.dropped", "reason", "tooOld")
+
+  /** The number of data points arriving out of order. Data is still kept and processed. */
+  private[cloudwatch] val outOfOrder = registry.createId("atlas.cloudwatch.datapoints.ooo")
+
+  /** The number of data points dropped reading from the cache due to the namespace config disappearing. */
+  private[cloudwatch] val purgedNS =
+    registry.counter("atlas.cloudwatch.datapoints.purged", "reason", "namespace")
+
+  /** The number of data points dropped reading from the cache due to the metric config disappearing. */
+  private[cloudwatch] val purgedMetric =
+    registry.counter("atlas.cloudwatch.datapoints.purged", "reason", "metric")
+
+  /** The number of data points dropped reading from the cache due to the tags configuration changing. */
+  private[cloudwatch] val purgedTags =
+    registry.counter("atlas.cloudwatch.datapoints.purged", "reason", "tags")
+
+  /** The number of data points dropped reading from the cache due to an updated query filter. */
+  private[cloudwatch] val purgedQuery =
+    registry.counter("atlas.cloudwatch.datapoints.purged", "reason", "query")
+
+  /** The number of cache entries that had empty data lists when being loaded. Usually happens due to an insert being too
+    * old and existing values being expired. */
+  private[cloudwatch] val publishEmpty = registry.createId("atlas.cloudwatch.publish.empty")
+
+  /** The number of data points still published even though their timestamp was for a time later than the expected
+    * publishing time. This is usually related to end-period-offsets but may be clock issues. */
+  private[cloudwatch] val publishFuture = registry.createId("atlas.cloudwatch.publish.future")
+
+  private val step = config.getDuration("atlas.cloudwatch.step").getSeconds.toInt
+  private val publishDelay = config.getDuration("atlas.cloudwatch.publishOffset").getSeconds.toInt
+  // TODO - temp and removable once we're happy with the results.
+  private val testMode = config.getBoolean("atlas.cloudwatch.testMode")
+
+  // ctor
+  {
+    val delay = {
+      val now = System.currentTimeMillis()
+      val topOfMinute = normalize(now, step)
+      ((step * 1000) - (now - topOfMinute)) + (publishDelay * 1000)
+    }
+    logger.info(s"Starting publishing in ${delay / 1000.0} seconds.")
+    system.scheduler.scheduleAtFixedRate(
+      FiniteDuration.apply(delay, TimeUnit.MILLISECONDS),
+      FiniteDuration.apply(step, TimeUnit.SECONDS)
+    )(() => {
+      try {
+        publish(normalize(System.currentTimeMillis(), step))
+      } catch {
+        case ex: Exception =>
+          logger.error("Whoops!?!?", ex)
+      }
+    })(system.dispatcher)
+  }
+
+  /**
+    * Evaluates the data against the rules and forwards it on to the cache if valid.
+    *
+    * @param datapoints
+    *     A non-null list of data points for processing.
+    * @param receivedTimestamp
+    *     The millisecond epoch timestamp when the values came in. Re-used to avoid fetching the current
+    *     time for every timestamp when evaluating latencies or expirations.
+    */
+  def processDatapoints(datapoints: List[FirehoseMetric], receivedTimestamp: Long): Unit = {
+    received.increment(datapoints.size)
+
+    datapoints.foreach { dp =>
+      rules.rules.get(dp.namespace) match {
+        case None => filteredNS.increment()
+        case Some(namespaceRules) =>
+          namespaceRules.get(dp.metricName) match {
+            case None => filteredMetric.increment()
+            case Some(tuple) =>
+              if (!tuple._1.dimensionsMatch(dp.dimensions)) {
+                filteredTags.increment()
+              } else if (tuple._1.filter.isDefined && tuple._1.filter.get.matches(toTagMap(dp))) {
+                filteredQuery.increment()
+              } else {
+                // finally passed the checks.
+                updateCache(dp, tuple._1, receivedTimestamp)
+              }
+
+              val delay = receivedTimestamp - dp.datapoint.timestamp().toEpochMilli
+              registry
+                .distributionSummary(
+                  "atlas.cloudwatch.namespace.delay",
+                  "namespace",
+                  tuple._1.namespace,
+                  "metric",
+                  dp.metricName
+                )
+                .record(delay)
+          }
+      }
+    }
+  }
+
+  /**
+    * Called when a data point matched a category and should be processed by the cache.
+    *
+    * @param datapoint
+    *     The non-null datapoint to cache.
+    * @param category
+    *     The non-null category the data point matched.
+    * @param receivedTimestamp
+    *     The receive time in unix epoch milliseconds.
+    */
+  protected def updateCache(
+    datapoint: FirehoseMetric,
+    category: MetricCategory,
+    receivedTimestamp: Long
+  ): Unit
+
+  /**
+    * Called by the scheduler to publish data accumulated in the cache. Exposed for unit testing.
+    */
+  protected[cloudwatch] def publish(now: Long): Future[Unit]
+
+  /**
+    * Removes the given entry from the cache. This is used to purge entries that are no longer valid due to a config
+    * change or error.
+    *
+    * @param key
+    *     The non-null key to delete. It's an `Any` for now since the key could be in any format.
+    */
+  protected[cloudwatch] def delete(key: Any): Unit
+
+  /**
+    * Inserts the given data point in the proper order of the CloudWatchCloudWatchCacheEntry **AND** expires any old data from
+    * the entry. Note that this can lead to empty cache entries and those should likely be deleted.
+    * Duplicates are overwritten.
+    */
+  private[cloudwatch] def insertDatapoint(
+    data: Array[Byte],
+    datapoint: FirehoseMetric,
+    category: MetricCategory,
+    receivedTimestamp: Long
+  ): CloudWatchCacheEntry = {
+    val entry = CloudWatchCacheEntry.parseFrom(data)
+    CloudWatchCacheEntry
+      .newBuilder(entry)
+      .clearData()
+      .addAllData(insert(datapoint, category, entry.getDataList, receivedTimestamp))
+      .build()
+  }
+
+  private[cloudwatch] def insert(
+    datapoint: FirehoseMetric,
+    category: MetricCategory,
+    data: java.util.List[CloudWatchValue],
+    receivedTimestamp: Long
+  ): java.util.List[CloudWatchValue] = {
+    val exp = (expirationSeconds(category) - category.period) * 1000
+    // this is the oldest value to keep. Anything older, we kick out.
+    val oldest = normalize(receivedTimestamp, 60) - exp
+
+    val filtered =
+      new util.LinkedList[CloudWatchValue](data.asScala.filter(_.getTimestamp >= oldest).asJava)
+    val ts = normalize(datapoint.datapoint.timestamp().toEpochMilli, category.period)
+    if (ts < oldest) {
+      logger.warn(
+        s"Dropping data for namespace {} and metric {} that was older than the retention period of ${exp / 1000}s. {}s over.",
+        category.namespace,
+        datapoint.metricName,
+        (oldest - ts) / 1000.0
+      )
+      registry.counter(droppedOld.withTag("namespace", category.namespace)).increment()
+    } else {
+      if (filtered.isEmpty) {
+        filtered.add(newValue(ts, datapoint.datapoint))
+      } else if (filtered.get(0).getTimestamp > ts) {
+        // prepend
+        filtered.add(0, newValue(ts, datapoint.datapoint))
+        registry.counter(outOfOrder.withTag("namespace", category.namespace)).increment()
+      } else {
+        // see if we need to overwrite or insert
+        var added = false
+        var i = 0
+        while (i < filtered.size() && !added) {
+          val dp = filtered.get(i)
+          if (dp.getTimestamp == ts) {
+            logger.debug(
+              s"Duplicate value for namespace {} and metric {}",
+              category.namespace,
+              datapoint.metricName
+            )
+            registry.counter(dupes.withTag("namespace", category.namespace)).increment()
+            filtered.set(i, newValue(ts, datapoint.datapoint))
+            added = true
+          } else if (dp.getTimestamp > ts) {
+            filtered.add(i, newValue(ts, datapoint.datapoint))
+            registry.counter(outOfOrder.withTag("namespace", category.namespace)).increment()
+            added = true
+          }
+          i += 1
+        }
+
+        if (!added) {
+          // apppend
+          filtered.add(newValue(ts, datapoint.datapoint))
+        }
+      }
+    }
+
+    filtered
+  }
+
+  private[cloudwatch] def sendToRouter(key: Any, data: Array[Byte], timestamp: Long): Unit = {
+    val entry = CloudWatchCacheEntry.parseFrom(data)
+    if (entry.getDataCount == 0) {
+      delete(key)
+      registry.counter(publishEmpty.withTag("namespace", entry.getNamespace)).increment()
+      return
+    }
+
+    rules.rules.get(entry.getNamespace) match {
+      case None =>
+        delete(key)
+        purgedNS.increment()
+      case Some(namespaceRules) =>
+        namespaceRules.get(entry.getMetric) match {
+          case None =>
+            delete(key)
+            purgedMetric.increment()
+          case Some(tuple) =>
+            val (category, definitions) = tuple
+            if (!category.dimensionsMatch(toAWSDimensions(entry))) {
+              delete(key)
+              purgedTags.increment()
+            } else if (category.filter.isDefined && category.filter.get.matches(toTagMap(entry))) {
+              delete(key)
+              purgedQuery.increment()
+            } else {
+              var i = 0
+              val offsetTimestamp =
+                timestamp - ((category.period * category.endPeriodOffset) * 1000)
+              while (i < entry.getDataCount && entry.getData(i).getTimestamp < offsetTimestamp) {
+                i += 1
+              }
+              if (i == entry.getDataCount) {
+                i = entry.getDataCount - 1
+              }
+              // TODO - it's possible that a value in the future relative to the lookup timestamp is returned here, e.g.
+              // if the entry at index 0 is greater than timestamp. In that case, do we not report? OR report the value?
+              if (entry.getData(i).getTimestamp > offsetTimestamp) {
+                registry.counter(publishFuture.withTag("namespace", category.namespace)).increment()
+              }
+              // TODO - there are some configs where the timeout is less than the period * period count, e.g. Neptune.
+              // if we _don't_ want the last available value to keep posting all the time, then we need to incorporate
+              // that timeout here. Otherwise, e.g. for a value posted once a day, we'll keep posting the daily value until
+              // we get a new one.
+              val cur = toAWSDatapoint(entry.getData(i), entry.getUnit)
+              val prev = if (i > 0) {
+                Some(toAWSDatapoint(entry.getData(i - 1), entry.getUnit))
+              } else None
+              definitions.foreach { d =>
+                val metric = MetricData(
+                  MetricMetadata(category, d, toAWSDimensions(entry)),
+                  prev,
+                  Some(cur),
+                  if (prev.isDefined) Some(Instant.ofEpochMilli(prev.get.timestamp().toEpochMilli))
+                  else None
+                )
+                val atlasDp = toAtlasDatapoint(metric, timestamp)
+                publishRouter.publish(atlasDp)
+              }
+            }
+        }
+    }
+  }
+
+  private[cloudwatch] def toAtlasDatapoint(
+    metric: MetricData,
+    receivedTimestamp: Long
+  ): AtlasDatapoint = {
+    val definition = metric.meta.definition
+    val ts = tagger(metric.meta.dimensions) ++ definition.tags + ("name" ->
+      // TODO - clean this out once tests are finished
+      (if (testMode) s"TEST.${definition.alias}" else definition.alias))
+    val newValue = definition.conversion(metric.meta, metric.datapoint())
+    // NOTE - the polling CW code uses now for the timestamp, likely for LWC. BUT data could be off by
+    // minutes potentially. And it didn't account for the offset value as far as I could tell. Now we'll at least
+    // use the offset value.
+    new AtlasDatapoint(ts, receivedTimestamp, newValue)
+  }
+}
+
+object CloudWatchMetricsProcessor {
+
+  /**
+    * Snaps the timestamp to the top of the period.
+    *
+    * @param ts
+    *     The unix epoch timestamp in milliseconds.
+    * @param period
+    *     The period to snap to in seconds (as the configs are in seconds)
+    * @return
+    *     The adjusted timestamp.
+    */
+  private[cloudwatch] def normalize(ts: Long, period: Int): Long = ts - (ts % (period * 1000))
+
+  /**
+    * Generates a new Protobuf cache entry from the given firehose data point and category. The data list will only
+    * contain the given data point.
+    *
+    * @param datapoint
+    *     The non-null datapoint to encode.
+    * @param category
+    *     The non-null category to pull a Unit from.
+    * @return
+    *     A non-null cache entry.
+    */
+  private[cloudwatch] def newCacheEntry(
+    datapoint: FirehoseMetric,
+    category: MetricCategory
+  ): CloudWatchCacheEntry = {
+    val dp = datapoint.datapoint
+    CloudWatchCacheEntry
+      .newBuilder()
+      .setNamespace(datapoint.namespace)
+      .setMetric(datapoint.metricName)
+      .setUnit(dp.unitAsString())
+      .addAllDimensions(datapoint.dimensions.map { d =>
+        CloudWatchDimension
+          .newBuilder()
+          .setName(d.name())
+          .setValue(d.value())
+          .build()
+      }.asJava)
+      .addData(
+        CloudWatchValue
+          .newBuilder()
+          .setTimestamp(normalize(dp.timestamp().toEpochMilli, category.period))
+          .setSum(dp.sum())
+          .setMin(dp.minimum())
+          .setMax(dp.maximum())
+          .setCount(dp.sampleCount())
+      )
+      .build()
+  }
+
+  /**
+    * Encodes a new Protobuf value.
+    * @param ts
+    *     The timestamp of the value in unix epoch milliseconds.
+    * @param dp
+    *     The non-null CW data point to encode.
+    * @return
+    *     A non-null cloud watch value.
+    */
+  private[cloudwatch] def newValue(ts: Long, dp: Datapoint): CloudWatchValue = {
+    CloudWatchValue
+      .newBuilder()
+      .setTimestamp(ts)
+      .setSum(dp.sum())
+      .setMin(dp.minimum())
+      .setMax(dp.maximum())
+      .setCount(dp.sampleCount())
+      .build()
+  }
+
+  /**
+    * Converts the Protobuf value to an AWS data point.
+    *
+    * @param dp
+    *     The non-null cloud watch data point.
+    * @param unit
+    *     The non-null unit from the cloud watch cache entry.
+    * @return
+    *     A non-null data point.
+    */
+  private[cloudwatch] def toAWSDatapoint(dp: CloudWatchValue, unit: String): Datapoint = {
+    Datapoint
+      .builder()
+      .timestamp(Instant.ofEpochMilli(dp.getTimestamp))
+      .unit(unit)
+      .sum(dp.getSum)
+      .maximum(dp.getMax)
+      .minimum(dp.getMin)
+      .sampleCount(dp.getCount)
+      .build()
+  }
+
+  /**
+    * Converts the given Protobuf entry's dimensions into a list of AWS dimensions.
+    *
+    * @param entry
+    *     The non-null entry to convert.
+    * @return
+    *     A non-null, potentially empty, list of dimensions.
+    */
+  private[cloudwatch] def toAWSDimensions(entry: CloudWatchCacheEntry): List[Dimension] = {
+    entry.getDimensionsList.asScala.map { d =>
+      Dimension
+        .builder()
+        .name(d.getName)
+        .value(d.getValue)
+        .build()
+    }.toList
+  }
+
+  /**
+    * Converts the dimensions from the Protobuf entry to a sorted tag map to use in evaluating against a
+    * Query filter from a [MetricCategory] config. Note that the `name` and `aws.namespace` tags are populated per
+    * Atlas standards.
+    *
+    * @param entry
+    *     The non-null entry to encode.
+    * @return
+    *     A non-null map with at least the `name` and `aws.namespace` tags.
+    */
+  private[cloudwatch] def toTagMap(entry: CloudWatchCacheEntry): Map[String, String] = {
+    SmallHashMap(
+      entry.getDimensionsCount + 2,
+      entry.getDimensionsList.asScala
+        .map(d => d.getName -> d.getValue)
+        .append("name" -> entry.getMetric)
+        .append("aws.namespace" -> entry.getNamespace)
+        .iterator
+    )
+  }
+
+  /**
+    * Converts the dimensions from the firehose datapoint to a sorted tag map to use in evaluating against a
+    * Query filter from a [MetricCategory] config. Note that the `name` and `aws.namespace` tags are populated per
+    * Atlas standards.
+    *
+    * @return
+    * A non-null map with at least the `name` and `aws.namespace` tags.
+    */
+  private[cloudwatch] def toTagMap(datapoint: FirehoseMetric): Map[String, String] = {
+    SmallHashMap(
+      datapoint.dimensions.size + 2,
+      datapoint.dimensions
+        .map(d => d.name() -> d.value())
+        .appended("name" -> datapoint.metricName)
+        .appended("aws.namespace" -> datapoint.namespace)
+        .iterator
+    )
+  }
+
+  /**
+    * Computes the expiration time for a value based on the [MetricCategory] configuration. It accounts for monotonic
+    * counters by adding a period to the period count, then returns the max of either the period * period count or
+    * the timeout value if set.
+    *
+    * @param category
+    *     The non-null category to pull settings from.
+    * @return
+    *     How long, in seconds, before expiration.
+    */
+  private[cloudwatch] def expirationSeconds(category: MetricCategory): Long = {
+    val periodCount =
+      if (category.hasMonotonic) category.periodCount + 1
+      else category.periodCount
+    val periodExpiration = periodCount * category.period
+
+    if (category.timeout.isDefined) {
+      Math.max(periodExpiration, category.timeout.get.getSeconds)
+    } else {
+      periodExpiration
+    }
+  }
+
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/LocalCloudWatchMetricsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/LocalCloudWatchMetricsProcessor.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import akka.actor.ActorSystem
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.expirationSeconds
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.newCacheEntry
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.concurrent.Future
+
+/**
+  * A local implementation of the metrics processor mean for unit testing or experimenting with
+  * Cloud Watch data.
+  *
+  * @param config
+  *     Non-null config to pull settings from.
+  * @param registry
+  *     Non-null registry to report metrics.
+  * @param tagger
+  *     The non-null tagger to use.
+  * @param rules
+  *     Non-null rules set to use for matching incoming data.
+  * @param publishRouter
+  *     The non-null publisher to report to.
+  * @param system
+  *     The Akka system we use for scheduling.
+  */
+class LocalCloudWatchMetricsProcessor(
+  config: Config,
+  registry: Registry,
+  rules: CloudWatchRules,
+  tagger: Tagger,
+  publishRouter: PublishRouter
+)(override implicit val system: ActorSystem)
+    extends CloudWatchMetricsProcessor(config, registry, rules, tagger, publishRouter) {
+
+  //                                               writeTS, expSec, data
+  private val cache = new ConcurrentHashMap[Long, (Long, Long, Array[Byte])]
+
+  override protected def updateCache(
+    datapoint: FirehoseMetric,
+    category: MetricCategory,
+    receivedTimestamp: Long
+  ): Unit = {
+    val hash = datapoint.xxHash
+    val existing = cache.get(hash)
+    val data = if (existing != null) {
+      val (ts, exp, data) = existing
+      if (ts + (exp * 1000) > receivedTimestamp) {
+        insertDatapoint(data, datapoint, category, receivedTimestamp).toByteArray
+      } else {
+        newCacheEntry(datapoint, category).toByteArray
+      }
+    } else {
+      newCacheEntry(datapoint, category).toByteArray
+    }
+
+    cache.put(hash, (receivedTimestamp, expirationSeconds(category), data))
+  }
+
+  override protected[cloudwatch] def publish(now: Long): Future[Unit] = {
+    val iterator = cache.entrySet().iterator()
+    while (iterator.hasNext) {
+      val entry = iterator.next()
+      val hash = entry.getKey
+      val (ts, exp, data) = entry.getValue
+      if (ts + (exp * 1000) < now) {
+        cache.remove(hash)
+      } else {
+        sendToRouter(hash, data, now)
+      }
+    }
+    Future.successful(null)
+  }
+
+  override protected[cloudwatch] def delete(key: Any): Unit = {
+    cache.remove(key)
+  }
+
+  private[cloudwatch] def inject(
+    key: Long,
+    payload: Array[Byte],
+    timestamp: Long,
+    exp: Long
+  ): Unit = {
+    cache.put(key, (timestamp, exp, payload))
+  }
+}

--- a/atlas-cloudwatch/src/test/resources/application.conf
+++ b/atlas-cloudwatch/src/test/resources/application.conf
@@ -14,6 +14,15 @@ atlas {
   }
 
   cloudwatch {
+    testMode = false
+    categories = ${?atlas.cloudwatch.categories} [
+      "ut1",
+      "ut-asg",
+      "ut-timeout",
+      "ut-offset",
+      "ut-mono",
+      "queryfilter"
+    ]
 
     account.routing {
       uri = "https://publish-${STACK}.foo.com/api/v1/publish"
@@ -32,3 +41,5 @@ atlas {
   }
 
 }
+
+include "test-rules.conf"

--- a/atlas-cloudwatch/src/test/resources/test-rules.conf
+++ b/atlas-cloudwatch/src/test/resources/test-rules.conf
@@ -1,0 +1,135 @@
+atlas {
+  cloudwatch {
+    tagger.mappings = ${?atlas.cloudwatch.tagger.mappings} [
+      {
+        name = "MyTag"
+        alias = "aws.tag"
+      }
+    ]
+
+    ut1 = {
+      namespace = "AWS/UT1"
+      period = 1m
+
+      dimensions = [
+        "MyTag"
+      ]
+
+      metrics = [
+        {
+          name = "SumRate"
+          alias = "aws.utm.sumrate"
+          conversion = "sum,rate"
+        },
+        {
+          name = "Dist"
+          alias = "aws.utm.dist"
+          conversion = "dist-summary"
+        },
+        {
+          name = "Max"
+          alias = "aws.utm.max"
+          conversion = "max"
+        }
+      ]
+    }
+
+    ut-asg = {
+      namespace = "AWS/UT1"
+      period = 1m
+
+      dimensions = [
+        "AvailabilityZone",
+        "LoadBalancerName"
+      ]
+
+      metrics = [
+        {
+          name = "Timer"
+          alias = "aws.utm.timer"
+          conversion = "timer"
+        },
+        {
+          name = "Bytes"
+          alias = "aws.utm.bytes"
+          conversion = "sum,rate"
+        }
+      ]
+    }
+
+    ut-timeout = {
+      namespace = "AWS/UT1"
+      period = 1m
+      timeout = 15m
+
+      dimensions = [
+        "MyTag"
+      ]
+
+      metrics = [
+        {
+          name = "TimeOut"
+          alias = "aws.utm.timeout"
+          conversion = "max"
+        }
+      ]
+    }
+
+    ut-offset = {
+      namespace = "AWS/UT1"
+      period = 1m
+      end-period-offset = 1
+
+      dimensions = [
+        "MyTag"
+      ]
+
+      metrics = [
+        {
+          name = "Offset"
+          alias = "aws.utm.offset"
+          conversion = "max"
+        }
+      ]
+    }
+
+    ut-mono = {
+      namespace = "AWS/UT1"
+      period = 1m
+
+      dimensions = [
+        "MyTag"
+      ]
+
+      metrics = [
+        {
+          name = "Mono"
+          alias = "aws.utm.mono"
+          conversion = "max,rate"
+          monotonic = true
+        }
+      ]
+    }
+
+    queryfilter = {
+      namespace = "AWS/UTQueryFilter"
+      period = 1m
+
+      dimensions = [
+        "Key"
+      ]
+
+      metrics = [
+        {
+          name = "MyTestMetric"
+          alias = "aws.queryfilter.mytestmetric"
+          conversion = "max,rate"
+          monotonic = true
+        }
+      ]
+
+      filter = "Key,:has"
+    }
+
+  }
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessorSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessorSuite.scala
@@ -1,0 +1,991 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import akka.actor.ActorSystem
+import akka.testkit.ImplicitSender
+import akka.testkit.TestKitBase
+import com.fasterxml.jackson.core.JsonGenerator
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.newCacheEntry
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.newValue
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.normalize
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.toAWSDatapoint
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.toAWSDimensions
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.assertAWSDP
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.assertCWDP
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.makeDatapoint
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.makeFirehoseMetric
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.timestamp
+import com.netflix.atlas.core.model.Query
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.ConfigFactory
+import munit.Assertions.assertEquals
+import munit.FunSuite
+import org.mockito.Mockito.when
+import org.mockito.MockitoSugar.mock
+import org.mockito.MockitoSugar.spy
+import org.mockito.MockitoSugar.times
+import org.mockito.MockitoSugar.verify
+import org.mockito.captor.ArgCaptor
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+
+import java.time.Instant
+
+class CloudWatchMetricsProcessorSuite extends FunSuite with TestKitBase with ImplicitSender {
+
+  override implicit def system: ActorSystem = ActorSystem("Test")
+
+  var registry: Registry = null
+  var publishRouter: PublishRouter = null
+  var processor: CloudWatchMetricsProcessor = null
+  var routerCaptor = ArgCaptor[AtlasDatapoint]
+  val config = ConfigFactory.load()
+  val tagger = new NetflixTagger(config.getConfig("atlas.cloudwatch.tagger"))
+  val rules: CloudWatchRules = new CloudWatchRules(config)
+  val category = MetricCategory("AWS/DynamoDB", 60, 0, 2, None, List("MyTag"), List.empty, null)
+
+  val cwDP = newCacheEntry(
+    makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp),
+    category
+  )
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    registry = new DefaultRegistry()
+    publishRouter = mock[PublishRouter]
+    processor = new LocalCloudWatchMetricsProcessor(config, registry, rules, tagger, publishRouter)
+    routerCaptor = ArgCaptor[AtlasDatapoint]
+  }
+
+  test("processDatapoints Empty") {
+    val hash = makeFirehoseMetric(Array(1.0, 1.0, 1.0, 1), timestamp).xxHash
+    processor
+      .asInstanceOf[LocalCloudWatchMetricsProcessor]
+      .inject(hash, cwDP.toBuilder.clearData().build().toByteArray, timestamp, 3600)
+
+    assertPublished(List.empty, timestamp + (60_000 * 10))
+    assertCounters(0, publishEmpty = 1)
+  }
+
+  test("processDatapoints No namespace config") {
+    processor.processDatapoints(
+      List(
+        makeFirehoseMetric(
+          "AWS/SomeNoneExistingNS",
+          "MyMetric",
+          List.empty,
+          Array(1.0, 1.0, 1.0, 1),
+          "Bytes"
+        )
+      ),
+      timestamp
+    )
+    assertPublished(List.empty)
+    assertCounters(1, filtered = Map("namespace" -> 1))
+  }
+
+  test("processDatapoints no metric match") {
+    processor.processDatapoints(
+      List(
+        makeFirehoseMetric(
+          "AWS/UT1",
+          "SomeUnknownMetric",
+          List(Dimension.builder().name("Key").value("Value").build()),
+          Array(39.0, 1.0, 7.0, 19),
+          "Count"
+        )
+      ),
+      timestamp
+    )
+    assertPublished(List.empty)
+    assertCounters(1, filtered = Map("metric" -> 1))
+  }
+
+  test("processDatapoints missing tag") {
+    processor.processDatapoints(
+      List(
+        makeFirehoseMetric(
+          "AWS/UT1",
+          "SumRate",
+          List(Dimension.builder().name("NotTheRightTag").value("Whoops").build()),
+          Array(39.0, 1.0, 7.0, 19),
+          "Count"
+        )
+      ),
+      timestamp
+    )
+    assertPublished(List.empty)
+    assertCounters(1, filtered = Map("tags" -> 1))
+  }
+
+  test("processDatapoints Filter by query") {
+    processor.processDatapoints(
+      List(
+        makeFirehoseMetric(
+          "AWS/UTQueryFilter",
+          "MyTestMetric",
+          List(Dimension.builder().name("Key").value("Whoops").build()),
+          Array(39.0, 1.0, 7.0, 19),
+          "Count"
+        )
+      ),
+      timestamp
+    )
+    assertPublished(List.empty)
+    assertCounters(1, filtered = Map("query" -> 1))
+  }
+
+  test("processDatapoints matched dist-summary") {
+    processor.processDatapoints(
+      List(
+        makeFirehoseMetric(
+          "AWS/UT1",
+          "Dist",
+          List(Dimension.builder().name("MyTag").value("Val").build()),
+          Array(39.0, 1.0, 7.0, 19),
+          "Count",
+          timestamp - 60_000
+        )
+      ),
+      timestamp - 60_000
+    )
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.dist",
+            "statistic"    -> "count",
+            "nf.region"    -> "us-west-2",
+            "aws.tag"      -> "Val",
+            "atlas.dstype" -> "rate"
+          ),
+          timestamp,
+          0.31666666666666665
+        ),
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.dist",
+            "statistic"    -> "totalAmount",
+            "nf.region"    -> "us-west-2",
+            "aws.tag"      -> "Val",
+            "atlas.dstype" -> "rate"
+          ),
+          timestamp,
+          0.65
+        ),
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.dist",
+            "statistic"    -> "max",
+            "nf.region"    -> "us-west-2",
+            "aws.tag"      -> "Val",
+            "atlas.dstype" -> "gauge"
+          ),
+          timestamp,
+          7.0
+        )
+      )
+    )
+    assertCounters(1)
+  }
+
+  test("processDatapoints matched timer") {
+    processor.processDatapoints(
+      List(
+        makeFirehoseMetric(
+          "AWS/UT1",
+          "Timer",
+          List(
+            Dimension.builder().name("LoadBalancerName").value("some-elb").build(),
+            Dimension.builder().name("AvailabilityZone").value("a").build()
+          ),
+          Array(0.1226732730865479, 0.1226732730865479, 0.1226732730865479, 1),
+          "Timer",
+          timestamp - 60_000
+        )
+      ),
+      timestamp - 60_000
+    )
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.timer",
+            "aws.elb"      -> "some-elb",
+            "statistic"    -> "count",
+            "nf.region"    -> "us-west-2",
+            "nf.cluster"   -> "some-elb",
+            "nf.stack"     -> "elb",
+            "nf.app"       -> "some",
+            "nf.zone"      -> "a",
+            "atlas.dstype" -> "rate"
+          ),
+          timestamp,
+          0.016666666666666666
+        ),
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.timer",
+            "aws.elb"      -> "some-elb",
+            "statistic"    -> "totalTime",
+            "nf.region"    -> "us-west-2",
+            "nf.cluster"   -> "some-elb",
+            "nf.stack"     -> "elb",
+            "nf.app"       -> "some",
+            "nf.zone"      -> "a",
+            "atlas.dstype" -> "rate"
+          ),
+          timestamp,
+          0.0020445545514424647
+        ),
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.timer",
+            "aws.elb"      -> "some-elb",
+            "statistic"    -> "max",
+            "nf.region"    -> "us-west-2",
+            "nf.cluster"   -> "some-elb",
+            "nf.stack"     -> "elb",
+            "nf.app"       -> "some",
+            "nf.zone"      -> "a",
+            "atlas.dstype" -> "gauge"
+          ),
+          timestamp,
+          0.1226732730865479
+        )
+      )
+    )
+    assertCounters(1)
+  }
+
+  test("processDatapoints matched bytes") {
+    processor.processDatapoints(
+      List(
+        makeFirehoseMetric(
+          "AWS/UT1",
+          "Bytes",
+          List(
+            Dimension.builder().name("LoadBalancerName").value("some-elb").build(),
+            Dimension.builder().name("AvailabilityZone").value("a").build()
+          ),
+          Array(1.6903156e7, 8378272.0, 8524884.0, 2),
+          "Bytes",
+          timestamp - 60_000
+        )
+      ),
+      timestamp - 60_000
+    )
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.bytes",
+            "aws.elb"      -> "some-elb",
+            "nf.region"    -> "us-west-2",
+            "nf.zone"      -> "a",
+            "nf.cluster"   -> "some-elb",
+            "nf.stack"     -> "elb",
+            "nf.app"       -> "some",
+            "atlas.dstype" -> "rate"
+          ),
+          timestamp,
+          281719.26666666666
+        )
+      )
+    )
+    assertCounters(1)
+  }
+
+  test("processDatapoints matched percent") {
+    processor.processDatapoints(
+      List(
+        makeFirehoseMetric(
+          "AWS/UT1",
+          "Max",
+          List(Dimension.builder().name("MyTag").value("Val").build()),
+          Array(4.1320470343685605, 4.1320470343685605, 4.1320470343685605, 1),
+          "Percent",
+          timestamp - 60_000
+        )
+      ),
+      timestamp - 60_000
+    )
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.max",
+            "aws.tag"      -> "Val",
+            "nf.region"    -> "us-west-2",
+            "atlas.dstype" -> "gauge"
+          ),
+          timestamp,
+          4.1320470343685605
+        )
+      )
+    )
+    assertCounters(1)
+  }
+
+  test("processDatapoints config with timeout") {
+    // 15m timeout so we make sure the data sticks around that long at least and we keep posting the last
+    // value.
+    var dp = makeFirehoseMetric(
+      "AWS/UT1",
+      "TimeOut",
+      List(Dimension.builder().name("MyTag").value("Val").build()),
+      Array(1, 1, 1, 1),
+      "None",
+      timestamp - (60_000 * 10)
+    )
+    processor.processDatapoints(List(dp), timestamp - 60_000)
+
+    dp = dp.copy(datapoint = makeDatapoint(Array(2, 2, 2, 2), timestamp - (60_000 * 5)))
+    processor.processDatapoints(List(dp), timestamp)
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.timeout",
+            "aws.tag"      -> "Val",
+            "nf.region"    -> "us-west-2",
+            "atlas.dstype" -> "gauge"
+          ),
+          timestamp,
+          2
+        )
+      )
+    )
+    assertCounters(2)
+  }
+
+  test("processDatapoints config with end period offset") {
+    // 1 end period offset so we back date.
+    val dp = makeFirehoseMetric(
+      "AWS/UT1",
+      "Offset",
+      List(Dimension.builder().name("MyTag").value("Val").build()),
+      Array(1, 1, 1, 1),
+      "None",
+      timestamp
+    )
+    processor.processDatapoints(List(dp), timestamp)
+    processor.processDatapoints(
+      List(
+        dp.copy(
+          datapoint = makeDatapoint(Array(2, 2, 2, 1), timestamp + 60_000, "None")
+        )
+      ),
+      timestamp + 60_000
+    )
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.offset",
+            "aws.tag"      -> "Val",
+            "nf.region"    -> "us-west-2",
+            "atlas.dstype" -> "gauge"
+          ),
+          timestamp + 60_000,
+          1
+        )
+      ),
+      timestamp + 60_000
+    )
+    assertCounters(2)
+  }
+
+  test("processDatapoints config with monotonic") {
+    var dp = makeFirehoseMetric(
+      "AWS/UT1",
+      "Mono",
+      List(Dimension.builder().name("MyTag").value("Val").build()),
+      Array(60, 60, 60, 1),
+      "None",
+      timestamp - (60_000 * 2)
+    )
+    processor.processDatapoints(List(dp), timestamp - (60_000 * 2))
+
+    dp = dp.copy(datapoint = makeDatapoint(Array(120, 120, 120, 1), timestamp - 60_000))
+    processor.processDatapoints(List(dp), timestamp - 60_000)
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.mono",
+            "nf.region"    -> "us-west-2",
+            "aws.tag"      -> "Val",
+            "atlas.dstype" -> "rate"
+          ),
+          timestamp,
+          1.0
+        )
+      )
+    )
+    assertCounters(2)
+  }
+
+  test("processDatapoints purged namespace") {
+    val ruleSpy = spy(rules)
+    when(ruleSpy.rules)
+      .thenCallRealMethod()
+      .thenReturn(Map.empty)
+    processor =
+      new LocalCloudWatchMetricsProcessor(config, registry, ruleSpy, tagger, publishRouter)
+    processor.processDatapoints(
+      List(makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp)),
+      timestamp
+    )
+
+    assertPublished(List.empty)
+    assertCounters(1, purged = Map("namespace" -> 1))
+  }
+
+  test("processDatapoints purged metric") {
+    val ruleSpy = spy(rules)
+    when(ruleSpy.rules)
+      .thenCallRealMethod()
+      .thenReturn(Map("AWS/UT1" -> Map("SomeMetric" -> (category, List.empty))))
+    processor =
+      new LocalCloudWatchMetricsProcessor(config, registry, ruleSpy, tagger, publishRouter)
+    processor.processDatapoints(
+      List(makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp)),
+      timestamp
+    )
+
+    assertPublished(List.empty)
+    assertCounters(1, purged = Map("metric" -> 1))
+  }
+
+  test("processDatapoints purged tags") {
+    val ruleSpy = spy(rules)
+    when(ruleSpy.rules)
+      .thenCallRealMethod()
+      .thenReturn(
+        Map(
+          "AWS/UT1" -> Map(
+            "SumRate" ->
+              (category.copy(dimensions = List("SomeOtherTag")), List.empty)
+          )
+        )
+      )
+    processor =
+      new LocalCloudWatchMetricsProcessor(config, registry, ruleSpy, tagger, publishRouter)
+    processor.processDatapoints(
+      List(makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp)),
+      timestamp
+    )
+
+    assertPublished(List.empty)
+    assertCounters(1, purged = Map("tags" -> 1))
+  }
+
+  test("processDatapoints purged query") {
+    val ruleSpy = spy(rules)
+    when(ruleSpy.rules)
+      .thenCallRealMethod()
+      .thenReturn(
+        Map(
+          "AWS/UT1" -> Map(
+            "SumRate" ->
+              (category.copy(filter = Some(Query.HasKey("MyTag"))), List.empty)
+          )
+        )
+      )
+    processor =
+      new LocalCloudWatchMetricsProcessor(config, registry, ruleSpy, tagger, publishRouter)
+    processor.processDatapoints(
+      List(makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp)),
+      timestamp
+    )
+
+    assertPublished(List.empty)
+    assertCounters(1, purged = Map("query" -> 1))
+  }
+
+  test("processDatapoints future data point") {
+    processor.processDatapoints(
+      List(makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp + 60_000)),
+      timestamp
+    )
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.sumrate",
+            "nf.region"    -> "us-west-2",
+            "aws.tag"      -> "Val",
+            "atlas.dstype" -> "rate"
+          ),
+          timestamp,
+          0.65
+        )
+      )
+    )
+    assertCounters(1, publishFuture = 1)
+  }
+
+  test("normalize") {
+    assertEquals(1677706140000L, normalize(1677706164123L, 60))
+    assertEquals(1677705900000L, normalize(1677706164123L, 300))
+    assertEquals(1677704400000L, normalize(1677706164123L, 3600))
+  }
+
+  test("newCacheEntry") {
+    assertEquals(cwDP.getNamespace, "AWS/UT1")
+    assertEquals(cwDP.getMetric, "SumRate")
+    assertEquals(cwDP.getDimensionsCount, 1)
+    assertEquals(
+      cwDP.getDimensions(0),
+      CloudWatchDimension
+        .newBuilder()
+        .setName("MyTag")
+        .setValue("Val")
+        .build()
+    )
+    assertEquals(cwDP.getDataCount, 1)
+    assertCWDP(cwDP.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
+    assertEquals(cwDP.getUnit, "Count")
+  }
+
+  test("newValue") {
+    val nv = newValue(
+      timestamp,
+      Datapoint
+        .builder()
+        .sum(39.0)
+        .minimum(1.0)
+        .maximum(7.0)
+        .sampleCount(19)
+        .build()
+    )
+    assertCWDP(nv, timestamp, Array(39.0, 1.0, 7.0, 19))
+  }
+
+  test("insertDatapoint empty") {
+    val updated = processor.insertDatapoint(
+      cwDP.toBuilder.clearData().build().toByteArray,
+      makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp),
+      category,
+      0
+    )
+    assertEquals(updated.getDataCount, 1)
+    assertCWDP(updated.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
+    assertCounters(0)
+  }
+
+  test("insertDatapoint after") {
+    val updated = processor.insertDatapoint(
+      cwDP.toByteArray,
+      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp + 60_000),
+      category,
+      0
+    )
+    assertEquals(updated.getDataCount, 2)
+    assertCWDP(updated.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
+    assertCWDP(updated.getData(1), timestamp + 60_000, Array(80.0, 2.0, 6.0, 5))
+    assertCounters(0)
+  }
+
+  test("insertDatapoint before") {
+    val updated = processor.insertDatapoint(
+      cwDP.toByteArray,
+      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp - 60_000),
+      category,
+      0
+    )
+    assertEquals(updated.getDataCount, 2)
+    assertCWDP(updated.getData(0), timestamp - 60_000, Array(80.0, 2.0, 6.0, 5))
+    assertCWDP(updated.getData(1), timestamp, Array(39.0, 1.0, 7.0, 19))
+    assertCounters(0, ooo = 1)
+  }
+
+  test("insertDatapoint between") {
+    var updated = processor.insertDatapoint(
+      cwDP.toByteArray,
+      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp + (60_000 * 2)),
+      category,
+      0
+    )
+    updated = processor.insertDatapoint(
+      updated.toByteArray,
+      makeFirehoseMetric(Array(2.0, 0.0, 1.0, 2), timestamp + 60_000),
+      category,
+      0
+    )
+    assertEquals(updated.getDataCount, 3)
+    assertCWDP(updated.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
+    assertCWDP(updated.getData(1), timestamp + 60_000, Array(2.0, 0.0, 1.0, 2))
+    assertCWDP(updated.getData(2), timestamp + (60_000 * 2), Array(80.0, 2.0, 6.0, 5))
+    assertCounters(0, ooo = 1)
+  }
+
+  test("insertDatapoint same first") {
+    var updated = processor.insertDatapoint(
+      cwDP.toByteArray,
+      makeFirehoseMetric(Array(2.0, 0.0, 1.0, 2), timestamp + 60_000),
+      category,
+      0
+    )
+    updated = processor.insertDatapoint(
+      updated.toByteArray,
+      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp + (60_000 * 2)),
+      category,
+      0
+    )
+    updated = processor.insertDatapoint(
+      updated.toByteArray,
+      makeFirehoseMetric(Array(-1.0, -1.0, -1.0, -2), timestamp),
+      category,
+      0
+    )
+    assertEquals(updated.getDataCount, 3)
+    assertCWDP(updated.getData(0), timestamp, Array(-1.0, -1.0, -1.0, -2))
+    assertCWDP(updated.getData(1), timestamp + 60_000, Array(2.0, 0.0, 1.0, 2))
+    assertCWDP(updated.getData(2), timestamp + (60_000 * 2), Array(80.0, 2.0, 6.0, 5))
+    assertCounters(0, dupes = 1)
+  }
+
+  test("insertDatapoint same middle") {
+    var updated = processor.insertDatapoint(
+      cwDP.toByteArray,
+      makeFirehoseMetric(Array(2.0, 0.0, 1.0, 2), timestamp + 60_000),
+      category,
+      0
+    )
+    updated = processor.insertDatapoint(
+      updated.toByteArray,
+      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp + (60_000 * 2)),
+      category,
+      0
+    )
+    updated = processor.insertDatapoint(
+      updated.toByteArray,
+      makeFirehoseMetric(Array(-1.0, -1.0, -1.0, -2), timestamp + 60_000),
+      category,
+      0
+    )
+    assertEquals(updated.getDataCount, 3)
+    assertCWDP(updated.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
+    assertCWDP(updated.getData(1), timestamp + 60_000, Array(-1.0, -1.0, -1.0, -2))
+    assertCWDP(updated.getData(2), timestamp + (60_000 * 2), Array(80.0, 2.0, 6.0, 5))
+    assertCounters(0, dupes = 1)
+  }
+
+  test("insertDatapoint same last") {
+    var updated = processor.insertDatapoint(
+      cwDP.toByteArray,
+      makeFirehoseMetric(Array(2.0, 0.0, 1.0, 2), timestamp + 60_000),
+      category,
+      0
+    )
+    updated = processor.insertDatapoint(
+      updated.toByteArray,
+      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp + (60_000 * 2)),
+      category,
+      0
+    )
+    updated = processor.insertDatapoint(
+      updated.toByteArray,
+      makeFirehoseMetric(Array(-1.0, -1.0, -1.0, -2), timestamp + (60_000 * 2)),
+      category,
+      0
+    )
+    assertEquals(updated.getDataCount, 3)
+    assertCWDP(updated.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
+    assertCWDP(updated.getData(1), timestamp + 60_000, Array(2.0, 0.0, 1.0, 2))
+    assertCWDP(updated.getData(2), timestamp + (60_000 * 2), Array(-1.0, -1.0, -1.0, -2))
+    assertCounters(0, dupes = 1)
+  }
+
+  test("insertDatapoint after and keep previous") {
+    val updated = processor.insertDatapoint(
+      cwDP.toByteArray,
+      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp + 60_000),
+      category,
+      timestamp + 60_000
+    )
+    assertEquals(updated.getDataCount, 2)
+    assertCWDP(updated.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
+    assertCWDP(updated.getData(1), timestamp + 60_000, Array(80.0, 2.0, 6.0, 5))
+    assertCounters(0)
+  }
+
+  test("insertDatapoint data point too old") {
+    val updated = processor.insertDatapoint(
+      cwDP.toByteArray,
+      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp - (60_000 * 2)),
+      category,
+      timestamp
+    )
+    assertEquals(updated.getDataCount, 1)
+    assertCWDP(updated.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
+    assertCounters(0, droppedOld = 1)
+  }
+
+  test("insertDatapoint expire old") {
+    var updated = processor.insertDatapoint(
+      cwDP.toBuilder.clearData().build().toByteArray,
+      makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp - (60_000 * 2)),
+      category,
+      0
+    )
+    updated = processor.insertDatapoint(
+      updated.toByteArray,
+      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp),
+      category,
+      timestamp
+    )
+    assertEquals(updated.getDataCount, 1)
+    assertCWDP(updated.getData(0), timestamp, Array(80.0, 2.0, 6.0, 5))
+    assertCounters(0)
+  }
+
+  test("insertDatapoint data point too old and expire old data to empty array") {
+    var updated = processor.insertDatapoint(
+      cwDP.toBuilder.clearData().build().toByteArray,
+      makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp - (60_000 * 2)),
+      category,
+      0
+    )
+    updated = processor.insertDatapoint(
+      updated.toByteArray,
+      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp - (60_000 * 2)),
+      category,
+      timestamp
+    )
+    assertEquals(updated.getDataCount, 0)
+    assertCounters(0, droppedOld = 1)
+  }
+
+  test("toAWSDatapoint") {
+    assertAWSDP(
+      toAWSDatapoint(cwDP.getData(0), cwDP.getUnit),
+      Array(39.0, 1.0, 7.0, 19),
+      timestamp,
+      "Count"
+    )
+  }
+
+  test("toAWSDimensions") {
+    val dimensions = toAWSDimensions(cwDP)
+    assertEquals(dimensions.size, cwDP.getDimensionsCount)
+    assertEquals(dimensions(0).name(), cwDP.getDimensions(0).getName)
+    assertEquals(dimensions(0).value(), cwDP.getDimensions(0).getValue)
+  }
+
+  def assertPublished(dps: List[AtlasDatapoint], ts: Long = timestamp): Unit = {
+    processor.publish(ts)
+    verify(publishRouter, times(dps.size)).publish(routerCaptor)
+    assertEquals(routerCaptor.values.size, dps.size)
+
+    dps.foreach { dp =>
+      val metric = routerCaptor.values.filter(_.tags.equals(dp.tags)).headOption match {
+        case Some(d) => d
+        case None =>
+          throw new AssertionError(s"Data point not found: ${dp} in ${routerCaptor.values}")
+      }
+      assertEquals(metric.value, dp.value, s"Wrong value for ${dp.tags}")
+      assertEquals(metric.timestamp, dp.timestamp, s"Wrong value for timestamp ${dp.tags}")
+    }
+  }
+
+  def assertCounters(
+    received: Long,
+    filtered: Map[String, Long] = Map.empty,
+    dupes: Long = 0,
+    droppedOld: Long = 0,
+    ooo: Long = 0,
+    purged: Map[String, Long] = Map.empty,
+    publishEmpty: Long = 0,
+    publishFuture: Long = 0
+  ): Unit = {
+    assertEquals(registry.counter("atlas.cloudwatch.datapoints.received").count(), received)
+    List("namespace", "metric", "tags", "query").foreach { reason =>
+      assertEquals(
+        registry.counter("atlas.cloudwatch.datapoints.filtered", "reason", reason).count(),
+        filtered.getOrElse(reason, 0L),
+        s"Count differs for ${reason}"
+      )
+    }
+
+    assertEquals(
+      registry.counter("atlas.cloudwatch.datapoints.dupes", "namespace", "AWS/DynamoDB").count(),
+      dupes
+    )
+    assertEquals(
+      registry
+        .counter(
+          "atlas.cloudwatch.datapoints.dropped",
+          "reason",
+          "tooOld",
+          "namespace",
+          "AWS/DynamoDB"
+        )
+        .count(),
+      droppedOld
+    )
+    assertEquals(
+      registry.counter("atlas.cloudwatch.datapoints.ooo", "namespace", "AWS/DynamoDB").count(),
+      ooo
+    )
+
+    List("namespace", "metric", "tags", "query").foreach { reason =>
+      assertEquals(
+        registry.counter("atlas.cloudwatch.datapoints.purged", "reason", reason).count(),
+        purged.getOrElse(reason, 0L),
+        s"Count differs for ${reason}"
+      )
+    }
+    assertEquals(
+      registry.counter("atlas.cloudwatch.publish.empty", "namespace", "AWS/UT1").count(),
+      publishEmpty
+    )
+    assertEquals(
+      registry.counter("atlas.cloudwatch.publish.future", "namespace", "AWS/UT1").count(),
+      publishFuture
+    )
+  }
+
+}
+
+object CloudWatchMetricsProcessorSuite {
+
+  val timestamp = 1672531200000L
+
+  def assertCWDP(cwdp: CloudWatchValue, timestamp: Long, values: Array[Double]): Unit = {
+    assertEquals(cwdp.getTimestamp, timestamp)
+    assertEquals(cwdp.getSum, values(0))
+    assertEquals(cwdp.getMin, values(1))
+    assertEquals(cwdp.getMax, values(2))
+    assertEquals(cwdp.getCount, values(3))
+  }
+
+  def assertAWSDP(dp: Datapoint, values: Array[Double], ts: Long, unit: String): Unit = {
+    assertEquals(dp.sum().asInstanceOf[Double], values(0))
+    assertEquals(dp.minimum().asInstanceOf[Double], values(1))
+    assertEquals(dp.maximum().asInstanceOf[Double], values(2))
+    assertEquals(dp.sampleCount().asInstanceOf[Double], values(3))
+    assertEquals(dp.timestamp().toEpochMilli, ts)
+    assertEquals(dp.unit().toString, unit)
+  }
+
+  def makeFirehoseMetric(values: Array[Double], ts: Long): FirehoseMetric = {
+    makeFirehoseMetric(
+      "AWS/UT1",
+      "SumRate",
+      List(Dimension.builder().name("MyTag").value("Val").build()),
+      values,
+      "Count",
+      ts
+    )
+  }
+
+  def makeFirehoseMetric(
+    ns: String,
+    metric: String,
+    dimensions: List[Dimension],
+    values: Array[Double],
+    unit: String,
+    ts: Long = timestamp
+  ): FirehoseMetric = {
+    FirehoseMetric(
+      "unitTest",
+      ns,
+      metric,
+      dimensions,
+      Datapoint
+        .builder()
+        .timestamp(Instant.ofEpochMilli(ts))
+        .sum(values(0))
+        .minimum(values(1))
+        .maximum(values(2))
+        .sampleCount(values(3))
+        .unit(unit)
+        .build()
+    )
+  }
+
+  def makeDatapoint(
+    values: Array[Double],
+    ts: Long = timestamp,
+    unit: String = "Rate"
+  ): Datapoint = {
+    Datapoint
+      .builder()
+      .timestamp(Instant.ofEpochMilli(ts))
+      .sum(values(0))
+      .minimum(values(1))
+      .maximum(values(2))
+      .sampleCount(values(3))
+      .unit(unit)
+      .build()
+  }
+
+  case class CWDP(
+    metric: String,
+    values: Array[Double],
+    dimensions: Int = 3,
+    wTimestamp: Boolean = true
+  ) {
+
+    def encode(json: JsonGenerator): Unit = {
+      json.writeStartObject()
+      json.writeStringField("metric_stream_name", "Stream1")
+      for (i <- 0 until Math.min(dimensions, 2)) {
+        if (i == 0) json.writeStringField("account_id", "1234")
+        if (i == 1) json.writeStringField("region", "us-west-2")
+      }
+      json.writeStringField("namespace", "UT/Test")
+      if (metric != null) {
+        json.writeStringField("metric_name", metric)
+      }
+      json.writeStringField("unit", "None")
+      if (wTimestamp) {
+        json.writeNumberField("timestamp", timestamp)
+      }
+      if (dimensions >= 3) {
+        json.writeObjectFieldStart("dimensions")
+        json.writeStringField("AwsTag", "AwsVal")
+        json.writeEndObject()
+      }
+      if (values != null) {
+        json.writeObjectFieldStart("value")
+        for (i <- 0 until values.length) {
+          if (i == 0) json.writeNumberField("sum", values(i))
+          if (i == 1) json.writeNumberField("min", values(i))
+          if (i == 2) json.writeNumberField("max", values(i))
+          if (i == 3) json.writeNumberField("count", values(i))
+          if (i > 3) json.writeNumberField(s"val${i}", values(i))
+        }
+        json.writeEndObject()
+      }
+      json.writeEndObject()
+    }
+
+  }
+
+}


### PR DESCRIPTION
for writing and reading from a backing store implementation. The processor is responsible for matching incoming fire hose data to rules and merging new values with existing values in the cache. It is also responsible for regularly scraping the cache and publishing the final data. Included is a simple local hash map based store for unit testing.