### PR TITLE
atlas cloudwatch: Fixes for Media* metrics

### DIFF
--- a/atlas-cloudwatch/src/main/resources/medialive.conf
+++ b/atlas-cloudwatch/src/main/resources/medialive.conf
@@ -6,7 +6,7 @@ atlas {
     medialive-audio = {
       namespace = "AWS/MediaLive"
       period = 1m
-      end-period-offset = 3
+      end-period-offset = 4
 
       dimensions = [
         "AudioDescriptionName",
@@ -95,7 +95,7 @@ atlas {
     medialive-output = {
       namespace = "AWS/MediaLive"
       period = 1m
-      end-period-offset = 3
+      end-period-offset = 4
 
       dimensions = [
         "ChannelId",
@@ -138,7 +138,7 @@ atlas {
     medialive-network = {
       namespace = "AWS/MediaLive"
       period = 1m
-      end-period-offset = 3
+      end-period-offset = 4
 
       dimensions = [
         "ChannelId",

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -204,7 +204,7 @@ atlas {
           name = "SourceARN"
           directives = [
             {
-              pattern = "^arn:aws:mediaconnect:(.*)"
+              pattern = "arn_aws_\\w+_([a-z\\-0-9]+)_\\d+_source_\\d-[a-zA-Z0-9]+-[a-zA-Z0-9]+_(.*)"
               alias = "aws.source"
             }
           ]
@@ -214,7 +214,7 @@ atlas {
           name = "FlowARN"
           directives = [
             {
-              pattern = "^arn:aws:mediaconnect:(.*)"
+              pattern = "arn_aws_\\w+_([a-z\\-0-9]+)_\\d+_flow_\\d-[a-zA-Z0-9]+-[a-zA-Z0-9]+_(.*)"
               alias = "aws.flow"
             }
           ]
@@ -330,10 +330,6 @@ atlas {
           alias = "aws.filter"
         },
         {
-          name = "FlowARN"
-          alias = "aws.flow"
-        },
-        {
           name = "FunctionName"
           alias = "aws.function"
         },
@@ -416,10 +412,6 @@ atlas {
         {
           name = "ServiceName"
           alias = "aws.service"
-        },
-        {
-          name = "SourceARN"
-          alias = "aws.source"
         },
         {
           name = "StorageType"

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/DefaultTagger.scala
@@ -110,7 +110,7 @@ object DefaultTagger {
     def unapply(extractorDirective: (Regex, String)): Option[(String, String)] = {
       val (regex, alias) = extractorDirective
       regex.findFirstMatchIn(rawValue).map { matches =>
-        val value = if (matches.groupCount > 0) matches.group(1) else rawValue
+        val value = if (matches.groupCount > 0) matches.subgroups.mkString("-") else rawValue
         alias -> value
       }
     }


### PR DESCRIPTION
Add support for extracting multiple groups from extractors and combine them with a hyphen to shorten the MediaConnect source and flow ARNs. Update the regexes for those configs.
Also remove duplicate SourceARN and FlowARN mappings that were conflicting with the extractors, causing some metrics to report the fulle string and others to use the regex.
Bump MediaLive metrics to 4 minute offset.