### PR TITLE
atlas cloudwatch: add detailed tags to APIGateway config.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/api-gateway.conf
+++ b/atlas-cloudwatch/src/main/resources/api-gateway.conf
@@ -2,16 +2,30 @@
 atlas {
   cloudwatch {
 
-    // http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-dashboard.html
+    // https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html
     api-gateway = {
       namespace = "AWS/ApiGateway"
       period = 1m
 
+	  // NOTE: Enabling detailed metrics for specific accounts that need the high level of detail
       dimensions = [
-        "ApiName"
+        "ApiName",
+        "Method",
+        "Resource",
+        "Stage"
       ]
 
       metrics = [
+        {
+          name = "CacheHitCount"
+          alias = "aws.apigateway.cache.hits"
+          conversion = "sum,rate"
+        },
+        {
+          name = "CacheMissCount"
+          alias = "aws.apigateway.cache.misses"
+          conversion = "sum,rate"
+        },
         {
           name = "Count"
           alias = "aws.apigateway.requests"
@@ -42,6 +56,11 @@ atlas {
         {
           name = "Latency"
           alias = "aws.apigateway.latency"
+          conversion = "timer-millis"
+        },
+        {
+          name = "IntegrationLatency"
+          alias = "aws.apigateway.backendLatency"
           conversion = "timer-millis"
         }
       ]

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -255,6 +255,10 @@ atlas {
           alias = "aws.elb"
         },
         {
+          name = "Method"
+          alias = "aws.method"
+        },
+        {
           name = "NatGatewayId"
           alias = "aws.gateway"
         },
@@ -313,6 +317,10 @@ atlas {
         {
           name = "SourceARN"
           alias = "aws.source"
+        },
+        {
+          name = "Stage"
+          alias = "aws.stage"
         },
         {
           name = "StorageType"


### PR DESCRIPTION
For some specific accounts that need the detail.
Also add cache and backend latency metrics.