### PR TITLE
atlas cloudwatch: rename fillMsec

### DIFF
--- a/atlas-cloudwatch/src/main/resources/medialive.conf
+++ b/atlas-cloudwatch/src/main/resources/medialive.conf
@@ -148,8 +148,8 @@ atlas {
       metrics = [
         {
           name = "FillMsec"
-          alias = "aws.medialive.fillMsec"
-          conversion = "max"
+          alias = "aws.medialive.fills"
+          conversion = "timer"
         },
         {
           name = "NetworkIn"

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -279,6 +279,10 @@ atlas {
           alias = "aws.channel"
         },
         {
+          name = "ChannelId"
+          alias = "aws.channel"
+        },
+        {
           name = "ClientId"
           alias = "aws.client"
         },


### PR DESCRIPTION
And fix ChannelId so it converts to aws.channel