### PR TITLE
atlas cloudwatch: Rework publish routing config.

### DIFF
--- a/atlas-cloudwatch/src/test/resources/application.conf
+++ b/atlas-cloudwatch/src/test/resources/application.conf
@@ -44,17 +44,32 @@ atlas {
         ]
       }
       routing {
-        uri = "https://publish-${STACK}.foo.com/api/v1/publish"
+        uri = "https://publish-${STACK}.${REGION}.foo.com/api/v1/publish"
         default = "main"
-        stackMap = {
-          stackA = [
-            "1",
-            "2"
-          ],
-          stackB = [
-            "3"
-          ]
-        }
+        routes = [
+          {
+            stack = "stackA"
+            accounts = [
+              {
+                account = "1"
+                routing = {
+                  "us-west-1" = "us-west-1"
+                }
+              },
+              {
+                account = "2"
+              }
+            ]
+          },
+          {
+            stack = "stackB"
+            accounts = [
+              {
+                account = "3"
+              }
+            ]
+          }
+        ]
       }
     }
 


### PR DESCRIPTION
This allows us to route by region as well as account. Necessary for the IEP stacks and maybe others in the future.