### PR TITLE
atlas cloudwatch: update media metrics.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/mediaconnect.conf
+++ b/atlas-cloudwatch/src/main/resources/mediaconnect.conf
@@ -49,6 +49,54 @@ atlas {
       ]
     }
 
+    mediaconnect-output = {
+      namespace = "AWS/MediaConnect"
+      period = 1m
+      end-period-offset = 4
+
+      dimensions = [
+        "OutputARN",
+      ]
+
+      metrics = [
+        {
+          name = "ConnectedOutputs"
+          alias = "aws.mediaconnect.connectedOutputs"
+          conversion = "max"
+        },
+        {
+          name = "OutputConnected"
+          alias = "aws.mediaconnect.outputConnected"
+          conversion = "max"
+        },
+        {
+          name = "OutputDisconnections"
+          alias = "aws.mediaconnect.outputDisconnections"
+          conversion = "sum,rate"
+        },
+        {
+          name = "OutputDroppedPayloads"
+          alias = "aws.mediaconnect.outputDroppedPayloads"
+          conversion = "sum,rate"
+        },
+        {
+          name = "OutputLatePayloads"
+          alias = "aws.mediaconnect.outputLatePayloads"
+          conversion = "sum,rate"
+        },
+        {
+          name = "OutputTotalPayloads"
+          alias = "aws.mediaconnect.outputTotalPayloads"
+          conversion = "sum,rate"
+        },
+        {
+          name = "OutputTotalBytes"
+          alias = "aws.mediaconnect.outputTotalBytes"
+          conversion = "sum,rate"
+        }
+      ]
+    }
+
     mediaconnect-source = {
       namespace = "AWS/MediaConnect"
       period = 1m
@@ -59,6 +107,11 @@ atlas {
       ]
 
       metrics = [
+        {
+          name = "SourceBitRate"
+          alias = "aws.mediaconnect.sourceBitRate"
+          conversion = "max"
+        },
         {
           name = "SourceDisconnections"
           alias = "aws.mediaconnect.sourceDisconnections"
@@ -95,6 +148,60 @@ atlas {
             {
               key = "id"
               value = "not-recovered"
+            }
+          ]
+        },
+        {
+          name = "SourceFECPackets"
+          alias = "aws.mediaconnect.sourcePackets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "fec"
+            }
+          ]
+        },
+        {
+          name = "SourceFECRecovered"
+          alias = "aws.mediaconnect.sourcePackets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "fec-recovered"
+            }
+          ]
+        },
+        {
+          name = "SourceMergeActive"
+          alias = "aws.mediaconnect.sourceMergeActive"
+          conversion = "max"
+        },
+        {
+          name = "SourceMergeLatency"
+          alias = "aws.mediaconnect.sourceMergeLatency"
+          conversion = "timer"
+        },
+        {
+          name = "SourceMergeStatusWarnMismatch"
+          alias = "aws.mediaconnect.sourceMergeWarningStatus"
+          conversion = "sum,rate"
+          tags =[
+            {
+              key = "id"
+              value = "mismatch"
+            }
+          ]
+        },
+        {
+          name = "SourceMergeStatusWarnSolo"
+          alias = "aws.mediaconnect.sourceMergeWarningStatus"
+          conversion = "sum,rate"
+          tags =[
+            {
+              key = "id"
+              value = "solo"
             }
           ]
         },
@@ -197,6 +304,11 @@ atlas {
           alias = "aws.mediaconnect.sourceRoundTripTime"
           conversion = "timer"
           tags = []
+        },
+        {
+          name = "SourceSelected"
+          alias = "aws.mediaconnect.sourceSelected"
+          conversion = "max"
         },
         {
           name = "SourceTransportError"

--- a/atlas-cloudwatch/src/main/resources/medialive.conf
+++ b/atlas-cloudwatch/src/main/resources/medialive.conf
@@ -90,6 +90,11 @@ atlas {
           tags = []
         },
         {
+          name = "FillMsec"
+          alias = "aws.medialive.fillMsec"
+          conversion = "max"
+        },
+        {
           name = "Output4xxErrors"
           alias = "aws.medialive.outputError"
           conversion = "sum,rate"
@@ -111,6 +116,21 @@ atlas {
             }
           ]
         },
+        {
+          name = "OutputAudioLevelLkfs"
+          alias = "aws.medialive.outputAudioLevelLKFS"
+          conversion = "min"
+        },
+        {
+          name = "OutputAudioLevelLkfs"
+          alias = "aws.medialive.outputAudioLevelLKFS"
+          conversion = "max"
+        },
+        {
+          name = "SvqTime"
+          alias = "aws.medialive.svqTime"
+          conversion = "max"
+        }
       ]
     }
 
@@ -147,6 +167,11 @@ atlas {
             }
           ]
         },
+        {
+          name = "PipelinesLocked"
+          alias = "aws.medialive.pipelineLocked"
+          conversion = "max"
+        }
       ]
     }
   }

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -196,6 +196,16 @@ atlas {
         },
         {
           # The tag is too long for default Atlas tag values in a number of cases.
+          name = "OutputARN"
+          directives = [
+            {
+              pattern = "^arn:aws:mediaconnect:(.*)"
+              alias = "aws.output"
+            }
+          ]
+        },
+        {
+          # The tag is too long for default Atlas tag values in a number of cases.
           name = "SourceARN"
           directives = [
             {
@@ -363,10 +373,6 @@ atlas {
         {
           name = "Operation"
           alias = "aws.op"
-        },
-        {
-          name = "OutputARN"
-          alias = "aws.output"
         },
         {
           name = "OutputGroupName"


### PR DESCRIPTION
Add metrics for mediaconnect and medialive.