### PR TITLE
atlas cloudwatch: Update AWS configurations.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/alb.conf
+++ b/atlas-cloudwatch/src/main/resources/alb.conf
@@ -4,13 +4,34 @@ atlas {
 
     // Metrics for the overall load balancer
     // http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html
-    alb = {
+    alb-lcus = {
       namespace = "AWS/ApplicationELB"
       period = 1m
-      end-period-offset = 12
+      end-period-offset = 44
 
       dimensions = [
         "LoadBalancer"
+      ]
+
+      metrics = [
+        {
+          name = "ConsumedLCUs"
+          alias = "aws.alb.consumedLCUs"
+          conversion = "sum"
+        }
+      ]
+    }
+
+    // Metrics for the overall load balancer by zone
+    // http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html
+    alb-zone = {
+      namespace = "AWS/ApplicationELB"
+      period = 1m
+      end-period-offset = 10
+
+      dimensions = [
+        "LoadBalancer",
+        "AvailabilityZone"
       ]
 
       metrics = [
@@ -23,6 +44,49 @@ atlas {
           name = "ActiveConnectionCount"
           alias = "aws.alb.activeConnectionCount"
           conversion = "sum"
+        },
+        {
+          name = "NewConnectionCount"
+          alias = "aws.alb.newConnections"
+          conversion = "sum,rate"
+        },
+        {
+          name = "RejectedConnectionCount"
+          alias = "aws.alb.rejectedConnections"
+          conversion = "sum,rate"
+        },
+        {
+          name = "HTTPCode_ELB_4XX_Count"
+          alias = "aws.alb.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "4xx"
+            }
+          ]
+        },
+        {
+          name = "HTTPCode_ELB_5XX_Count"
+          alias = "aws.alb.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "5xx"
+            }
+          ]
+        },
+        {
+          name = "ClientTLSNegotiationErrorCount"
+          alias = "aws.alb.clientErrors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "error"
+              value = "TLSNegotiation"
+            }
+          ]
         },
         {
           name = "ELBAuthError"
@@ -61,83 +125,6 @@ atlas {
           name = "ELBAuthLatency"
           alias = "aws.alb.authLatency"
           conversion = "timer"
-        },
-        {
-          name = "NewConnectionCount"
-          alias = "aws.alb.newConnections"
-          conversion = "sum,rate"
-        },
-        {
-          name = "RejectedConnectionCount"
-          alias = "aws.alb.rejectedConnections"
-          conversion = "sum,rate"
-        }
-      ]
-    }
-
-    alb-lcus = {
-          namespace = "AWS/ApplicationELB"
-          period = 1m
-          end-period-offset = 44
-
-          dimensions = [
-            "LoadBalancer"
-          ]
-
-          metrics = [
-            {
-              name = "ConsumedLCUs"
-              alias = "aws.alb.consumedLCUs"
-              conversion = "sum"
-            }
-          ]
-        }
-
-    // Metrics for the overall load balancer by zone
-    // http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html
-    alb-zone = {
-      namespace = "AWS/ApplicationELB"
-      period = 1m
-      end-period-offset = 12
-
-      dimensions = [
-        "LoadBalancer",
-        "AvailabilityZone"
-      ]
-
-      metrics = [
-        {
-          name = "HTTPCode_ELB_4XX_Count"
-          alias = "aws.alb.errors"
-          conversion = "sum,rate"
-          tags = [
-            {
-              key = "status"
-              value = "4xx"
-            }
-          ]
-        },
-        {
-          name = "HTTPCode_ELB_5XX_Count"
-          alias = "aws.alb.errors"
-          conversion = "sum,rate"
-          tags = [
-            {
-              key = "status"
-              value = "5xx"
-            }
-          ]
-        },
-        {
-          name = "ClientTLSNegotiationErrorCount"
-          alias = "aws.alb.clientErrors"
-          conversion = "sum,rate"
-          tags = [
-            {
-              key = "error"
-              value = "TLSNegotiation"
-            }
-          ]
         }
       ]
     }
