### PR TITLE
cloudwatch: attempt mockito fix for #462

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,6 @@ lazy val `atlas-cloudwatch` = project
     Dependencies.atlasWebApi % "test",
     Dependencies.akkaHttpTestkit % "test",
     Dependencies.akkaTestkit % "test",
-    Dependencies.mockitoCore % "test",
     Dependencies.mockitoScala % "test",
     Dependencies.munit % "test"
   ))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,8 +71,7 @@ object Dependencies {
   val log4jJcl           = "org.apache.logging.log4j" % "log4j-jcl" % log4j
   val log4jJul           = "org.apache.logging.log4j" % "log4j-jul" % log4j
   val log4jSlf4j         = "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4j
-  val mockitoCore        = "org.mockito" % "mockito-core" % "3.12.4"
-  val mockitoScala       = "org.mockito" % "mockito-scala_2.13" % "1.10.4"
+  val mockitoScala       = "org.mockito" % "mockito-scala_2.13" % "1.17.4"
   val munit              = "org.scalameta" %% "munit" % "0.7.29"
   val openHFT            = "net.openhft" % "zero-allocation-hashing" % "0.16"
   val protobuf           = "com.google.protobuf" % "protobuf-java" % "3.22.2"


### PR DESCRIPTION
Mockito-scala docs excplicity ask to not declare a dependency on mockito-core, instead let mockito-scala bring it in. I was likely including a much older version than needed and could have caused load ordering issues.