### PR TITLE
atlas cloudwatch: FSx operations to timer.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/fsx.conf
+++ b/atlas-cloudwatch/src/main/resources/fsx.conf
@@ -44,6 +44,14 @@ atlas {
             {
               key = "id"
               value = "read"
+            },
+            {
+              key = "statistic"
+              value = "count"
+            },
+            {
+              key = "atlas.dstype"
+              value = "sum"
             }
           ]
         },
@@ -55,6 +63,14 @@ atlas {
             {
               key = "id"
               value = "write"
+            },
+            {
+              key = "statistic"
+              value = "count"
+            },
+            {
+              key = "atlas.dstype"
+              value = "sum"
             }
           ]
         },
@@ -66,12 +82,20 @@ atlas {
             {
               key = "id"
               value = "metadata"
+            },
+            {
+              key = "statistic"
+              value = "count"
+            },
+            {
+              key = "atlas.dstype"
+              value = "sum"
             }
           ]
         },
         {
           name = "DataReadOperationTime"
-          alias = "aws.fsx.volume.operation.totalTime"
+          alias = "aws.fsx.volume.operations"
           conversion = "timer"
           tags = [
             {
@@ -82,7 +106,7 @@ atlas {
         },
         {
           name = "DataWriteOperationTime"
-          alias = "aws.fsx.volume.operation.totalTime"
+          alias = "aws.fsx.volume.operations"
           conversion = "timer"
           tags = [
             {
@@ -93,7 +117,7 @@ atlas {
         },
         {
           name = "MetadataOperationTime"
-          alias = "aws.fsx.volume.operation.totalTime"
+          alias = "aws.fsx.volume.operations"
           conversion = "timer"
           tags = [
             {


### PR DESCRIPTION
This will convert the timer metric to the same name as the count and allow the two to be combined for `:dist-avg`