### PR TITLE
atlas cloudwatch: add last polled methods.

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
@@ -226,6 +226,20 @@ abstract class CloudWatchMetricsProcessor(
   protected[cloudwatch] def delete(key: Any): Unit
 
   /**
+    * @return
+    *     The last successful poll time in unix epoch milliseconds.
+    */
+  protected[cloudwatch] def lastSuccessfulPoll: Long
+
+  /**
+    * Updates the last successful poll time.
+    *
+    * @param timestamp
+    *     The unix epoch milliseconds of the last successful poll.
+    */
+  protected[cloudwatch] def updateLastSuccessfulPoll(timestamp: Long): Unit
+
+  /**
     * Inserts the given data point in the proper order of the CloudWatchCloudWatchCacheEntry **AND** expires any old data from
     * the entry. Note that this can lead to empty cache entries and those should likely be deleted.
     * Duplicates are overwritten.

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/LocalCloudWatchMetricsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/LocalCloudWatchMetricsProcessor.scala
@@ -22,6 +22,7 @@ import com.netflix.spectator.api.Registry
 import com.typesafe.config.Config
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.Future
 
 /**
@@ -53,6 +54,7 @@ class LocalCloudWatchMetricsProcessor(
 
   //                                               writeTS, expSec, data
   private val cache = new ConcurrentHashMap[Long, (Long, Long, Array[Byte])]
+  private val lastPoll = new AtomicLong()
 
   override protected def updateCache(
     datapoint: FirehoseMetric,
@@ -93,6 +95,11 @@ class LocalCloudWatchMetricsProcessor(
   override protected[cloudwatch] def delete(key: Any): Unit = {
     cache.remove(key)
   }
+
+  override protected[cloudwatch] def lastSuccessfulPoll: Long = lastPoll.get()
+
+  override protected[cloudwatch] def updateLastSuccessfulPoll(timestamp: Long): Unit =
+    lastPoll.set(timestamp)
 
   private[cloudwatch] def inject(
     key: Long,

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/RedisClusterCloudWatchMetricsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/RedisClusterCloudWatchMetricsProcessor.scala
@@ -95,6 +95,7 @@ class RedisClusterCloudWatchMetricsProcessor(
     .count(config.getInt("atlas.redis-cluster.scan.count"))
   private val commandObjects = new CommandObjects()
   private val maxBatch = config.getInt("atlas.redis-cluster.batch.size")
+  private val pollKey = "cw_last_poll".getBytes("UTF-8")
 
   private val currentScan = new AtomicReference[Future[Unit]]()
   private val running = new AtomicBoolean(false)
@@ -367,6 +368,23 @@ class RedisClusterCloudWatchMetricsProcessor(
         registry
           .counter(writeExs.withTags("call", "del", "ex", ex.getClass.getSimpleName))
           .increment()
+    }
+  }
+
+  override protected[cloudwatch] def lastSuccessfulPoll: Long = {
+    jedis.get(pollKey) match {
+      case null  => 0
+      case bytes => ByteBuffer.wrap(bytes).getLong()
+    }
+  }
+
+  override protected[cloudwatch] def updateLastSuccessfulPoll(timestamp: Long): Unit = {
+    val bytes = new Array[Byte](8)
+    ByteBuffer.wrap(bytes).putLong(timestamp)
+    jedis.set(pollKey, bytes) match {
+      case null => logger.error("Failed to set last poll key. Null response.")
+      case "OK" => // no-op
+      case unk  => logger.error(s"Failed to set last poll key: ${unk}")
     }
   }
 


### PR DESCRIPTION
This will be used for polling to determine when we need to poll for daily CloudWatch metrics.