### PR TITLE
atlas cloudwatch: Update FSx operation latency.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/fsx.conf
+++ b/atlas-cloudwatch/src/main/resources/fsx.conf
@@ -71,7 +71,7 @@ atlas {
         },
         {
           name = "DataReadOperationTime"
-          alias = "aws.fsx.volume.operation.latency"
+          alias = "aws.fsx.volume.operation.totalTime"
           conversion = "timer"
           tags = [
             {
@@ -82,7 +82,7 @@ atlas {
         },
         {
           name = "DataWriteOperationTime"
-          alias = "aws.fsx.volume.operation.latency"
+          alias = "aws.fsx.volume.operation.totalTime"
           conversion = "timer"
           tags = [
             {
@@ -93,7 +93,7 @@ atlas {
         },
         {
           name = "MetadataOperationTime"
-          alias = "aws.fsx.volume.operation.latency"
+          alias = "aws.fsx.volume.operation.totalTime"
           conversion = "timer"
           tags = [
             {


### PR DESCRIPTION
Changing it to `aws.fsx.volume.operation.totalTime` to better reflect the fact that it is a total time to complete the operation, not a latency value that should be small.