### PR TITLE
atlas cloudwatch: Allow EC2 for streaming.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -491,7 +491,7 @@ atlas {
       "dynamodb-table-5m",
       "dynamodb-table-ops",
       "dynamodb-capacity",
-      //"ec2",
+      "ec2",
       "ec2-api",
       "ec2-credit",
       "ec2-imdsv2",


### PR DESCRIPTION
Small accounts with non-Netflix AMIs need EC2 CPU and network since they can't install our system agent. We'll disable the EC2 filter for those accounts.