### PR TITLE
atlas cloudwatch: remove polling filter.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/ec2.conf
+++ b/atlas-cloudwatch/src/main/resources/ec2.conf
@@ -190,6 +190,7 @@ atlas {
       namespace = "AWS/EC2"
       period = 5m
       end-period-offset = 4
+      poll-offset = 5m
 
       dimensions = [
         "Per-VPC Metrics",

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -115,11 +115,6 @@ atlas {
       // How often to run the polling scheduler to see if a polling run needs to
       // execute.
       frequency = 5m
-
-      # The period configured for namespaces that will be polled instead of sent via
-      # Firehose. So far we only care about S3 aggregates that are reported daily. If we
-      # need additional periods, we'll need to tweak the code.
-      period-filter = 1d
     }
 
     # TEMP: Used while testing cloud watch streaming to prepend "TEST." to metrics in order to compare against


### PR DESCRIPTION
Allows for polling more frequently, e.g. every 5m for the EC2 VPC metrics.