### PR TITLE
add regions for cloudwatch forwarding

### DIFF
--- a/iep-lwc-cloudwatch/src/main/resources/application.conf
+++ b/iep-lwc-cloudwatch/src/main/resources/application.conf
@@ -22,6 +22,12 @@ atlas {
 netflix.iep.aws {
   // Configs for clients named by region, used to allow publishing across
   // regions
+  ap-south-1 {
+    region = "ap-south-1"
+  }
+  ap-southeast-2 {
+    region = "ap-southeast-2"
+  }
   eu-west-1 {
     region = "eu-west-1"
   }
@@ -33,6 +39,9 @@ netflix.iep.aws {
   }
   us-east-1 {
     region = "us-east-1"
+  }
+  us-east-2 {
+    region = "us-east-2"
   }
 }
 


### PR DESCRIPTION
Update AWS client configs for cloudwatch forwarding to include some clients for additional regions that are in use at Netflix.