@@ -147,7 +134,7 @@ atlas {
     alb-tg-zone = {
       namespace = "AWS/ApplicationELB"
       period = 1m
-      end-period-offset = 12
+      end-period-offset = 10
 
       dimensions = [
         "LoadBalancer",

--- a/atlas-cloudwatch/src/main/resources/api-gateway.conf
+++ b/atlas-cloudwatch/src/main/resources/api-gateway.conf
@@ -4,12 +4,12 @@ atlas {
 
     // http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-dashboard.html
     api-gateway = {
-      namespace = "ApiGateway"
+      namespace = "AWS/ApiGateway"
       period = 1m
+      end-period-offset = 3
 
       dimensions = [
-        "ApiName",
-        "Label"
+        "ApiName"
       ]
 
       metrics = [

--- a/atlas-cloudwatch/src/main/resources/billing.conf
+++ b/atlas-cloudwatch/src/main/resources/billing.conf
@@ -3,6 +3,7 @@ atlas {
   cloudwatch {
 
     // http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/monitor_estimated_charges_with_cloudwatch.html
+    // Not enabled by default.
     billing = {
       namespace = "AWS/Billing"
       period = 6h

--- a/atlas-cloudwatch/src/main/resources/dynamodb.conf
+++ b/atlas-cloudwatch/src/main/resources/dynamodb.conf
@@ -138,7 +138,7 @@ atlas {
     dynamodb-capacity = {
       namespace = "AWS/DynamoDB"
       period = 1m
-      end-period-offset = 12
+      end-period-offset = 6
 
       dimensions = [
         "TableName"

--- a/atlas-cloudwatch/src/main/resources/ec2.conf
+++ b/atlas-cloudwatch/src/main/resources/ec2.conf
@@ -143,8 +143,8 @@ atlas {
     // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-transition-to-version-2
     ec2-imdsv2 = {
       namespace = "AWS/EC2"
-      period = 5m
-      end-period-offset = 12
+      period = 1m
+      end-period-offset = 225
       timeout = 20m
 
       dimensions = [
@@ -163,8 +163,8 @@ atlas {
     // http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-instances.html#t2-instances-monitoring-cpu-credits
     ec2-credit = {
       namespace = "AWS/EC2"
-      period = 5m
-      end-period-offset = 13
+      period = 1m
+      end-period-offset = 10
       timeout = 20m
 
       dimensions = [
@@ -185,11 +185,34 @@ atlas {
       ]
     }
 
+    ec2-nau = {
+      namespace = "AWS/EC2"
+      period = 5m
+      end-period-offset = 4
+
+      dimensions = [
+        "Per-VPC Metrics",
+      ]
+
+      metrics = [
+        {
+          name = "NetworkAddressUsage"
+          alias = "aws.vpc.networkAddressUsage"
+          conversion = "max"
+        },
+        {
+          name = "NetworkAddressUsagePeered"
+          alias = "aws.vpc.networkAddressUsagePeered"
+          conversion = "max"
+        }
+      ]
+    }
+
     // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/monitor.html
     ec2-api = {
       namespace = "AWS/EC2/API"
       period = 1m
-      end-period-offset = 22
+      end-period-offset = 44
       timeout = 20m
 
       dimensions = [
@@ -256,7 +279,7 @@ atlas {
               value = "SuccessfulCalls"
             },
           ]
-        },
+        }
       ]
     }
   }

--- a/atlas-cloudwatch/src/main/resources/elasticache.conf
+++ b/atlas-cloudwatch/src/main/resources/elasticache.conf
@@ -11,7 +11,7 @@ atlas {
     elasticache = {
       namespace = "AWS/ElastiCache"
       period = 1m
-      end-period-offset = 4
+      end-period-offset = 5
 
       dimensions = [
         "CacheClusterId",

--- a/atlas-cloudwatch/src/main/resources/elb.conf
+++ b/atlas-cloudwatch/src/main/resources/elb.conf
@@ -150,6 +150,11 @@ atlas {
           name = "EstimatedProcessedBytes"
           alias = "aws.elb.processedBytes"
           conversion = "sum,rate"
+        },
+        {
+          name = "EstimatedALBConsumedLCUs"
+          alias = "aws.elb.consumedCapacity"
+          conversion = "sum,rate"
         }
       ]
     }

--- a/atlas-cloudwatch/src/main/resources/es.conf
+++ b/atlas-cloudwatch/src/main/resources/es.conf
@@ -5,8 +5,8 @@ atlas {
     // http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/es-metricscollected.html
     es = {
       namespace = "AWS/ES"
-      period = 5m
-      end-period-offset = 9
+      period = 1m
+      end-period-offset = 7
 
       dimensions = [
         "ClientId",

--- a/atlas-cloudwatch/src/main/resources/events.conf
+++ b/atlas-cloudwatch/src/main/resources/events.conf
@@ -6,7 +6,7 @@ atlas {
     events = {
       namespace = "AWS/Events"
       period = 1m
-      end-period-offset = 19
+      end-period-offset = 25
 
       dimensions = [
         "RuleName"

--- a/atlas-cloudwatch/src/main/resources/iot.conf
+++ b/atlas-cloudwatch/src/main/resources/iot.conf
@@ -6,6 +6,7 @@ atlas {
     iot-base = {
       namespace = "AWS/IoT"
       period = 1m
+      end-period-offset = 4
 
       dimensions = [
         //"RuleName"
@@ -24,6 +25,7 @@ atlas {
     iot-rule = {
       namespace = "AWS/IoT"
       period = 1m
+      end-period-offset = 4
 
       dimensions = [
         "RuleName"
@@ -75,6 +77,7 @@ atlas {
     iot-rule-action = {
       namespace = "AWS/IoT"
       period = 1m
+      end-period-offset = 4
 
       dimensions = [
         "RuleName",
@@ -111,6 +114,7 @@ atlas {
     iot-message-broker = {
       namespace = "AWS/IoT"
       period = 1m
+      end-period-offset = 4
 
       dimensions = [
         "Protocol"

--- a/atlas-cloudwatch/src/main/resources/lambda.conf
+++ b/atlas-cloudwatch/src/main/resources/lambda.conf
@@ -6,7 +6,7 @@ atlas {
     lambda = {
       namespace = "AWS/Lambda"
       period = 1m
-      end-period-offset = 3
+      end-period-offset = 5
 
       dimensions = []
 
@@ -39,7 +39,7 @@ atlas {
     lambda-fn-res = {
       namespace = "AWS/Lambda"
       period = 1m
-      end-period-offset = 12
+      end-period-offset = 14
 
       dimensions = [
         "FunctionName",

--- a/atlas-cloudwatch/src/main/resources/mediaconnect.conf
+++ b/atlas-cloudwatch/src/main/resources/mediaconnect.conf
@@ -6,6 +6,7 @@ atlas {
     mediaconnect-flow = {
       namespace = "AWS/MediaConnect"
       period = 1m
+      end-period-offset = 20
 
       dimensions = [
         "FlowARN",
@@ -51,6 +52,7 @@ atlas {
     mediaconnect-source = {
       namespace = "AWS/MediaConnect"
       period = 1m
+      end-period-offset = 4
 
       dimensions = [
         "SourceARN",

--- a/atlas-cloudwatch/src/main/resources/medialive.conf
+++ b/atlas-cloudwatch/src/main/resources/medialive.conf
@@ -6,8 +6,12 @@ atlas {
     medialive-global = {
       namespace = "AWS/MediaLive"
       period = 1m
+      end-period-offset = 4
 
-      dimensions = []
+      dimensions = [
+        "ChannelId",
+        "Pipeline",
+      ]
 
       metrics = [
         {
@@ -22,10 +26,11 @@ atlas {
     medialive-input = {
       namespace = "AWS/MediaLive"
       period = 1m
+      end-period-offset = 4
 
       dimensions = [
         "ActiveInputFailoverLabel",
-        "ChannelID",
+        "ChannelId",
         "Pipeline",
       ]
 
@@ -70,11 +75,11 @@ atlas {
     medialive-output = {
       namespace = "AWS/MediaLive"
       period = 1m
+      end-period-offset = 3
 
       dimensions = [
-        "ChannelID",
-        "OutputGroupName",
-        "Pipeline",
+        "ChannelId",
+        "OutputGroupName"
       ]
 
       metrics = [
@@ -112,9 +117,10 @@ atlas {
     medialive-network = {
       namespace = "AWS/MediaLive"
       period = 1m
+      end-period-offset = 3
 
       dimensions = [
-        "ChannelID",
+        "ChannelId",
         "Pipeline",
       ]
 

--- a/atlas-cloudwatch/src/main/resources/neptune.conf
+++ b/atlas-cloudwatch/src/main/resources/neptune.conf
@@ -176,7 +176,7 @@ atlas {
     neptune-cluster-5m = {
       namespace = "AWS/Neptune"
       period = 5m
-      end-period-offset = 7
+      end-period-offset = 9
       timeout = 15m
 
       dimensions = [
@@ -218,8 +218,8 @@ atlas {
     neptune-cluster-1d = {
       namespace = "AWS/Neptune"
       period = 1d
-      end-period-offset = 2
-      timeout = 15m
+      end-period-offset = 3
+      poll-offset = 4h
 
       dimensions = [
         "DBClusterIdentifier"

--- a/atlas-cloudwatch/src/main/resources/nlb.conf
+++ b/atlas-cloudwatch/src/main/resources/nlb.conf
@@ -10,7 +10,7 @@ atlas {
     nlb = {
       namespace = "AWS/NetworkELB"
       period = 1m
-      end-period-offset = 3
+      end-period-offset = 14
       timeout = 15m
 
       dimensions = [
@@ -57,8 +57,7 @@ atlas {
     nlb-zone = {
       namespace = "AWS/NetworkELB"
       period = 1m
-      period-count = 8
-      end-period-offset = 6
+      end-period-offset = 14
 
       dimensions = [
         "AvailabilityZone",
@@ -243,7 +242,7 @@ atlas {
     nlb-tg-zone = {
       namespace = "AWS/NetworkELB"
       period = 1m
-      end-period-offset = 12
+      end-period-offset = 14
 
       dimensions = [
         "AvailabilityZone",

--- a/atlas-cloudwatch/src/main/resources/rds.conf
+++ b/atlas-cloudwatch/src/main/resources/rds.conf
@@ -149,7 +149,6 @@ atlas {
           conversion = "max"
         },
         {
-        // only DatabaseClass tag
           name = "Deadlocks"
           alias = "aws.rds.deadlocks"
           conversion = "sum,rate"
@@ -468,8 +467,7 @@ atlas {
       # (1m * (91 - 1)) to avoid gaps in minutely timeseries.
       #
       period = 1m
-      period-count = 91
-      end-period-offset = 1
+      end-period-offset = 130
       timeout = 15m
 
       dimensions = [

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -159,14 +159,14 @@ atlas {
       // How many threads to use for the polling executor.
       num-threads = 8
 
-      // The period configured for namespaces that will be polled instead of sent via
-      // Firehose. So far we only care about S3 aggregates that are reported daily. If we
-      // need additional periods, we'll need to tweak the code.
+      # The period configured for namespaces that will be polled instead of sent via
+      # Firehose. So far we only care about S3 aggregates that are reported daily. If we
+      # need additional periods, we'll need to tweak the code.
       period-filter = 1d
     }
 
-    // TEMP: Used while testing cloud watch streaming to prepend "TEST." to metrics in order to compare against
-    // the poller.
+    # TEMP: Used while testing cloud watch streaming to prepend "TEST." to metrics in order to compare against
+    # the poller.
     testMode = true
 
     // How often to run the publish thread.
@@ -234,6 +234,26 @@ atlas {
             {
               pattern = "^targetgroup/([^/]+)/.*"
               alias = "aws.target"
+            }
+          ]
+        },
+        {
+          # The tag is too long for default Atlas tag values in a number of cases.
+          name = "SourceARN"
+          directives = [
+            {
+              pattern = "^arn:aws:mediaconnect:(.*)"
+              alias = "aws.source"
+            }
+          ]
+        },
+        {
+          # The tag is too long for default Atlas tag values in a number of cases.
+          name = "FlowARN"
+          directives = [
+            {
+              pattern = "^arn:aws:mediaconnect:(.*)"
+              alias = "aws.flow"
             }
           ]
         }
@@ -376,6 +396,10 @@ atlas {
           alias = "nf.node"
         },
         {
+          name = "NodeName"
+          alias = "nf.node"
+        },
+        {
           name = "Operation"
           alias = "aws.op"
         },
@@ -491,7 +515,6 @@ atlas {
     // ec2 is excluded by default because at Netflix it tends to add a lot of load in terms of
     // CW calls and offers little value over internal system metrics.
     categories = [
-      "alb",
       "alb-lcus",
       "alb-zone",
       "alb-tg-zone",
@@ -509,6 +532,8 @@ atlas {
       //"ec2",
       "ec2-api",
       "ec2-credit",
+      "ec2-imdsv2",
+      "ec2-nau",
       "efs",
       "elasticache",
       "elb",
@@ -549,7 +574,7 @@ atlas {
       "s3-request",
       "sns",
       "sqs",
-      "sqs5m",
+      "sqs-msg-size",
       "tgw",
       //"trustedadvisor",
       "vpn",

--- a/atlas-cloudwatch/src/main/resources/route53.conf
+++ b/atlas-cloudwatch/src/main/resources/route53.conf
@@ -6,7 +6,7 @@ atlas {
     route53-healthcheck = {
       namespace = "AWS/Route53"
       period = 1m
-      end-period-offset = 3
+      end-period-offset = 5
 
       dimensions = [
         "HealthCheckId"
@@ -30,7 +30,7 @@ atlas {
     route53-hostedzone = {
       namespace = "AWS/Route53"
       period = 1m
-      end-period-offset = 25
+      end-period-offset = 7
 
       dimensions = [
         "HostedZoneId"
@@ -49,7 +49,7 @@ atlas {
     route53-resolver-inbound = {
       namespace = "AWS/Route53Resolver"
       period = 1m
-      end-period-offset = 9
+      end-period-offset = 6
 
       // RniId or EndpointId, odd.
       dimensions = [
@@ -74,7 +74,7 @@ atlas {
     route53-resolver-outbound = {
       namespace = "AWS/Route53Resolver"
       period = 1m
-      end-period-offset = 9
+      end-period-offset = 6
 
       // RniId or EndpointId.. bizzare.
       dimensions = [

--- a/atlas-cloudwatch/src/main/resources/s3-request.conf
+++ b/atlas-cloudwatch/src/main/resources/s3-request.conf
@@ -6,7 +6,9 @@ atlas {
     s3-request = {
       namespace = "AWS/S3"
       period = 1m
-      end-period-offset = 30
+      # Note that this data repeatedly posts in batches of timestamps so going offset
+      # the max stale age is not a good idea. Use the average instead and pad it a little.
+      end-period-offset = 10
 
       dimensions = [
         "BucketName",

--- a/atlas-cloudwatch/src/main/resources/s3.conf
+++ b/atlas-cloudwatch/src/main/resources/s3.conf
@@ -2,11 +2,12 @@
 atlas {
   cloudwatch {
 
-    // http://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html
+    // https://docs.aws.amazon.com/AmazonS3/latest/userguide/metrics-dimensions.html
     s3 = {
       namespace = "AWS/S3"
       period = 1d
-      period-count = 20
+      end-period-offset = 4
+      poll-offset = 8h
 
       dimensions = [
         "BucketName",

--- a/atlas-cloudwatch/src/main/resources/sns.conf
+++ b/atlas-cloudwatch/src/main/resources/sns.conf
@@ -5,8 +5,8 @@ atlas {
     // http://docs.aws.amazon.com/sns/latest/dg/MonitorSNSwithCloudWatch.html
     sns = {
       namespace = "AWS/SNS"
-      period = 5m
-      end-period-offset = 39
+      period = 1m
+      end-period-offset = 10
 
       dimensions = [
         "TopicName"

--- a/atlas-cloudwatch/src/main/resources/sqs.conf
+++ b/atlas-cloudwatch/src/main/resources/sqs.conf
@@ -6,7 +6,7 @@ atlas {
     sqs = {
       namespace = "AWS/SQS"
       period = 1m
-      end-period-offset = 12
+      end-period-offset = 3
 
       dimensions = [
         "QueueName"
@@ -74,12 +74,10 @@ atlas {
       ]
     }
 
-
-    sqs5m = {
+    sqs-msg-size = {
       namespace = "AWS/SQS"
-      period = 5m
-      end-period-offset = 45
-      timeout = 1h
+      period = 1m
+      end-period-offset = 155
 
       dimensions = [
         "QueueName"
@@ -94,4 +92,5 @@ atlas {
       ]
     }
   }
+
 }

--- a/atlas-cloudwatch/src/main/resources/vpn.conf
+++ b/atlas-cloudwatch/src/main/resources/vpn.conf
@@ -7,6 +7,7 @@ atlas {
     vpn = {
       namespace = "AWS/VPN"
       period = 1m
+      end-period-offset = 4
 
       dimensions = [
         "VpnId",


### PR DESCRIPTION
Another round of updates to tune the offsets for streaming. Also configure S3 and Neptune billing for polling. Fix some issues with typos in tags, wrong tag combinations  or incorrect posting intervals.