### PR TITLE
atlas cloudwatch: add an aws account supplier.

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/AwsAccountSupplier.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/AwsAccountSupplier.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import software.amazon.awssdk.regions.Region
+
+import scala.concurrent.Future
+
+/**
+  * Interface for supplying the list of accounts to poll for CloudWatch metrics.
+  */
+trait AwsAccountSupplier {
+
+  /**
+    * @return
+    *     A future resolving to the non-null map of account IDs to poll for CloudWatch
+    *     metrics along with the regions they operate in.
+    */
+  def accounts: Future[Map[String, List[Region]]]
+
+}

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/ConfigAccountSupplier.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/ConfigAccountSupplier.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.typesafe.config.Config
+import software.amazon.awssdk.regions.Region
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+/**
+  * Simple Typesafe config based AWS account supplier. Used for testing and in place of a supplier using internal tooling.
+  */
+class ConfigAccountSupplier(config: Config) extends AwsAccountSupplier {
+
+  private[cloudwatch] val defaultRegions =
+    if (config.hasPath("atlas.cloudwatch.account.polling.default-regions"))
+      config
+        .getStringList("atlas.cloudwatch.account.polling.default-regions")
+        .asScala
+        .map(Region.of(_))
+        .toList
+    else List(Region.of(System.getenv("NETFLIX_REGION")))
+
+  private val map = config
+    .getConfigList("atlas.cloudwatch.account.polling.accounts")
+    .asScala
+    .map { c =>
+      val regions = if (c.hasPath("regions")) {
+        c.getStringList("regions").asScala.map(Region.of(_)).toList
+      } else {
+        defaultRegions
+      }
+      c.getString("account") -> regions
+    }
+    .toMap
+
+  /**
+    * @return The non-null list of account IDs to poll for CloudWatch metrics.
+    */
+  override val accounts: Future[Map[String, List[Region]]] = Future(map)
+}

--- a/atlas-cloudwatch/src/test/resources/application.conf
+++ b/atlas-cloudwatch/src/test/resources/application.conf
@@ -26,20 +26,36 @@ atlas {
       "queryfilter"
     ]
 
-    account.routing {
-      uri = "https://publish-${STACK}.foo.com/api/v1/publish"
-      default = "main"
-      stackMap = {
-        stackA = [
-          "1",
-          "2"
-        ],
-        stackB = [
-          "3"
+    account {
+      polling = {
+        default-regions = ["us-east-1", "us-west-2"]
+        accounts = [
+          {
+            account = "000000000001"
+          },
+          {
+            account = "000000000002"
+          },
+          {
+            account = "000000000003"
+            regions = ["us-east-1"]
+          }
         ]
       }
+      routing {
+        uri = "https://publish-${STACK}.foo.com/api/v1/publish"
+        default = "main"
+        stackMap = {
+          stackA = [
+            "1",
+            "2"
+          ],
+          stackB = [
+            "3"
+          ]
+        }
+      }
     }
-
   }
 
 }

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConfigAccountSupplierSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConfigAccountSupplierSuite.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.typesafe.config.ConfigException.Missing
+import com.typesafe.config.ConfigFactory
+import munit.FunSuite
+import software.amazon.awssdk.regions.Region
+
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+class ConfigAccountSupplierSuite extends FunSuite {
+
+  test("test config") {
+    val cfg = ConfigFactory.load()
+    val accts = new ConfigAccountSupplier(cfg)
+    val map = Await.result(accts.accounts, 60.seconds)
+    assertEquals(map.size, 3)
+    assertEquals(map("000000000001"), accts.defaultRegions)
+    assertEquals(map("000000000002"), accts.defaultRegions)
+    assertEquals(map("000000000003"), List(Region.US_EAST_1))
+  }
+
+  test("empty accounts") {
+    val cfg = ConfigFactory.parseString("""
+        |atlas.cloudwatch.account.polling {
+        |  default-regions = ["us-east-1"]
+        |  accounts = []
+        |}
+      """.stripMargin)
+    val accts = new ConfigAccountSupplier(cfg)
+    val map = Await.result(accts.accounts, 60.seconds)
+    assert(map.isEmpty)
+  }
+
+  test("missing accounts") {
+    val cfg = ConfigFactory.parseString("""
+        |atlas.cloudwatch.account.polling {
+        |  default-regions = ["us-east-1"]
+        |}
+      """.stripMargin)
+    intercept[Missing] {
+      new ConfigAccountSupplier(cfg)
+    }
+  }
+}


### PR DESCRIPTION
This will be used by the new poller for metrics that are unavailable via the firehose stream. For now there is a simple config based implementation but we'll have an internal implementation using internal tools.