### PR TITLE
add clusters path to filter slotting data

### DIFF
--- a/atlas-slotting/README.md
+++ b/atlas-slotting/README.md
@@ -110,8 +110,6 @@ The following Atlas metrics are published:
 
 ## API
 
-### Standard
-
 <table>
     <tr><th>Action <th>Specification
     <tr>
@@ -129,34 +127,12 @@ The following Atlas metrics are published:
     <tr>
         <td width="30%">Single AutoScalingGroup Details
         <td><code>GET /api/v1/autoScalingGroups/:asgName</code>
-</table>
-
-### Edda Compatibility
-
-This API is designed to ease the transition from using Edda for slotting data. Any matrix args and
-field selectors will be stripped from the request URL and standard slotting service payloads will
-be returned.
-
-<table>
-    <tr><th>Action <th>Specification
     <tr>
-        <td width="30%">List of Available AutoScalingGroups
-        <td><code>GET /api/v2/group/autoScalingGroups</code>
+        <td width="30%">List of AutoScalingGroups Matching a Cluster Name
+        <td><code>GET /api/v1/clusters/:clusterName</code>
     <tr>
-        <td width="30%">All AutoScalingGroup Details
-        <td><code>GET /api/v2/group/autoScalingGroups;_expand</code>
-    <tr>
-        <td width="30%">Single AutoScalingGroup Details
-        <td><code>GET /api/v2/group/autoScalingGroups/:asgName</code>
-    <tr>
-        <td width="30%">List of Available AutoScalingGroups
-        <td><code>GET /REST/v2/group/autoScalingGroups</code>
-    <tr>
-        <td width="30%">All AutoScalingGroup Details
-        <td><code>GET /REST/v2/group/autoScalingGroups;_expand</code>
-    <tr>
-        <td width="30%">Single AutoScalingGroup Details
-        <td><code>GET /REST/v2/group/autoScalingGroups/:asgName</code>
+        <td width="30%">All AutoScalingGroup Details Matching a Cluster Name
+        <td><code>GET /api/v1/clusters/:clusterName?verbose=true</code>
 </table>
 
 ## Local Development

--- a/atlas-slotting/src/test/resources/atlas_app-main-none-v001.json
+++ b/atlas-slotting/src/test/resources/atlas_app-main-none-v001.json
@@ -1,0 +1,40 @@
+{
+  "name": "atlas_app-main-none-v001",
+  "cluster": "atlas_app-main-none",
+  "createdTime": 1552023610994,
+  "desiredCapacity": 3,
+  "maxSize": 6,
+  "minSize": 0,
+  "instances": [
+    {
+      "availabilityZone": "us-west-2b",
+      "imageId": "ami-001",
+      "instanceId": "i-003",
+      "instanceType": "r4.large",
+      "launchTime": 1552023619000,
+      "lifecycleState": "InService",
+      "privateIpAddress": "192.168.1.3",
+      "slot": 0
+    },
+    {
+      "availabilityZone": "us-west-2a",
+      "imageId": "ami-001",
+      "instanceId": "i-004",
+      "instanceType": "r4.large",
+      "launchTime": 1552023619000,
+      "lifecycleState": "InService",
+      "privateIpAddress": "192.168.1.4",
+      "slot": 1
+    },
+    {
+      "availabilityZone": "us-west-2b",
+      "imageId": "ami-001",
+      "instanceId": "i-005",
+      "instanceType": "r4.large",
+      "launchTime": 1552023619000,
+      "lifecycleState": "InService",
+      "privateIpAddress": "192.168.1.5",
+      "slot": 2
+    }
+  ]
+}


### PR DESCRIPTION
The `/api/v1/clusters/:clusterName` path provides both an index view and a
verbose view of the stored slotting data. This view performs a Frigga cluster
name match on the AutoScalingGroup name and returns the result. This allows
a user to distinguish between `app-foo` and `app-foobar` when filtering.

The `/api/v2` paths which provided Edda compatibility have been removed. They
never implemented true compatibility, not having selectors, and thus were
misleading and made the API routes more complicated than necessary. There is
no usage of these endpoints outside of a few manual testing calls.