### PR TITLE
Atlas Cloud Watch: Remove Typesafe config bean from the local spring …

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/spring/CloudWatchConfiguration.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/spring/CloudWatchConfiguration.scala
@@ -45,10 +45,6 @@ import java.util.Optional
 @Configuration
 class CloudWatchConfiguration extends StrictLogging {
 
-  // REPLACE With the dyn config jar include
-  @Bean
-  def getConfig: Config = ConfigFactory.load()
-
   @Bean
   def cloudWatchRules(config: Config): CloudWatchRules = new CloudWatchRules(config)
 


### PR DESCRIPTION
…config

class since it's instantiated elsewhere.