### PR TITLE
atlas cloudwatch: Poll flag per account and region.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -40,19 +40,6 @@ iep.leader {
 
 atlas {
 
-  poller {
-
-    // How often to collect data from the pollers.
-    frequency = 1 m
-
-    pollers = ${?atlas.poller.pollers} [
-      {
-        class = "com.netflix.atlas.cloudwatch.CloudWatchPoller"
-        name = "cloudwatch"
-      }
-    ]
-  }
-
   redis-cluster {
     # number of keys to scan in each call
     scan.count = 500
@@ -127,10 +114,7 @@ atlas {
     poller {
       // How often to run the polling scheduler to see if a polling run needs to
       // execute.
-      frequency = 1m
-
-      // How many threads to use for the polling executor.
-      num-threads = 8
+      frequency = 5m
 
       # The period configured for namespaces that will be polled instead of sent via
       # Firehose. So far we only care about S3 aggregates that are reported daily. If we


### PR DESCRIPTION
This lets us recover a big more graceffully if a particular account or region has an issue when polling. Instead of tracking a flag and a key in redis for the whole job (all accounts and regions) track per account and region combo so that we can retry only those that fail. Also set the check for polling state to every 5 minutes instead.