### PR TITLE
Atlas CloudWatch: Normalize incoming timestamps to the minute instead …

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
@@ -256,7 +256,7 @@ abstract class CloudWatchMetricsProcessor(
 
     val filtered =
       new util.LinkedList[CloudWatchValue](data.asScala.filter(_.getTimestamp >= oldest).asJava)
-    val ts = normalize(datapoint.datapoint.timestamp().toEpochMilli, category.period)
+    val ts = normalize(datapoint.datapoint.timestamp().toEpochMilli, 60)
     if (ts < oldest) {
       registry.counter(droppedOld.withTag("aws.namespace", category.namespace)).increment()
       debugger.debugIncoming(datapoint, IncomingMatch.DroppedOld, receivedTimestamp, Some(category))


### PR DESCRIPTION
…of the

period. When some configs are set to 5m but the data is actually streamed every 5, the values overwrite and post incorrectly.