### PR TITLE
0.3.x: fix namespace for ApiGateway

### DIFF
--- a/atlas-cloudwatch/src/main/resources/api-gateway.conf
+++ b/atlas-cloudwatch/src/main/resources/api-gateway.conf
@@ -4,12 +4,11 @@ atlas {
 
     // http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-dashboard.html
     api-gateway = {
-      namespace = "ApiGateway"
+      namespace = "AWS/ApiGateway"
       period = 1m
 
       dimensions = [
-        "ApiName",
-        "Label"
+        "ApiName"
       ]
 
       metrics = [

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     val akka       = "2.6.20"
     val akkaHttpV  = "10.2.10"
 
-    val atlas      = "1.7.0-SNAPSHOT"
+    val atlas      = "1.7.7"
     val aws2       = "2.18.10"
     val iep        = "4.0.2"
     val log4j      = "2.19.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     val akka       = "2.6.20"
     val akkaHttpV  = "10.2.10"
 
-    val atlas      = "1.7.7"
+    val atlas      = "1.7.5"
     val aws2       = "2.18.10"
     val iep        = "4.0.2"
     val log4j      = "2.19.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     // - https://www.lightbend.com/blog/why-we-are-changing-the-license-for-akka
     // - https://github.com/akka/akka/pull/31561
     // - https://github.com/akka/akka-http/pull/4155
-    val akka       = "2.6.20"
+    val akka       = "2.6.21"
     val akkaHttpV  = "10.2.10"
 
     val atlas      = "1.7.5"


### PR DESCRIPTION
Looks like the namespace for these metrics changed at some point. It was fixed in 0.4.x branch, but not this branch which is still needed for some legacy polling.