### PR TITLE
Atlas Cloud Watch: Add a unit test validating separate min/max rules

### DIFF
--- a/atlas-cloudwatch/src/test/resources/test-rules.conf
+++ b/atlas-cloudwatch/src/test/resources/test-rules.conf
@@ -30,6 +30,16 @@ atlas {
           name = "Max"
           alias = "aws.utm.max"
           conversion = "max"
+        },
+        {
+          name = "TwoRuleMatch"
+          alias = "aws.utm.2rulematch"
+          conversion = "min"
+        },
+        {
+          name = "TwoRuleMatch"
+          alias = "aws.utm.2rulematch"
+          conversion = "max"
         }
       ]
     }


### PR DESCRIPTION
via streaming.