### PR TITLE
Atlas Cloud Watch: Add the Firehose endpoint that will receive messag…

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/webapi/CloudWatchFirehoseEndpoint.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/webapi/CloudWatchFirehoseEndpoint.scala
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import com.fasterxml.jackson.core.JsonParser
+import com.netflix.atlas.akka.CustomDirectives.customJson
+import com.netflix.atlas.akka.CustomDirectives.endpointPath
+import com.netflix.atlas.akka.CustomDirectives.parseEntity
+import com.netflix.atlas.akka.WebApi
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor
+import com.netflix.atlas.cloudwatch.FirehoseMetric
+import com.netflix.atlas.json.Json
+import com.netflix.atlas.json.JsonParserHelper.foreachField
+import com.netflix.atlas.json.JsonParserHelper.foreachItem
+import com.netflix.atlas.webapi.CloudWatchFirehoseEndpoint.decodeCommonTags
+import com.netflix.atlas.webapi.CloudWatchFirehoseEndpoint.decodeMetricJson
+import com.netflix.spectator.api.Registry
+import com.typesafe.scalalogging.StrictLogging
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+
+import java.time.Instant
+import java.util.Base64
+import scala.collection.mutable
+import scala.util.Using
+
+class CloudWatchFirehoseEndpoint(
+  registry: Registry,
+  processor: CloudWatchMetricsProcessor
+)(implicit val system: ActorSystem)
+    extends WebApi
+    with StrictLogging {
+
+  private val dataReceived = registry.counter("atlas.cloudwatch.firehose.parse.dps")
+  private val unknownField = registry.counter("atlas.cloudwatch.firehose.parse.unknown")
+  private val parseException = registry.createId("atlas.cloudwatch.firehose.parse.exception")
+
+  override def routes: Route = {
+    post {
+      endpointPath("api" / "v1" / "firehose") {
+        handleReq
+      } ~
+      complete(StatusCodes.NotFound)
+    } ~
+    put { // just to be safe
+      endpointPath("api" / "v1" / "firehose") {
+        handleReq
+      } ~
+      complete(StatusCodes.NotFound)
+    }
+  }
+
+  private def handleReq: Route = {
+    extractRequestContext { ctx =>
+      val commonTags = decodeCommonTags(ctx.request)
+      parseEntity(customJson(p => parseFirehoseMessage(p, commonTags))) { response =>
+        if (response.exception.isDefined) {
+          complete(StatusCodes.BadRequest, response.getEntity)
+        } else {
+          complete(StatusCodes.OK, response.getEntity)
+        }
+      }
+    }
+  }
+
+  private def parseFirehoseMessage(parser: JsonParser, commonTags: List[Dimension]): RequestId = {
+    var requestId: String = null
+    var timestamp: Long = 0
+    val receivedTimestamp = System.currentTimeMillis()
+    try {
+      foreachField(parser) {
+        case "requestId" => requestId = parser.nextTextValue()
+        case "timestamp" => timestamp = parser.nextLongValue(0L)
+        case "records" =>
+          foreachItem(parser) {
+            foreachField(parser) {
+              case "data" =>
+                try {
+                  // catch the exception here in the case one data set is errant but the others are alright.
+                  // At least we should get _some_ data that way.
+                  Using.resource(
+                    Json.newJsonParser(Base64.getDecoder.decode(parser.nextTextValue()))
+                  ) { p =>
+                    val datapoints = decodeMetricJson(p, commonTags)
+                    processor.processDatapoints(datapoints, receivedTimestamp)
+                    dataReceived.increment(datapoints.size)
+                  }
+                } catch {
+                  case ex: Exception =>
+                    logger.warn("Unexpected data parse exception", ex)
+                    incrementException(ex, true)
+                }
+              case unknown => // Ignore unknown fields
+                logger.debug("Skipping unknown firehose record field: {}", unknown)
+                parser.nextToken()
+                parser.skipChildren()
+                unknownField.increment()
+            }
+          }
+        case unknown => // Ignore unknown fields
+          logger.debug("Skipping unknown firehose field: {}", unknown)
+          parser.nextToken()
+          parser.skipChildren()
+          unknownField.increment()
+      }
+      RequestId(requestId, timestamp)
+    } catch {
+      case ex: Exception =>
+        logger.error("Failed to parse request", ex)
+        incrementException(ex)
+        RequestId(requestId, timestamp, Some(ex))
+    }
+  }
+
+  private def incrementException(ex: Exception, data: Boolean = false): Unit = {
+    val id = if (data) "data" else "outer"
+    registry.counter(parseException.withTags("id", id, "ex", ex.getClass.getSimpleName)).increment()
+  }
+}
+
+object CloudWatchFirehoseEndpoint extends StrictLogging {
+
+  private[webapi] def decodeMetricJson(
+    parser: JsonParser,
+    commonTags: List[Dimension]
+  ): List[FirehoseMetric] = {
+    // JSON stream format, i.e. new line separated list of objects.
+    var t = parser.nextToken()
+    val results = List.newBuilder[FirehoseMetric]
+
+    var dp = Datapoint.builder()
+    var metricStreamName: String = null
+    var accountId: String = null
+    var region: String = null
+    var namespace: String = null
+    var metricName: String = null
+    var dimensions = List.newBuilder[Dimension]
+    while (t != null) {
+      foreachField(parser) {
+        case "metric_stream_name" => metricStreamName = parser.nextTextValue()
+        case "account_id"         => accountId = parser.nextTextValue
+        case "region"             => region = parser.nextTextValue
+        case "namespace"          => namespace = parser.nextTextValue
+        case "metric_name"        => metricName = parser.nextTextValue
+        case "unit"               => dp.unit(parser.nextTextValue())
+        case "dimensions"         => decodeDimensions(parser, dimensions)
+        case "timestamp" =>
+          dp.timestamp(Instant.ofEpochMilli(parser.nextLongValue(0L)))
+        case "value" => decodeValue(parser, dp)
+        case unknown => // Ignore unknown fields
+          logger.debug("Skipping unknown firehose metric field: {}", unknown)
+          parser.nextToken()
+          parser.skipChildren()
+      }
+
+      if (accountId != null) {
+        dimensions += Dimension
+          .builder()
+          .name("nf.account")
+          .value(accountId)
+          .build()
+      }
+      if (region != null) {
+        dimensions += Dimension
+          .builder()
+          .name("nf.region")
+          .value(region)
+          .build()
+      }
+      dimensions ++= commonTags
+
+      results += FirehoseMetric(
+        metricStreamName,
+        namespace,
+        metricName,
+        dimensions.result(),
+        dp.build()
+      )
+
+      // reset
+      dp = Datapoint.builder()
+      metricStreamName = null
+      accountId = null
+      region = null
+      namespace = null
+      metricName = null
+      dimensions = List.newBuilder[Dimension]
+
+      // advance
+      t = parser.nextToken()
+    }
+    results.result()
+  }
+
+  private[webapi] def decodeDimensions(
+    parser: JsonParser,
+    dimensions: mutable.Builder[Dimension, List[Dimension]]
+  ): Unit = {
+    foreachField(parser) {
+      case key =>
+        val value = parser.nextTextValue()
+        if (value != null) {
+          dimensions += Dimension
+            .builder()
+            .name(key)
+            .value(value)
+            .build()
+        }
+    }
+  }
+
+  private[webapi] def decodeValue(parser: JsonParser, dp: Datapoint.Builder): Unit = {
+    foreachField(parser) {
+      case "sum" =>
+        parser.nextToken()
+        dp.sum(parser.getDoubleValue)
+      case "count" =>
+        parser.nextToken()
+        dp.sampleCount(parser.getDoubleValue)
+      case "max" =>
+        parser.nextToken()
+        dp.maximum(parser.getDoubleValue)
+      case "min" =>
+        parser.nextToken()
+        dp.minimum(parser.getDoubleValue)
+      case unknown => // Ignore unknown fields
+        // TODO - Extend this if we need to record any of the other fields offered by AWS.
+        // Note that each field is an additional financial cost though.
+        logger.debug("Skipping unknown value field: {}", unknown)
+        parser.nextToken()
+        parser.skipChildren()
+    }
+  }
+
+  private[webapi] def decodeCommonTags(request: HttpRequest): List[Dimension] = {
+    val hdr = request.getHeader("X-Amz-Firehose-Common-Attributes")
+    if (hdr.isPresent) {
+      Using.resource(Json.newJsonParser(hdr.get().value())) { parser =>
+        val dimensions = List.newBuilder[Dimension]
+        foreachField(parser) {
+          case "commonAttributes" => decodeDimensions(parser, dimensions)
+        }
+        dimensions.result()
+      }
+    } else {
+      List.empty
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/webapi/CloudWatchFirehoseEndpoint.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/webapi/CloudWatchFirehoseEndpoint.scala
@@ -54,13 +54,7 @@ class CloudWatchFirehoseEndpoint(
   private val parseException = registry.createId("atlas.cloudwatch.firehose.parse.exception")
 
   override def routes: Route = {
-    post {
-      endpointPath("api" / "v1" / "firehose") {
-        handleReq
-      } ~
-      complete(StatusCodes.NotFound)
-    } ~
-    put { // just to be safe
+    (post | put) {
       endpointPath("api" / "v1" / "firehose") {
         handleReq
       } ~

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/webapi/RequestId.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/webapi/RequestId.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import akka.http.scaladsl.model.ContentTypes
+import akka.http.scaladsl.model.HttpEntity
+import com.netflix.atlas.json.Json
+import com.netflix.atlas.webapi.RequestId.getByteArrayOutputStream
+
+import java.io.ByteArrayOutputStream
+import scala.util.Using
+
+/**
+  * This is the class we have to use to respond to the Firehose publisher. The request ID and timestamp must match
+  * those of the message received in order for Firehose to consider the data successfully processed.
+  *
+  * @param requestId
+  *     The request ID given by AWS Firehose.
+  * @param timestamp
+  *     The timestamp in unix epoch milliseconds given by AWS Firehose.
+  * @param exception
+  *     An optional exception to encode if processing failed. This will be stored in Cloud Watch logs.
+  */
+case class RequestId(requestId: String, timestamp: Long, exception: Option[Exception] = None) {
+
+  def getEntity: HttpEntity.Strict = {
+    val stream = getByteArrayOutputStream
+    Using.resource(Json.newJsonGenerator(stream)) { json =>
+      json.writeStartObject()
+      json.writeStringField("requestId", requestId)
+      json.writeNumberField("timestamp", timestamp)
+      exception.map { ex =>
+        json.writeStringField("errorMessage", ex.getMessage)
+      }
+      json.writeEndObject()
+    }
+    HttpEntity(ContentTypes.`application/json`, stream.toByteArray)
+  }
+
+}
+
+object RequestId {
+
+  private val byteArrayStreams = new ThreadLocal[ByteArrayOutputStream]
+
+  private[atlas] def getByteArrayOutputStream: ByteArrayOutputStream = {
+    var baos = byteArrayStreams.get()
+    if (baos == null) {
+      baos = new ByteArrayOutputStream()
+      byteArrayStreams.set(baos)
+    } else {
+      baos.reset()
+    }
+    baos
+  }
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/webapi/CloudWatchFirehoseEndpointSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/webapi/CloudWatchFirehoseEndpointSuite.scala
@@ -1,0 +1,494 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.webapi
+
+import akka.http.scaladsl.model.ContentTypes
+import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.HttpMethods.POST
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.RawHeader
+import com.fasterxml.jackson.core.io.JsonEOFException
+import com.netflix.atlas.akka.testkit.MUnitRouteSuite
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.CWDP
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.timestamp
+import com.netflix.atlas.cloudwatch.FirehoseMetric
+import com.netflix.atlas.core.util.FastGzipOutputStream
+import com.netflix.atlas.json.Json
+import com.netflix.atlas.webapi.CloudWatchFirehoseEndpoint.decodeMetricJson
+import com.netflix.atlas.webapi.CloudWatchFirehoseEndpointSuite.generateRequest
+import com.netflix.atlas.webapi.CloudWatchFirehoseEndpointSuite.makeFirehosePayload
+import com.netflix.atlas.webapi.CloudWatchFirehoseEndpointSuite.makeJson
+import com.netflix.atlas.webapi.CloudWatchFirehoseEndpointSuite.parsedDatapointsA
+import com.netflix.atlas.webapi.CloudWatchFirehoseEndpointSuite.parsedDatapointsB
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Registry
+import junit.framework.TestCase.assertNull
+import org.mockito.ArgumentMatchersSugar.anyLong
+import org.mockito.MockitoSugar.mock
+import org.mockito.MockitoSugar.never
+import org.mockito.MockitoSugar.times
+import org.mockito.MockitoSugar.verify
+import org.mockito.captor.ArgCaptor
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+
+import java.io.ByteArrayOutputStream
+import java.time.Instant
+import java.util.Base64
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+import scala.util.Using
+
+class CloudWatchFirehoseEndpointSuite extends MUnitRouteSuite {
+
+  var registry: Registry = null
+  var processor: CloudWatchMetricsProcessor = null
+  var processorCaptor = ArgCaptor[List[FirehoseMetric]]
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    registry = new DefaultRegistry()
+    processor = mock[CloudWatchMetricsProcessor]
+    processorCaptor = ArgCaptor[List[FirehoseMetric]]
+  }
+
+  test("firehose success") {
+    val req = generateRequest("/api/v1/firehose")
+    val handler = new CloudWatchFirehoseEndpoint(registry, processor)
+    req ~> handler.routes ~> check {
+      assert(StatusCodes.OK == status)
+      assertParse()
+      assertCounters(3)
+      assertResponse(response)
+    }
+  }
+
+  test("firehose GZIP success") {
+    val req = generateRequest("/api/v1/firehose", gzip = true)
+    val handler = new CloudWatchFirehoseEndpoint(registry, processor)
+    req ~> handler.routes ~> check {
+      assert(StatusCodes.OK == status)
+      assertParse()
+      assertCounters(3)
+      assertResponse(response)
+    }
+  }
+
+  test("firehose success w attributes") {
+    val req = generateRequest("/api/v1/firehose", attributes = Map("MyKey" -> "MyVal"))
+    val handler = new CloudWatchFirehoseEndpoint(registry, processor)
+    req ~> handler.routes ~> check {
+      assert(StatusCodes.OK == status)
+      assertParse(attributes = Map("MyKey" -> "MyVal"))
+      assertCounters(3)
+      assertResponse(response)
+    }
+  }
+
+  test("firehose missing id/value") {
+    val req = generateRequest("/api/v1/firehose", makeFirehosePayload(missingHeader = true))
+    val handler = new CloudWatchFirehoseEndpoint(registry, processor)
+    req ~> handler.routes ~> check {
+      assert(StatusCodes.OK == status)
+      assertParse()
+      assertCounters(3)
+      assertResponse(response, missing = true)
+    }
+  }
+
+  test("firehose extra fields") {
+    val req = generateRequest("/api/v1/firehose", makeFirehosePayload(extra = true))
+    val handler = new CloudWatchFirehoseEndpoint(registry, processor)
+    req ~> handler.routes ~> check {
+      assert(StatusCodes.OK == status)
+      assertParse()
+      assertCounters(3, unknown = 1)
+      assertResponse(response)
+    }
+  }
+
+  test("firehose unexpected data field") {
+    val req = generateRequest("/api/v1/firehose", makeFirehosePayload(badData = true))
+    val handler = new CloudWatchFirehoseEndpoint(registry, processor)
+    req ~> handler.routes ~> check {
+      assert(StatusCodes.OK == status)
+      assertParse(badData = true)
+      assertCounters(2, dataParse = 1)
+      assertResponse(response)
+    }
+  }
+
+  test("firehose malformed json") {
+    val req = generateRequest("/api/v1/firehose", makeFirehosePayload(malformed = true))
+    val handler = new CloudWatchFirehoseEndpoint(registry, processor)
+    req ~> handler.routes ~> check {
+      assertEquals(status, StatusCodes.BadRequest)
+      verify(processor, never).processDatapoints(processorCaptor, anyLong)
+      assertCounters(outerParse = 1)
+      assertResponse(response, withException = true)
+    }
+  }
+
+  test("decode ok") {
+    val json = makeJson(
+      CWDP("MetricA", Array[Double](42.0, 10.0, 32.0, 2.0)),
+      CWDP("MetricB", Array[Double](1.0, 1.0, 1.0, 1.0), 2)
+    )
+    Using.resource(Json.newJsonParser(json)) { parser =>
+      val obtained = decodeMetricJson(parser, List.empty)
+      assertEquals(obtained, parsedDatapointsA)
+    }
+  }
+
+  test("decode malformed") {
+    val json = makeJson(
+      CWDP("MetricA", Array[Double](42.0, 10.0, 32.0, 2.0)),
+      CWDP("MetricB", Array[Double](1.0, 1.0, 1.0, 1.0), 2)
+    )
+    intercept[JsonEOFException] {
+      Using.resource(Json.newJsonParser(json.substring(0, 256))) { parser =>
+        decodeMetricJson(parser, List.empty)
+      }
+    }
+  }
+
+  test("decode extra top-level field") {
+    var json = makeJson(CWDP("MetricA", Array[Double](42.0, 10.0, 32.0, 2.0)))
+    json = json.substring(0, json.length - 2) + ",\"ignored\":\"field\"}"
+
+    Using.resource(Json.newJsonParser(json)) { parser =>
+      val obtained = decodeMetricJson(parser, List.empty)
+      assertEquals(obtained, List(parsedDatapointsA(0)))
+    }
+  }
+
+  test("decode missing metric") {
+    val json = makeJson(CWDP(null, Array[Double](42.0, 10.0, 32.0, 2.0)))
+    Using.resource(Json.newJsonParser(json)) { parser =>
+      val obtained = decodeMetricJson(parser, List.empty)
+      assertEquals(
+        obtained,
+        List(
+          parsedDatapointsA(0).copy(
+            metricName = null
+          )
+        )
+      )
+    }
+  }
+
+  test("decode missing timestamp") {
+    import scala.compat.java8.FunctionConverters._
+    val json = makeJson(CWDP("MetricA", Array[Double](42.0, 10.0, 32.0, 2.0), wTimestamp = false))
+    Using.resource(Json.newJsonParser(json)) { parser =>
+      val obtained = decodeMetricJson(parser, List.empty)
+      assertEquals(
+        obtained,
+        List(
+          parsedDatapointsA(0).copy(
+            datapoint = parsedDatapointsA(0).datapoint.copy(
+              asJavaConsumer[Datapoint.Builder](_.timestamp(null))
+            )
+          )
+        )
+      )
+    }
+  }
+
+  test("decode extra value fields") {
+    val json = makeJson(CWDP("MetricA", Array[Double](42.0, 10.0, 32.0, 2.0, 1.0)))
+    Using.resource(Json.newJsonParser(json)) { parser =>
+      val obtained = decodeMetricJson(parser, List.empty)
+      assertEquals(obtained, List(parsedDatapointsA(0)))
+    }
+  }
+
+  test("decode missing values") {
+    import scala.compat.java8.FunctionConverters._
+    val json = makeJson(CWDP("MetricA", Array[Double](42.0, 10.0, 32.0)))
+    Using.resource(Json.newJsonParser(json)) { parser =>
+      val obtained = decodeMetricJson(parser, List.empty)
+      assertEquals(
+        obtained,
+        List(
+          parsedDatapointsA(0).copy(
+            datapoint = parsedDatapointsA(0).datapoint.copy(
+              asJavaConsumer[Datapoint.Builder](_.sampleCount(null))
+            )
+          )
+        )
+      )
+    }
+  }
+
+  test("decode w common tags") {
+    val json = makeJson(CWDP("MetricA", Array[Double](42.0, 10.0, 32.0, 2.0)))
+    Using.resource(Json.newJsonParser(json)) { parser =>
+      val obtained =
+        decodeMetricJson(parser, List(Dimension.builder().name("Key").value("Value").build()))
+      assertEquals(
+        obtained,
+        List(
+          parsedDatapointsA(0).copy(
+            dimensions = parsedDatapointsA(0).dimensions :+
+              Dimension.builder().name("Key").value("Value").build()
+          )
+        )
+      )
+    }
+  }
+
+  def assertCounters(
+    parsed: Long = 0,
+    unknown: Long = 0,
+    dataParse: Long = 0,
+    outerParse: Long = 0
+  ): Unit = {
+    assertEquals(registry.counter("atlas.cloudwatch.firehose.parse.dps").count(), parsed)
+    assertEquals(registry.counter("atlas.cloudwatch.firehose.parse.unknown").count(), unknown)
+    assertEquals(
+      registry
+        .counter(
+          "atlas.cloudwatch.firehose.parse.exception",
+          "id",
+          "data",
+          "ex",
+          "JsonParseException"
+        )
+        .count(),
+      dataParse
+    )
+    assertEquals(
+      registry
+        .counter(
+          "atlas.cloudwatch.firehose.parse.exception",
+          "id",
+          "outer",
+          "ex",
+          "CharConversionException"
+        )
+        .count(),
+      outerParse
+    )
+  }
+
+  def assertParse(badData: Boolean = false, attributes: Map[String, String] = Map.empty): Unit = {
+    val expectedCount = if (badData) 1 else 2
+    verify(processor, times(expectedCount)).processDatapoints(processorCaptor, anyLong)
+
+    var expected = if (!attributes.isEmpty) {
+      parsedDatapointsA.map { dp =>
+        dp.copy(dimensions = dp.dimensions ++ attributes.map { t =>
+          Dimension.builder().name(t._1).value(t._2).build()
+        })
+      }
+    } else parsedDatapointsA
+
+    assertEquals(processorCaptor.values(0), expected)
+    if (!badData) {
+      expected = if (!attributes.isEmpty) {
+        parsedDatapointsB.map { dp =>
+          dp.copy(dimensions = dp.dimensions ++ attributes.map { t =>
+            Dimension.builder().name(t._1).value(t._2).build()
+          })
+        }
+      } else parsedDatapointsB
+      assertEquals(processorCaptor.values(1), expected)
+    }
+  }
+
+  def assertResponse(
+    response: HttpResponse,
+    missing: Boolean = false,
+    withException: Boolean = false
+  ): Unit = {
+    val bs = Await.result(response.entity.dataBytes.runReduce(_ ++ _), 1.seconds)
+    val decoded = Json.decode[RequestId](bs.toArray)
+    if (missing || withException) {
+      assertNull(decoded.requestId)
+      assertEquals(decoded.timestamp, 0L)
+    } else {
+      assertEquals(decoded.requestId, "0001")
+      assertEquals(decoded.timestamp, timestamp + 35_000)
+    }
+    if (withException) {
+      val string = new String(bs.toArray)
+      assert(string.contains("Invalid"))
+    }
+  }
+}
+
+object CloudWatchFirehoseEndpointSuite {
+
+  def makeJson(vals: CWDP*): String = {
+    val stream = new ByteArrayOutputStream()
+    Using.resource(Json.newJsonGenerator(stream)) { json =>
+      vals.foreach { dp =>
+        dp.encode(json)
+        json.writeRaw("\n")
+      }
+    }
+    new String(stream.toByteArray)
+  }
+
+  var parsedDatapointsA = List(
+    FirehoseMetric(
+      "Stream1",
+      "UT/Test",
+      "MetricA",
+      List(
+        Dimension.builder().name("AwsTag").value("AwsVal").build(),
+        Dimension.builder().name("nf.account").value("1234").build(),
+        Dimension.builder().name("nf.region").value("us-west-2").build()
+      ),
+      Datapoint
+        .builder()
+        .timestamp(Instant.ofEpochMilli(timestamp))
+        .sum(42.0)
+        .minimum(10.0)
+        .maximum(32.0)
+        .sampleCount(2.0)
+        .unit("None")
+        .build()
+    ),
+    FirehoseMetric(
+      "Stream1",
+      "UT/Test",
+      "MetricB",
+      List(
+        Dimension.builder().name("nf.account").value("1234").build(),
+        Dimension.builder().name("nf.region").value("us-west-2").build()
+      ),
+      Datapoint
+        .builder()
+        .timestamp(Instant.ofEpochMilli(timestamp))
+        .sum(1.0)
+        .minimum(1.0)
+        .maximum(1.0)
+        .sampleCount(1.0)
+        .unit("None")
+        .build()
+    )
+  )
+
+  var parsedDatapointsB = List(
+    FirehoseMetric(
+      "Stream1",
+      "UT/Test",
+      "MetricC",
+      List(
+        Dimension.builder().name("AwsTag").value("AwsVal").build(),
+        Dimension.builder().name("nf.account").value("1234").build(),
+        Dimension.builder().name("nf.region").value("us-west-2").build()
+      ),
+      Datapoint
+        .builder()
+        .timestamp(Instant.ofEpochMilli(timestamp))
+        .sum(2.0)
+        .minimum(2.0)
+        .maximum(2.0)
+        .sampleCount(1.0)
+        .unit("None")
+        .build()
+    )
+  )
+
+  def makeFirehosePayload(
+    missingHeader: Boolean = false,
+    empty: Boolean = false,
+    extra: Boolean = false,
+    badData: Boolean = false,
+    malformed: Boolean = false
+  ): Array[Byte] = {
+    val stream = new ByteArrayOutputStream()
+    Using.resource(Json.newJsonGenerator(stream)) { json =>
+      json.writeStartObject()
+      if (!missingHeader) {
+        json.writeStringField("requestId", "0001")
+        json.writeNumberField("timestamp", timestamp + 35_000)
+      }
+      json.writeArrayFieldStart("records")
+
+      if (!empty) {
+        json.writeStartObject()
+        var data = makeJson(
+          CWDP("MetricA", Array[Double](42.0, 10.0, 32.0, 2.0)),
+          CWDP("MetricB", Array[Double](1.0, 1.0, 1.0, 1.0), 2)
+        )
+        json.writeStringField("data", Base64.getEncoder.encodeToString(data.getBytes()))
+        json.writeEndObject()
+
+        json.writeStartObject()
+        if (badData) {
+          data = "definitely not json"
+        } else {
+          data = makeJson(
+            CWDP("MetricC", Array[Double](2.0, 2.0, 2.0, 1.0))
+          )
+        }
+        json.writeStringField("data", Base64.getEncoder.encodeToString(data.getBytes()))
+        json.writeEndObject()
+      }
+
+      json.writeEndArray()
+
+      if (extra) json.writeStringField("Ignore", "me")
+      json.writeEndObject()
+    }
+    val ba = stream.toByteArray
+    if (malformed) {
+      ba(0) = 0
+      ba(1) = 0
+      ba(2) = 0
+      ba(3) = 0
+    }
+    ba
+  }
+
+  def generateRequest(
+    uri: String,
+    payload: Array[Byte] = makeFirehosePayload(),
+    gzip: Boolean = false,
+    attributes: Map[String, String] = null
+  ): HttpRequest = {
+
+    val bytes = if (gzip) {
+      val baos = new ByteArrayOutputStream()
+      val stream = new FastGzipOutputStream(baos)
+      stream.write(payload)
+      stream.close()
+      baos.toByteArray
+    } else payload
+
+    HttpRequest(
+      POST,
+      uri,
+      if (attributes != null) {
+        Seq(
+          RawHeader(
+            "X-Amz-Firehose-Common-Attributes",
+            Json.encode(Map("commonAttributes" -> attributes))
+          )
+        )
+      } else {
+        Seq.empty
+      },
+      entity = HttpEntity(ContentTypes.`application/json`, bytes)
+    )
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,7 @@ lazy val `atlas-cloudwatch` = project
     Dependencies.openHFT,
     Dependencies.protobuf,
 
+    Dependencies.atlasAkkaTestkit % "test",
     Dependencies.atlasWebApi % "test",
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaTestkit % "test",


### PR DESCRIPTION
…es from

Firehose, parse and process them. Includes the RequestId class that stores the timestamp and request ID that firehose requires in the response to accept the data as successfully received.