### PR TITLE
atlas cloudwatch: Add executor factory.

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/spring/CloudWatchConfiguration.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/spring/CloudWatchConfiguration.scala
@@ -25,6 +25,7 @@ import com.netflix.atlas.cloudwatch.PublishRouter
 import com.netflix.atlas.cloudwatch.RedisClusterCloudWatchMetricsProcessor
 import com.netflix.atlas.cloudwatch.NetflixTagger
 import com.netflix.atlas.cloudwatch.Tagger
+import com.netflix.atlas.util.ExecutorFactory
 import com.netflix.iep.leader.api.LeaderStatus
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.api.Spectator.globalRegistry
@@ -48,6 +49,9 @@ class CloudWatchConfiguration extends StrictLogging {
 
   @Bean
   def cloudWatchRules(config: Config): CloudWatchRules = new CloudWatchRules(config)
+
+  @Bean
+  def executorFactor: ExecutorFactory = new ExecutorFactory
 
   @Bean
   def tagger(config: Config): Tagger = new NetflixTagger(

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/util/ExecutorFactory.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/util/ExecutorFactory.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.util
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+/**
+  * Simple shim for unit testing polling.
+  */
+class ExecutorFactory {
+
+  /**
+    * Returns a new fixed thread pool.
+    * @param numThreads
+    *     The number of threads to allocate.
+    * @return
+    *     An executor service.
+    */
+  def createFixedPool(numThreads: Int): ExecutorService = Executors.newFixedThreadPool(numThreads)
+
+}


### PR DESCRIPTION
Used in the new poller to avoid tying up other threads. Shimmed for unit testing.