### PR TITLE
atlas cloudwatch: add AWS Config account supplier.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -55,19 +55,51 @@ atlas {
 
     // Handles routing data points to the proper publish proxy instance for the given stack. Uses the account ID of the
     // Cloud Watch data to map to stacks.
-    account.routing {
-      queue {
-        // The upper limit for each queue to buffer before rejecting data points.
-        queueSize = 100000
+    account {
+      routing {
+        queue {
+          // The upper limit for each queue to buffer before rejecting data points.
+          queueSize = 100000
 
-        // The maximum number of data points to collate into a single flush.
-        batchSize = 1000
+          // The maximum number of data points to collate into a single flush.
+          batchSize = 1000
 
-        // How long to wait for a group of data to reach the batch size or be flushed.
-        batchTimeout = 5s
+          // How long to wait for a group of data to reach the batch size or be flushed.
+          batchTimeout = 5s
 
-        // How many times to retry a batch if downstream returns a backoff or an exception occurs.
-        maxRetries = 1
+          // How many times to retry a batch if downstream returns a backoff or an exception occurs.
+          maxRetries = 1
+        }
+      }
+
+      supplier {
+        aws {
+          // These settings apply to the AWS Config account supplier module. The module queries the AWS Config
+          // database for accounts and resources in use in each region.
+          // Note that you must have an "netflix.iep.aws.config-query" credentials clause setup with the proper
+          // role-arn with permission to make the AWS call.
+
+          // The name of an aggregator instance to use for querying the AWS Config database.
+          aggregator = ""
+
+          // The region where the aggregator is located.
+          aggregator-region = ""
+
+          // The account under which to query the aggregator.
+          config-account = ""
+
+          // A list of regions to fetch resources for. The Config API returns all regions and all accounts but
+          // a poller is likely to only handle a subset of regions. Specify those here.
+          regions = []
+
+          // Whether or not the accounts list is an allow list that would filter out anything NOT in the list or
+          // a deny list that will filter out ONLY those accounts in the list. Note that if this is true and the
+          // accounts list is empty, nothing will be returned.
+          is-allow = false
+
+          // The list if accounts to filter on.
+          accounts = []
+        }
       }
     }
 

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/AwsAccountSupplier.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/AwsAccountSupplier.scala
@@ -20,15 +20,17 @@ import software.amazon.awssdk.regions.Region
 import scala.concurrent.Future
 
 /**
-  * Interface for supplying the list of accounts to poll for CloudWatch metrics.
+  * Interface for supplying the list of accounts, regions and namespaces to poll for CloudWatch metrics.
   */
 trait AwsAccountSupplier {
 
   /**
+    * The map of accounts to regions to namespaces for polling. The final set is the namespace list in
+    * the format of CloudWatch, e.g. "AWS/EC2" or "AWS/ECS".
     * @return
-    *     A future resolving to the non-null map of account IDs to poll for CloudWatch
-    *     metrics along with the regions they operate in.
+    *     The non-null map of account IDs to poll for CloudWatch metrics along with the regions they
+    *     operate in and namespaces to poll.
     */
-  def accounts: Future[Map[String, List[Region]]]
+  def accounts: Map[String, Map[Region, Set[String]]]
 
 }

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/AwsConfigAccountSupplier.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/AwsConfigAccountSupplier.scala
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import akka.actor.ActorSystem
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.normalize
+import com.netflix.atlas.json.Json
+import com.netflix.atlas.json.JsonParserHelper.foreachField
+import com.netflix.iep.aws2.AwsClientFactory
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.config.ConfigClient
+import software.amazon.awssdk.services.config.model.SelectAggregateResourceConfigRequest
+
+import java.util.Optional
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.compat.java8.StreamConverters.StreamHasToScala
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.DurationLong
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.util.Random
+import scala.util.Using
+
+/**
+  * Periodically calls configuration aggregators for a list of accounts and active
+  * resources in each region. The list is filtered through the regions we want in the config
+  * and accounts can be allowed or denied via a list and "is-allow" flag.
+  *
+  * Note that on startup, the config is loaded and exceptions thrown so that we don't start
+  * an instance that isn't ready to handle data.
+  */
+class AwsConfigAccountSupplier(
+  config: Config,
+  registry: Registry,
+  clientFactory: AwsClientFactory
+)(implicit val system: ActorSystem)
+    extends AwsAccountSupplier
+    with StrictLogging {
+
+  private val aggregator = config.getString("atlas.cloudwatch.account.supplier.aws.aggregator")
+
+  private val aggregatorRegion =
+    Region.of(config.getString("atlas.cloudwatch.account.supplier.aws.aggregator-region"))
+
+  private val configAccount =
+    config.getString("atlas.cloudwatch.account.supplier.aws.config-account")
+
+  private val regions =
+    config.getStringList("atlas.cloudwatch.account.supplier.aws.regions").asScala.toSet
+  private val isAllow = config.getBoolean("atlas.cloudwatch.account.supplier.aws.is-allow")
+
+  private val accountList =
+    config.getStringList("atlas.cloudwatch.account.supplier.aws.accounts").asScala.toSet
+  private val initialized = new AtomicBoolean()
+
+  @volatile private[cloudwatch] var rawAccountResources
+    : Map[String, Map[Region, Map[String, Set[String]]]] = null
+  @volatile private[cloudwatch] var filtered: Map[String, Map[Region, Set[String]]] = null
+
+  val delay = {
+    val now = System.currentTimeMillis()
+    val normalized = normalize(now, 86_400) + (new Random().nextInt(3600) * 1000)
+    (if (now < normalized) normalized - now else (normalized + (86400 * 1000)) - now) / 1000
+  }
+  system.scheduler.scheduleAtFixedRate(delay.seconds, 24.hours)(runner)(system.dispatcher)
+  logger.info(s"Next AWS Config load in ${delay} seconds.")
+
+  private val runner: Runnable = () => {
+    val start = System.currentTimeMillis()
+    logger.info(
+      s"Starting load of AWS accounts and resources from AWS Config aggregator ${aggregator} in ${aggregatorRegion}"
+    )
+    //                  acct        region      ns      resources
+    var map = Map.empty[String, Map[Region, Map[String, Set[String]]]]
+
+    try {
+      val client: ConfigClient = clientFactory.getInstance(
+        "config-query",
+        classOf[ConfigClient],
+        configAccount,
+        Optional.of(aggregatorRegion)
+      )
+      val req = SelectAggregateResourceConfigRequest
+        .builder()
+        .configurationAggregatorName(aggregator)
+        .expression(
+          "SELECT COUNT(*), accountId, resourceType, awsRegion GROUP BY accountId, resourceType, awsRegion"
+        )
+        .build()
+
+      val resp = client.selectAggregateResourceConfigPaginator(req)
+      var records = 0
+      var skipped = 0
+      // Should be fine for a smallish # off records. If it becomes a problem, stream.
+      resp.results().stream().toScala(List).foreach { json =>
+        try {
+          Using.resource(Json.newJsonParser(json)) { parser =>
+            var account: String = null
+            var resource: String = null
+            var region: String = null
+            foreachField(parser) {
+              case "accountId"    => account = parser.nextTextValue()
+              case "resourceType" => resource = parser.nextTextValue()
+              case "awsRegion"    => region = parser.nextTextValue()
+              case _ =>
+                parser.nextToken()
+                parser.skipChildren()
+            }
+            records += 1
+
+            if (regions.contains(region)) {
+              val r = region match {
+                case "global" => Region.AWS_GLOBAL
+                case other    => Region.of(other)
+              }
+              var regions = map.getOrElse(account, Map.empty)
+              var nss = regions.getOrElse(r, Map.empty)
+              val (ns, remainder) = splitResource(resource)
+              var set = nss.getOrElse(ns, Set.empty)
+              set += remainder
+              nss += ns      -> set
+              regions += r   -> nss
+              map += account -> regions
+            } else {
+              skipped += 1
+            }
+          }
+        } catch {
+          case ex: Exception =>
+            logger.error(s"Failed to parse resource: ${json}", ex)
+            registry
+              .counter(
+                "atlas.cloudwatch.account.supplier.aws.parseException",
+                "exception",
+                ex.getClass.getSimpleName
+              )
+              .increment()
+        }
+      }
+      logger.info(s"Successfully loaded ${records} records (skipped ${skipped})")
+    } catch {
+      case ex: Exception =>
+        logger.error("Failed to query for resources", ex)
+        registry
+          .counter(
+            "atlas.cloudwatch.account.supplier.aws.loadException",
+            "exception",
+            ex.getClass.getSimpleName
+          )
+          .increment()
+        throw ex
+    }
+    rawAccountResources = map
+    val f = if (isAllow) {
+      rawAccountResources.filter { case (account, _) => accountList.contains(account) }
+    } else {
+      rawAccountResources.filterNot { case (account, _) => accountList.contains(account) }
+    }
+    filtered = f.map(acct => acct._1 -> acct._2.map(r => r._1 -> r._2.keySet))
+    logger.info(
+      s"Finished loading ${rawAccountResources.size} (${filtered.size} filtered) AWS accounts and resources in ${(System.currentTimeMillis() - start) / 1000.0} seconds"
+    )
+    registry
+      .timer("atlas.cloudwatch.account.supplier.aws.loadTime")
+      .record(System.currentTimeMillis() - start, TimeUnit.MILLISECONDS)
+    initialized.set(true)
+  }
+  // run now to make sure we have access and can start
+  runner.run()
+
+  override def accounts: Map[String, Map[Region, Set[String]]] = filtered
+
+  private def splitResource(resource: String): (String, String) = {
+    var idx = resource.indexOf("::")
+    if (idx < 0) throw new IllegalArgumentException(s"Invalid resource: ${resource}")
+    idx = resource.indexOf("::", idx + 2)
+    if (idx < 0) throw new IllegalArgumentException(s"Invalid resource: ${resource}")
+    val namespace = resource.substring(0, idx).replaceAll("::", "/")
+    val remainder = resource.substring(idx + 2).replaceAll("::", "/")
+    (namespace, remainder)
+  }
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/AwsConfigAccountSupplierSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/AwsConfigAccountSupplierSuite.scala
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2014-2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKitBase
+import com.netflix.iep.aws2.AwsClientFactory
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import munit.FunSuite
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchersSugar.any
+import org.mockito.MockitoSugar.mock
+import org.mockito.MockitoSugar.when
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.config.ConfigClient
+import software.amazon.awssdk.services.config.model.SelectAggregateResourceConfigRequest
+import software.amazon.awssdk.services.config.model.SelectAggregateResourceConfigResponse
+import software.amazon.awssdk.services.config.paginators.SelectAggregateResourceConfigIterable
+
+import java.util.Optional
+
+class AwsConfigAccountSupplierSuite extends FunSuite with TestKitBase {
+
+  override implicit def system: ActorSystem = ActorSystem("Test")
+
+  var registry: Registry = null
+  var clientFactory: AwsClientFactory = null
+  var client: ConfigClient = null
+  var config: Config = null
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    registry = new DefaultRegistry()
+    clientFactory = mock[AwsClientFactory]
+    client = mock[ConfigClient]
+    when(
+      clientFactory.getInstance(
+        anyString,
+        any[Class[ConfigClient]],
+        anyString,
+        any[Optional[Region]]
+      )
+    ).thenReturn(client)
+    config = ConfigFactory.parseString("""
+        |atlas.cloudwatch.account.supplier.aws {
+        |  aggregator = "agg1"
+        |  aggregator-region = "us-west-2"
+        |  regions = ["us-west-1", "us-west-2"]
+        |  config-account = "042"
+        |  is-allow = false
+        |  accounts = []
+        |}
+      """.stripMargin)
+  }
+
+  test("success") {
+    mockResp()
+    val accts = new AwsConfigAccountSupplier(config, registry, clientFactory)(system)
+    assertEquals(accts.filtered.size, 3)
+    var regions = accts.filtered("123")
+    assertEquals(regions.size, 2)
+    assertEquals(regions(Region.US_WEST_1), Set("AWS/EC2", "AWS/S3"))
+    assertEquals(regions(Region.US_WEST_2), Set("AWS/EC2"))
+    regions = accts.filtered("456")
+    assertEquals(regions.size, 2)
+    assertEquals(regions(Region.US_WEST_1), Set("AWS/RDS", "AWS/S3"))
+    assertEquals(regions(Region.US_WEST_2), Set("AWS/S3"))
+    regions = accts.filtered("789")
+    assertEquals(regions.size, 1)
+    assertEquals(regions(Region.US_WEST_1), Set("AWS/EC2"))
+    assertCounters()
+  }
+
+  test("empty response") {
+    mockResp(empty = true)
+    val accts = new AwsConfigAccountSupplier(config, registry, clientFactory)(system)
+    assertEquals(accts.filtered.size, 0)
+    assertCounters()
+  }
+
+  test("exception on startup") {
+    mockResp(exception = true)
+    intercept[RuntimeException] {
+      new AwsConfigAccountSupplier(config, registry, clientFactory)(system)
+    }
+    assertCounters(ex = 1)
+  }
+
+  test("malformed") {
+    mockResp(malformed = true)
+    val accts = new AwsConfigAccountSupplier(config, registry, clientFactory)(system)
+    assertEquals(accts.filtered.size, 3)
+    var regions = accts.filtered("123")
+    assertEquals(regions.size, 2)
+    assertEquals(regions(Region.US_WEST_1), Set("AWS/EC2", "AWS/S3"))
+    assertEquals(regions(Region.US_WEST_2), Set("AWS/EC2"))
+    regions = accts.filtered("456")
+    assertEquals(regions.size, 2)
+    assertEquals(regions(Region.US_WEST_1), Set("AWS/RDS"))
+    assertEquals(regions(Region.US_WEST_2), Set("AWS/S3"))
+    regions = accts.filtered("789")
+    assertEquals(regions.size, 1)
+    assertEquals(regions(Region.US_WEST_1), Set("AWS/EC2"))
+    assertCounters(parse = 1)
+  }
+
+  test("allow list") {
+    config = ConfigFactory.parseString("""
+        |atlas.cloudwatch.account.supplier.aws {
+        |  aggregator = "agg1"
+        |  aggregator-region = "us-west-2"
+        |  regions = ["us-west-1", "us-west-2"]
+        |  config-account = "042"
+        |  is-allow = true
+        |  accounts = ["456"]
+        |}
+      """.stripMargin)
+    mockResp()
+    val accts = new AwsConfigAccountSupplier(config, registry, clientFactory)(system)
+    assertEquals(accts.filtered.size, 1)
+    val regions = accts.filtered("456")
+    assertEquals(regions.size, 2)
+    assertEquals(regions(Region.US_WEST_1), Set("AWS/RDS", "AWS/S3"))
+    assertEquals(regions(Region.US_WEST_2), Set("AWS/S3"))
+  }
+
+  test("deny list") {
+    config = ConfigFactory.parseString("""
+        |atlas.cloudwatch.account.supplier.aws {
+        |  aggregator = "agg1"
+        |  aggregator-region = "us-west-2"
+        |  regions = ["us-west-1", "us-west-2"]
+        |  config-account = "042"
+        |  is-allow = false
+        |  accounts = ["456"]
+        |}
+      """.stripMargin)
+    mockResp()
+    val accts = new AwsConfigAccountSupplier(config, registry, clientFactory)(system)
+    assertEquals(accts.filtered.size, 2)
+    var regions = accts.filtered("123")
+    assertEquals(regions.size, 2)
+    assertEquals(regions(Region.US_WEST_1), Set("AWS/EC2", "AWS/S3"))
+    assertEquals(regions(Region.US_WEST_2), Set("AWS/EC2"))
+    regions = accts.filtered("789")
+    assertEquals(regions.size, 1)
+    assertEquals(regions(Region.US_WEST_1), Set("AWS/EC2"))
+    assertCounters()
+  }
+
+  test("filter global") {
+    config = ConfigFactory.parseString("""
+        |atlas.cloudwatch.account.supplier.aws {
+        |  aggregator = "agg1"
+        |  aggregator-region = "us-west-2"
+        |  regions = ["global"]
+        |  config-account = "042"
+        |  is-allow = false
+        |  accounts = []
+        |}
+      """.stripMargin)
+    mockResp()
+    val accts = new AwsConfigAccountSupplier(config, registry, clientFactory)(system)
+    assertEquals(accts.filtered.size, 1)
+    val regions = accts.filtered("456")
+    assertEquals(regions.size, 1)
+    assertEquals(regions(Region.AWS_GLOBAL), Set("AWS/IAM"))
+  }
+
+  def mockResp(
+    empty: Boolean = false,
+    exception: Boolean = false,
+    malformed: Boolean = false
+  ): Unit = {
+    val resp = SelectAggregateResourceConfigResponse
+      .builder()
+      .results(
+        "{\"COUNT(*)\":16,\"accountId\":\"123\",\"resourceType\":\"AWS::EC2::InternetGateway\",\"awsRegion\":\"us-west-1\"}",
+        "{\"COUNT(*)\":16,\"accountId\":\"123\",\"resourceType\":\"AWS::S3::Bucket\",\"awsRegion\":\"us-west-1\"}",
+        "{\"COUNT(*)\":2,\"accountId\":\"123\",\"resourceType\":\"AWS::EC2::InternetGateway\",\"awsRegion\":\"us-west-2\"}",
+        "{\"COUNT(*)\":8,\"accountId\":\"456\",\"resourceType\":\"AWS::RDS::DBSecurityGroup\",\"awsRegion\":\"us-west-1\"}",
+        "{\"COUNT(*)\":8,\"accountId\":\"456\",\"resourceType\":\"AWS::IAM::Policy\",\"awsRegion\":\"global\"}",
+        "{\"COUNT(*)\":3,\"accountId\":\"456\",\"resourceType\":\"AWS::S3::Bucket\",\"awsRegion\":\"us-west-2\"}",
+        if (malformed) "{\"COUNT(*)\":2,\"accountId\":\"456\",\"reso"
+        else
+          "{\"COUNT(*)\":2,\"accountId\":\"456\",\"resourceType\":\"AWS::S3::Bucket\",\"awsRegion\":\"us-west-1\"}",
+        "{\"COUNT(*)\":20,\"accountId\":\"789\",\"resourceType\":\"AWS::EC2::InternetGateway\",\"awsRegion\":\"us-west-1\"}"
+      )
+      .build
+    val emptyResp = SelectAggregateResourceConfigResponse.builder().build
+    if (exception) {
+      when(client.selectAggregateResourceConfig(any[SelectAggregateResourceConfigRequest]))
+        .thenThrow(new RuntimeException("test"))
+    } else if (empty) {
+      when(client.selectAggregateResourceConfig(any[SelectAggregateResourceConfigRequest]))
+        .thenReturn(emptyResp)
+    } else {
+      when(client.selectAggregateResourceConfig(any[SelectAggregateResourceConfigRequest]))
+        .thenReturn(resp)
+    }
+    when(client.selectAggregateResourceConfigPaginator(any[SelectAggregateResourceConfigRequest]))
+      .thenAnswer((req: SelectAggregateResourceConfigRequest) =>
+        new SelectAggregateResourceConfigIterable(client, req)
+      )
+  }
+
+  def assertCounters(
+    parse: Long = 0,
+    ex: Long = 0
+  ): Unit = {
+    assertEquals(
+      registry
+        .counter(
+          "atlas.cloudwatch.account.supplier.aws.parseException",
+          "exception",
+          "JsonEOFException"
+        )
+        .count(),
+      parse
+    )
+    assertEquals(
+      registry
+        .counter(
+          "atlas.cloudwatch.account.supplier.aws.loadException",
+          "exception",
+          "RuntimeException"
+        )
+        .count(),
+      ex
+    )
+  }
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchPollerSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchPollerSuite.scala
@@ -110,9 +110,7 @@ class CloudWatchPollerSuite extends FunSuite with TestKitBase {
       )
     ).thenReturn(client)
     when(accountSupplier.accounts).thenReturn(
-      Future(
-        Map(account -> List(Region.US_EAST_1))
-      )
+      Map(account -> Map(Region.US_EAST_1 -> Set("AWS/UT1", "AWS/UTRedis", "AWS/UTQueryFilter")))
     )
   }
 
@@ -233,7 +231,7 @@ class CloudWatchPollerSuite extends FunSuite with TestKitBase {
   }
 
   test("poll accounts exception") {
-    when(accountSupplier.accounts).thenReturn(Future.failed(new RuntimeException("test")))
+    when(accountSupplier.accounts).thenThrow(new RuntimeException("test"))
     val poller = getPoller
     val flag = new AtomicBoolean()
     val full = Promise[List[CloudWatchPoller#Poller]]()
@@ -253,7 +251,7 @@ class CloudWatchPollerSuite extends FunSuite with TestKitBase {
   }
 
   test("poll empty accounts") {
-    when(accountSupplier.accounts).thenReturn(Future(Map.empty))
+    when(accountSupplier.accounts).thenReturn(Map.empty)
     val poller = getPoller
     val flag = new AtomicBoolean()
     val full = Promise[List[CloudWatchPoller#Poller]]()

--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ lazy val `atlas-cloudwatch` = project
     Dependencies.atlasJson,
     Dependencies.atlasSpringAkka,
     Dependencies.aws2CloudWatch,
+    Dependencies.aws2Config,
     Dependencies.frigga,
     Dependencies.iepDynConfig,
     Dependencies.iepSpring,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,6 +45,7 @@ object Dependencies {
   val atlasWebApi        = "com.netflix.atlas_v1" %% "atlas-webapi" % atlas
   val aws2AutoScaling    = "software.amazon.awssdk" % "autoscaling" % aws2
   val aws2CloudWatch     = "software.amazon.awssdk" % "cloudwatch" % aws2
+  val aws2Config         = "software.amazon.awssdk" % "config" % aws2
   val aws2DynamoDB       = "software.amazon.awssdk" % "dynamodb" % aws2
   val aws2EC2            = "software.amazon.awssdk" % "ec2" % aws2
   val aws2S3             = "software.amazon.awssdk" % "s3" % aws2


### PR DESCRIPTION
The supplier polls an AWS Config database for the list of accounts and resources active in each region to avoid manual configuration and mappings. This change re-works the AwsAccountSupplier to return a map of accounts to regions to namespaces so we can only poll for the data that should be there, saving a bit of money. Also drops the future from that interface.