### PR TITLE
order is not important for encoding

### DIFF
--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AkkaPublisher.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AkkaPublisher.scala
@@ -84,7 +84,7 @@ class AkkaPublisher(registry: Registry, config: AggrConfig, implicit val system:
 
   private def createClient(name: String): StreamOps.SourceQueue[RequestTuple] = {
     val flow = Flow[RequestTuple]
-      .mapAsync(encodingParallelism) { t =>
+      .mapAsyncUnordered(encodingParallelism) { t =>
         Future(t.mkRequest() -> t)(ec)
       }
       .via(Http().superPool[RequestTuple]())


### PR DESCRIPTION
Update the encoding operation to use mapAsyncUnordered. The order is not important for this use-case and adds some overhead.