### PR TITLE
atlas cloudwatch: Fix polling timestamp API.

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
@@ -227,18 +227,23 @@ abstract class CloudWatchMetricsProcessor(
   protected[cloudwatch] def delete(key: Any): Unit
 
   /**
+    * Returns the last successful poll time.
+    * @param id
+    *     The non-null unique identifier for the polling config.
     * @return
     *     The last successful poll time in unix epoch milliseconds.
     */
-  protected[cloudwatch] def lastSuccessfulPoll: Long
+  protected[cloudwatch] def lastSuccessfulPoll(id: String): Long
 
   /**
     * Updates the last successful poll time.
     *
+    * @param id
+    *     The non-null unique identifier for the polling config.
     * @param timestamp
     *     The unix epoch milliseconds of the last successful poll.
     */
-  protected[cloudwatch] def updateLastSuccessfulPoll(timestamp: Long): Unit
+  protected[cloudwatch] def updateLastSuccessfulPoll(id: String, timestamp: Long): Unit
 
   /**
     * Inserts the given data point in the proper order of the CloudWatchCloudWatchCacheEntry **AND** expires any old data from

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/ConfigAccountSupplier.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/ConfigAccountSupplier.scala
@@ -16,6 +16,7 @@
 package com.netflix.atlas.cloudwatch
 
 import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
 import software.amazon.awssdk.regions.Region
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -25,7 +26,7 @@ import scala.jdk.CollectionConverters.CollectionHasAsScala
 /**
   * Simple Typesafe config based AWS account supplier. Used for testing and in place of a supplier using internal tooling.
   */
-class ConfigAccountSupplier(config: Config) extends AwsAccountSupplier {
+class ConfigAccountSupplier(config: Config) extends AwsAccountSupplier with StrictLogging {
 
   private[cloudwatch] val defaultRegions =
     if (config.hasPath("atlas.cloudwatch.account.polling.default-regions"))
@@ -48,6 +49,7 @@ class ConfigAccountSupplier(config: Config) extends AwsAccountSupplier {
       c.getString("account") -> regions
     }
     .toMap
+  logger.debug(s"Loaded accounts: ${map}")
 
   /**
     * @return The non-null list of account IDs to poll for CloudWatch metrics.


### PR DESCRIPTION
Since we can (and do) have multiple offsets running, we need a unique key in Redis for each. Updated with an ID.
Also log the config account supplier map.