### PR TITLE
atlas cloudwatch: MediaConnect ARN tuning.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -194,7 +194,7 @@ atlas {
           name = "OutputARN"
           directives = [
             {
-              pattern = "^arn:aws:mediaconnect:(.*)"
+              pattern = "arn:aws:\\w+:([a-z\\-0-9]+):\\d+:output:\\d-[a-zA-Z0-9]+-[a-zA-Z0-9]+:(.*)"
               alias = "aws.output"
             }
           ]
@@ -214,7 +214,7 @@ atlas {
           name = "FlowARN"
           directives = [
             {
-              pattern = "arn:aws:\\w+:([a-z\\-0-9]+):\\d+_flow_\\d-[a-zA-Z0-9]+-[a-zA-Z0-9]+:(.*)"
+              pattern = "arn:aws:\\w+:([a-z\\-0-9]+):\\d+:flow:\\d-[a-zA-Z0-9]+-[a-zA-Z0-9]+:(.*)"
               alias = "aws.flow"
             }
           ]


### PR DESCRIPTION
Fix typo in the pattern for FlowARN and apply the pattern to the OutputARN