### PR TITLE
atlas cloudwatch: add polling offset to MetricCategory

### DIFF
--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
@@ -207,6 +207,27 @@ class MetricCategorySuite extends FunSuite {
     assert(category.hasMonotonic)
   }
 
+  test("category with poll offset") {
+    val cfg = ConfigFactory.parseString("""
+        namespace = "AWS/ELB"
+        |period = 1m
+        |poll-offset = 7h
+        |dimensions = ["LoadBalancerName"]
+        |metrics = [
+        |  {
+        |    name = "RequestCount"
+        |    alias = "aws.elb.requests"
+        |    conversion = "sum,rate",
+        |    monotonic = true
+        |  }
+        |]
+        |filter = "name,RequestCount,:eq"
+      """.stripMargin)
+
+    val category = MetricCategory.fromConfig(cfg)
+    assertEquals(category.pollOffset.get, Duration.ofHours(7))
+  }
+
   test("dimensionsMatch true") {
     val cfg = ConfigFactory.parseString("""
         |namespace = "AWS/ELB"


### PR DESCRIPTION
This will be used to tell the app that a metric should be polled instead of expecting it from Firehose. E.g. S3 bucket aggregate metrics are computed and available daily. They are back-dated so that they won't arrive via Firehose.