### PR TITLE
atlas cloudwatch: enable polling for EC2 status check failures.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/ec2.conf
+++ b/atlas-cloudwatch/src/main/resources/ec2.conf
@@ -5,108 +5,109 @@ atlas {
     // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/viewing_metrics_with_cloudwatch.html
     ec2 = {
       namespace = "AWS/EC2"
-      period = 5m
-      end-period-offset = 3
+      period = 1m
       timeout = 20m
+      end-period-offset = 1
+      poll-offset = 1m
 
       dimensions = [
         "AutoScalingGroupName"
       ]
 
       metrics = [
-        {
-          name = "CPUUtilization"
-          alias = "aws.ec2.cpuUtilization"
-          conversion = "max"
-        },
-        {
-          name = "NetworkIn"
-          alias = "aws.ec2.networkThroughput"
-          conversion = "sum,rate"
-          tags = [
-            {
-              key = "id"
-              value = "in"
-            }
-          ]
-        },
-        {
-          name = "NetworkOut"
-          alias = "aws.ec2.networkThroughput"
-          conversion = "sum,rate"
-          tags = [
-            {
-              key = "id"
-              value = "out"
-            }
-          ]
-        },
-        {
-          name = "NetworkPacketsIn"
-          alias = "aws.ec2.networkPackets"
-          conversion = "sum,rate"
-          tags = [
-            {
-              key = "id"
-              value = "in"
-            }
-          ]
-        },
-        {
-          name = "NetworkPacketsOut"
-          alias = "aws.ec2.networkPackets"
-          conversion = "sum,rate"
-          tags = [
-            {
-              key = "id"
-              value = "out"
-            }
-          ]
-        },
-        {
-          name = "DiskReadBytes"
-          alias = "aws.ec2.ioThroughput"
-          conversion = "sum,rate"
-          tags = [
-            {
-              key = "id"
-              value = "read"
-            }
-          ]
-        },
-        {
-          name = "DiskWriteBytes"
-          alias = "aws.ec2.ioThroughput"
-          conversion = "sum,rate"
-          tags = [
-            {
-              key = "id"
-              value = "write"
-            }
-          ]
-        },
-        {
-          name = "DiskReadOps"
-          alias = "aws.ec2.iops"
-          conversion = "sum,rate"
-          tags = [
-            {
-              key = "id"
-              value = "read"
-            }
-          ]
-        },
-        {
-          name = "DiskWriteOps"
-          alias = "aws.ec2.iops"
-          conversion = "sum,rate"
-          tags = [
-            {
-              key = "id"
-              value = "write"
-            }
-          ]
-        },
+//        {
+//          name = "CPUUtilization"
+//          alias = "aws.ec2.cpuUtilization"
+//          conversion = "max"
+//        },
+//        {
+//          name = "NetworkIn"
+//          alias = "aws.ec2.networkThroughput"
+//          conversion = "sum,rate"
+//          tags = [
+//            {
+//              key = "id"
+//              value = "in"
+//            }
+//          ]
+//        },
+//        {
+//          name = "NetworkOut"
+//          alias = "aws.ec2.networkThroughput"
+//          conversion = "sum,rate"
+//          tags = [
+//            {
+//              key = "id"
+//              value = "out"
+//            }
+//          ]
+//        },
+//        {
+//          name = "NetworkPacketsIn"
+//          alias = "aws.ec2.networkPackets"
+//          conversion = "sum,rate"
+//          tags = [
+//            {
+//              key = "id"
+//              value = "in"
+//            }
+//          ]
+//        },
+//        {
+//          name = "NetworkPacketsOut"
+//          alias = "aws.ec2.networkPackets"
+//          conversion = "sum,rate"
+//          tags = [
+//            {
+//              key = "id"
+//              value = "out"
+//            }
+//          ]
+//        },
+//        {
+//          name = "DiskReadBytes"
+//          alias = "aws.ec2.ioThroughput"
+//          conversion = "sum,rate"
+//          tags = [
+//            {
+//              key = "id"
+//              value = "read"
+//            }
+//          ]
+//        },
+//        {
+//          name = "DiskWriteBytes"
+//          alias = "aws.ec2.ioThroughput"
+//          conversion = "sum,rate"
+//          tags = [
+//            {
+//              key = "id"
+//              value = "write"
+//            }
+//          ]
+//        },
+//        {
+//          name = "DiskReadOps"
+//          alias = "aws.ec2.iops"
+//          conversion = "sum,rate"
+//          tags = [
+//            {
+//              key = "id"
+//              value = "read"
+//            }
+//          ]
+//        },
+//        {
+//          name = "DiskWriteOps"
+//          alias = "aws.ec2.iops"
+//          conversion = "sum,rate"
+//          tags = [
+//            {
+//              key = "id"
+//              value = "write"
+//            }
+//          ]
+//        },
         {
           name = "StatusCheckFailed_Instance"
           alias = "aws.ec2.badInstances"
@@ -129,6 +130,17 @@ atlas {
             }
           ]
         },
+        {
+          name = "StatusCheckFailed_AttachedEBS"
+          alias = "aws.ec2.badInstances"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "ebs"
+            }
+          ]
+        }
       ]
     }
 

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -14,9 +14,9 @@ aws-poller-io-dispatcher {
   type = Dispatcher
   executor = "thread-pool-executor"
   thread-pool-executor {
-    fixed-pool-size = 8
+    fixed-pool-size = 16
   }
-  throughput = 16
+  throughput = 32
 }
 
 iep.leader {

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/AwsConfigAccountSupplier.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/AwsConfigAccountSupplier.scala
@@ -168,6 +168,7 @@ class AwsConfigAccountSupplier(
     logger.info(
       s"Finished loading ${rawAccountResources.size} (${filtered.size} filtered) AWS accounts and resources in ${(System.currentTimeMillis() - start) / 1000.0} seconds"
     )
+    logger.info(s"Final AWS accounts: ${filtered}")
     registry
       .timer("atlas.cloudwatch.account.supplier.aws.loadTime")
       .record(System.currentTimeMillis() - start, TimeUnit.MILLISECONDS)

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchPollerSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchPollerSuite.scala
@@ -453,7 +453,8 @@ class CloudWatchPollerSuite extends FunSuite with TestKitBase {
       category,
       client,
       account,
-      region
+      region,
+      60
     )
   }
 


### PR DESCRIPTION
Polls at 60s. Disabled the other EC2 system metrics to avoid polling. Also log the polling offset at completion and log the accounts resolved from the account config.