### PR TITLE
atlas cloudwatch: Fix mediaconnect ARN pattern.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -204,7 +204,7 @@ atlas {
           name = "SourceARN"
           directives = [
             {
-              pattern = "arn_aws_\\w+_([a-z\\-0-9]+)_\\d+_source_\\d-[a-zA-Z0-9]+-[a-zA-Z0-9]+_(.*)"
+              pattern = "arn:aws:\\w+:([a-z\\-0-9]+):\\d+:source:\\d-[a-zA-Z0-9]+-[a-zA-Z0-9]+:(.*)"
               alias = "aws.source"
             }
           ]
@@ -214,7 +214,7 @@ atlas {
           name = "FlowARN"
           directives = [
             {
-              pattern = "arn_aws_\\w+_([a-z\\-0-9]+)_\\d+_flow_\\d-[a-zA-Z0-9]+-[a-zA-Z0-9]+_(.*)"
+              pattern = "arn:aws:\\w+:([a-z\\-0-9]+):\\d+_flow_\\d-[a-zA-Z0-9]+-[a-zA-Z0-9]+:(.*)"
               alias = "aws.flow"
             }
           ]

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/DefaultTaggerSuite.scala
@@ -117,7 +117,7 @@ class DefaultTaggerSuite extends FunSuite {
         |    name = "MediaConnectARN"
         |    directives = [
         |      {
-        |        pattern = "arn_aws_\\w+_([a-z\\-0-9]+)_\\d+_source_\\d-[a-zA-Z0-9]+-[a-zA-Z0-9]+_(.*)"
+        |        pattern = "arn:aws:\\w+:([a-z\\-0-9]+):\\d+:source:\\d-[a-zA-Z0-9]+-[a-zA-Z0-9]+:(.*)"
         |      }
         |    ]
         |  }
@@ -142,7 +142,7 @@ class DefaultTaggerSuite extends FunSuite {
         .builder()
         .name("MediaConnectARN")
         .value(
-          "arn_aws_mediaconnect_us-west-1_123456789011_source_1-aAbBcCdDeEfFgGHh-aA913dabeef2_test-Episode1-1-ABCDE"
+          "arn:aws:mediaconnect:us-west-1:123456789011:source:1-aAbBcCdDeEfFgGHh-aA913dabeef2:test-Episode1-1-ABCDE"
         )
         .build()
     )


### PR DESCRIPTION
Needed to match the pre-character-substitution string.