### PR TITLE
atlas cloudwatch: Fix queue stack name.

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
@@ -95,7 +95,7 @@ class PublishRouter(
             routes += defaultKey -> new PublishQueue(
               config.getConfig("atlas.cloudwatch.account.routing"),
               registry,
-              NetflixEnvironment.region(),
+              stack + "-" + NetflixEnvironment.region(),
               baseURI
                 .replaceAll("\\$\\{STACK\\}", stack)
                 .replaceAll("\\$\\{REGION}", NetflixEnvironment.region()),


### PR DESCRIPTION
For regions, it was only posting the region, not the stack. Now it will appear correctly in the metrics.