### PR TITLE
rename classes with Akka in the name

### DIFF
--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AggrConfig.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AggrConfig.scala
@@ -75,7 +75,7 @@ class AggrConfig(
   override def validTagCharacters(): String = null
 
   override def publisher(): Publisher = {
-    new AkkaPublisher(registry, this, system)
+    new PekkoPublisher(registry, this, system)
   }
 
   override def evaluatorStepSize(): Long = {

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PekkoPublisher.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PekkoPublisher.scala
@@ -59,14 +59,14 @@ import scala.util.Try
 import scala.util.Using
 
 /**
-  * Use Akka-Http client for sending data instead of default which is based on the
+  * Use Pekko-Http client for sending data instead of default which is based on the
   * URLConnection class built into the JDK. This helps reduce the number of threads
   * needed overall.
   */
-class AkkaPublisher(registry: Registry, config: AggrConfig, implicit val system: ActorSystem)
+class PekkoPublisher(registry: Registry, config: AggrConfig, implicit val system: ActorSystem)
     extends Publisher {
 
-  import AkkaPublisher.*
+  import PekkoPublisher.*
 
   private val atlasUri = Uri(config.uri())
   private val evalUri = Uri(config.evalUri())
@@ -129,7 +129,7 @@ class AkkaPublisher(registry: Registry, config: AggrConfig, implicit val system:
   }
 }
 
-object AkkaPublisher {
+object PekkoPublisher {
 
   private val VoidInstance = null.asInstanceOf[Void]
 

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
@@ -60,7 +60,7 @@ import scala.util.Success
   * calls to CloudWatch will only happen once a day to keep polling costs down.
   *
   * TODO - Add support for other frequencies if we need them.
-  * TODO - Akka/Pekka streamify it. It should be simple but I had a hard time parallelizing
+  * TODO - Pekko/Pekka streamify it. It should be simple but I had a hard time parallelizing
   * the calls and backpressuring properly, particularly with the async AWS client.
   */
 class CloudWatchPoller(

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/LocalCloudWatchMetricsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/LocalCloudWatchMetricsProcessor.scala
@@ -41,7 +41,7 @@ import scala.concurrent.Future
   * @param publishRouter
   *     The non-null publisher to report to.
   * @param system
-  *     The Akka system we use for scheduling.
+  *     The Pekko system we use for scheduling.
   */
 class LocalCloudWatchMetricsProcessor(
   config: Config,

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishQueue.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishQueue.scala
@@ -24,7 +24,7 @@ import org.apache.pekko.http.scaladsl.model.HttpResponse
 import org.apache.pekko.stream.scaladsl.Keep
 import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.util.ByteString
-import com.netflix.atlas.pekko.AkkaHttpClient
+import com.netflix.atlas.pekko.PekkoHttpClient
 import com.netflix.atlas.pekko.CustomMediaTypes
 import com.netflix.atlas.pekko.StreamOps
 import com.netflix.atlas.core.model.Datapoint
@@ -57,7 +57,7 @@ class PublishQueue(
   registry: Registry,
   val stack: String,
   val uri: String,
-  httpClient: AkkaHttpClient,
+  httpClient: PekkoHttpClient,
   scheduler: ScheduledExecutorService
 )(implicit system: ActorSystem)
     extends StrictLogging {

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
@@ -16,7 +16,7 @@
 package com.netflix.atlas.cloudwatch
 
 import org.apache.pekko.actor.ActorSystem
-import com.netflix.atlas.pekko.AkkaHttpClient
+import com.netflix.atlas.pekko.PekkoHttpClient
 import com.netflix.atlas.cloudwatch.PublishRouter.defaultKey
 import com.netflix.iep.config.NetflixEnvironment
 import com.netflix.spectator.api.Registry
@@ -30,7 +30,7 @@ class PublishRouter(
   config: Config,
   registry: Registry,
   tagger: Tagger,
-  httpClient: AkkaHttpClient
+  httpClient: PekkoHttpClient
 )(implicit system: ActorSystem)
     extends StrictLogging {
 

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/spring/CloudWatchConfiguration.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/spring/CloudWatchConfiguration.scala
@@ -16,8 +16,8 @@
 package com.netflix.atlas.spring
 
 import org.apache.pekko.actor.ActorSystem
-import com.netflix.atlas.pekko.AkkaHttpClient
-import com.netflix.atlas.pekko.DefaultAkkaHttpClient
+import com.netflix.atlas.pekko.PekkoHttpClient
+import com.netflix.atlas.pekko.DefaultPekkoHttpClient
 import com.netflix.atlas.cloudwatch.AwsAccountSupplier
 import com.netflix.atlas.cloudwatch.CloudWatchDebugger
 import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor
@@ -86,7 +86,7 @@ class CloudWatchConfiguration extends StrictLogging {
     config: Config,
     registry: Optional[Registry],
     tagger: Tagger,
-    httpClient: AkkaHttpClient,
+    httpClient: PekkoHttpClient,
     system: ActorSystem
   ): PublishRouter = {
     val r = registry.orElseGet(() => globalRegistry())
@@ -128,8 +128,8 @@ class CloudWatchConfiguration extends StrictLogging {
   @Bean
   def httpClient(
     system: ActorSystem
-  ): DefaultAkkaHttpClient = {
-    new DefaultAkkaHttpClient("PubProxy")(system)
+  ): DefaultPekkoHttpClient = {
+    new DefaultPekkoHttpClient("PubProxy")(system)
   }
 
   /**

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/PublishQueueSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/PublishQueueSuite.scala
@@ -25,7 +25,7 @@ import org.apache.pekko.http.scaladsl.model.ResponseEntity
 import org.apache.pekko.http.scaladsl.model.StatusCode
 import org.apache.pekko.http.scaladsl.model.StatusCodes
 import org.apache.pekko.testkit.TestKitBase
-import com.netflix.atlas.pekko.AkkaHttpClient
+import com.netflix.atlas.pekko.PekkoHttpClient
 import com.netflix.atlas.pekko.CustomMediaTypes
 import com.netflix.atlas.core.model.Datapoint
 import com.netflix.atlas.json.Json
@@ -55,7 +55,7 @@ class PublishQueueSuite extends FunSuite with TestKitBase {
   override implicit def system: ActorSystem = ActorSystem(getClass.getSimpleName)
 
   var registry: Registry = null
-  var httpClient = mock[AkkaHttpClient]
+  var httpClient = mock[PekkoHttpClient]
   var httpCaptor = ArgCaptor[HttpRequest]
   var scheduler = mock[ScheduledExecutorService]
   val timestamp = 1672531200000L
@@ -64,7 +64,7 @@ class PublishQueueSuite extends FunSuite with TestKitBase {
 
   override def beforeEach(context: BeforeEach): Unit = {
     registry = new DefaultRegistry()
-    httpClient = mock[AkkaHttpClient]
+    httpClient = mock[PekkoHttpClient]
     httpCaptor = ArgCaptor[HttpRequest]
     scheduler = mock[ScheduledExecutorService]
   }

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/PublishRouterSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/PublishRouterSuite.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.cloudwatch
 
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.testkit.TestKitBase
-import com.netflix.atlas.pekko.AkkaHttpClient
+import com.netflix.atlas.pekko.PekkoHttpClient
 import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.timestamp
 import com.netflix.atlas.core.model.Datapoint
 import com.netflix.spectator.api.DefaultRegistry
@@ -33,7 +33,7 @@ class PublishRouterSuite extends FunSuite with TestKitBase {
   var registry: Registry = new DefaultRegistry()
   val config = ConfigFactory.load()
   val tagger = new NetflixTagger(config.getConfig("atlas.cloudwatch.tagger"))
-  val httpClient = mock[AkkaHttpClient]
+  val httpClient = mock[PekkoHttpClient]
   val router = new PublishRouter(config, registry, tagger, httpClient)
 
   test("initialize") {

--- a/atlas-druid/src/main/resources/application.conf
+++ b/atlas-druid/src/main/resources/application.conf
@@ -53,7 +53,7 @@ pekko.http {
     idle-timeout = 120s
     client.idle-timeout = 30s
 
-    // https://github.com/pekko/pekko-http/issues/1836
+    // https://github.com/akka/akka-http/issues/1836
     response-entity-subscription-timeout = 35s
   }
 }

--- a/atlas-druid/src/main/resources/application.conf
+++ b/atlas-druid/src/main/resources/application.conf
@@ -53,7 +53,7 @@ pekko.http {
     idle-timeout = 120s
     client.idle-timeout = 30s
 
-    // https://github.com/akka/akka-http/issues/1836
+    // https://github.com/pekko/pekko-http/issues/1836
     response-entity-subscription-timeout = 35s
   }
 }

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/LocalFilePersistService.scala
@@ -158,7 +158,7 @@ class LocalFilePersistService(
     }
   }
 
-  // This service should stop the Akka flow when application is shutdown gracefully, and let
+  // This service should stop the Pekko flow when application is shutdown gracefully, and let
   // S3CopyService do the cleanup. It should trigger:
   //   1. stop taking more data points (monitor droppedQueueClosed)
   //   2. close current file writer so that last file is ready to copy to s3


### PR DESCRIPTION
Rename to use Pekko for better consistency and making it easier to automate the transition of other projects that pull in these classes. Allows for easier search and replace to migrate.