### PR TITLE
0.3.x: fix namespace for ApiGateway

### DIFF
--- a/atlas-cloudwatch/src/main/resources/api-gateway.conf
+++ b/atlas-cloudwatch/src/main/resources/api-gateway.conf
@@ -8,8 +8,7 @@ atlas {
       period = 1m
 
       dimensions = [
-        "ApiName",
-        "Label"
+        "ApiName"
       ]
 
       metrics = [

--- a/atlas-cloudwatch/src/main/resources/api-gateway.conf
+++ b/atlas-cloudwatch/src/main/resources/api-gateway.conf
@@ -4,7 +4,7 @@ atlas {
 
     // http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-dashboard.html
     api-gateway = {
-      namespace = "ApiGateway"
+      namespace = "AWS/ApiGateway"
       period = 1m
 
       dimensions = [


### PR DESCRIPTION
Looks like the namespace for these metrics changed at some point. It was fixed in 0.4.x branch, but not this branch which is still needed for some legacy polling.