### PR TITLE
atlas cloudwatch: add Per-VPC mapping.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -412,6 +412,10 @@ atlas {
           alias = "aws.output-group"
         },
         {
+          name = "Per-VPC Metrics"
+          alias = "aws.vpc"
+        },
+        {
           name = "Pipeline"
           alias = "aws.pipeline"
         },
@@ -495,10 +499,6 @@ atlas {
 
       // Tags that should get applied to all metrics from cloudwatch.
       common-tags = [
-        {
-          key = "nf.region"
-          value = "us-west-2"
-        }
       ]
 
       // When using the netflix mapper, this setting specifies which keys should get

--- a/atlas-cloudwatch/src/test/resources/application.conf
+++ b/atlas-cloudwatch/src/test/resources/application.conf
@@ -2,7 +2,7 @@ atlas {
 
   poller {
 
-    // Set to a large value because we don't want it running during tests
+    # Set to a large value because we don't want it running during tests
     frequency = 60 minutes
 
     pollers = [
@@ -56,6 +56,15 @@ atlas {
           ]
         }
       }
+    }
+
+    tagger = {
+      common-tags = [
+        {
+          key = "nf.region"
+          value = "us-west-2"
+        }
+      ]
     }
   }
 

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
@@ -347,8 +347,7 @@ class DefaultTaggerSuite extends FunSuite {
     val tagger = new DefaultTagger(cfg.getConfig("atlas.cloudwatch.tagger"))
 
     val expected = Map(
-      "aws.alb"   -> "captured-portion",
-      "nf.region" -> "us-west-2"
+      "aws.alb" -> "captured-portion"
     )
 
     val actual = tagger(
@@ -365,8 +364,7 @@ class DefaultTaggerSuite extends FunSuite {
     val tagger = new DefaultTagger(cfg.getConfig("atlas.cloudwatch.tagger"))
 
     val expected = Map(
-      "aws.nlb"   -> "captured-portion",
-      "nf.region" -> "us-west-2"
+      "aws.nlb" -> "captured-portion"
     )
 
     val actual = tagger(


### PR DESCRIPTION
And remove the common nf.region tag from the reference.conf. Move it to the test application file instead. Entailed cleaning up a couple of DefaultTagger unit tests.