### PR TITLE
persistence: use AWS client factory

### DIFF
--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/AppConfiguration.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/AppConfiguration.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.atlas.persistence
 
+import com.netflix.iep.aws2.AwsClientFactory
 import org.apache.pekko.actor.ActorSystem
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
@@ -30,6 +31,7 @@ class AppConfiguration {
 
   @Bean
   def s3CopyService(
+    awsFactory: AwsClientFactory,
     config: Optional[Config],
     registry: Optional[Registry],
     system: ActorSystem

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/AppConfiguration.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/AppConfiguration.scala
@@ -38,7 +38,7 @@ class AppConfiguration {
   ): S3CopyService = {
     val c = config.orElseGet(() => ConfigFactory.load())
     val r = registry.orElseGet(() => new NoopRegistry)
-    new S3CopyService(c, r, system)
+    new S3CopyService(awsFactory, c, r, system)
   }
 
   @Bean

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopyService.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopyService.scala
@@ -15,10 +15,11 @@
  */
 package com.netflix.atlas.persistence
 
+import com.netflix.iep.aws2.AwsClientFactory
+
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
-
 import org.apache.pekko.NotUsed
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.KillSwitch
@@ -34,6 +35,7 @@ import scala.concurrent.duration.*
 import scala.util.Using
 
 class S3CopyService(
+  val awsFactory: AwsClientFactory,
   val config: Config,
   val registry: Registry,
   implicit val system: ActorSystem
@@ -62,7 +64,7 @@ class S3CopyService(
       .tick(1.second, 5.seconds, NotUsed)
       .viaMat(KillSwitches.single)(Keep.right)
       .flatMapMerge(Int.MaxValue, _ => Source(FileUtil.listFiles(new File(dataDir))))
-      .toMat(new S3CopySink(s3Config, registry, system))(Keep.left)
+      .toMat(new S3CopySink(awsFactory, s3Config, registry, system))(Keep.left)
       .run()
   }
 

--- a/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopySink.scala
+++ b/atlas-persistence/src/main/scala/com/netflix/atlas/persistence/S3CopySink.scala
@@ -15,11 +15,12 @@
  */
 package com.netflix.atlas.persistence
 
+import com.netflix.iep.aws2.AwsClientFactory
+
 import java.io.File
 import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
-
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.Attributes
 import org.apache.pekko.stream.Inlet
@@ -39,6 +40,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 
+import java.util.Optional
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.TimeoutException
@@ -48,6 +50,7 @@ import scala.util.Failure
 import scala.util.Success
 
 class S3CopySink(
+  val awsFactory: AwsClientFactory,
   val s3Config: Config,
   val registry: Registry,
   implicit val system: ActorSystem
@@ -103,12 +106,9 @@ class S3CopySink(
 
       setHandler(in, this)
 
-      // TODO use iep/iep-module-aws2
       private def initS3Client(): Unit = {
-        s3Client = S3Client
-          .builder()
-          .region(Region.of(region))
-          .build()
+        s3Client =
+          awsFactory.getInstance("s3", classOf[S3Client], null, Optional.of(Region.of(region)))
       }
 
       def shouldProcess(f: File): Boolean = {

--- a/build.sbt
+++ b/build.sbt
@@ -89,6 +89,7 @@ lazy val `atlas-persistence` = project
       Dependencies.avro,
       Dependencies.aws2S3,
       Dependencies.iepSpring,
+      Dependencies.iepSpringAws2,
       Dependencies.log4jApi,
       Dependencies.log4jCore,
       Dependencies.log4jSlf4j,


### PR DESCRIPTION
Use client factory to create the S3 client. This allows it to be configured in a consistent way including enabling dualstack where appropriate.