### PR TITLE
atlas cloudwatch: Throttle AWS polling requests.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/ec2.conf
+++ b/atlas-cloudwatch/src/main/resources/ec2.conf
@@ -11,7 +11,7 @@ atlas {
       poll-offset = 1m
 
       dimensions = [
-        "AutoScalingGroupName"
+        "InstanceId"
       ]
 
       metrics = [
@@ -109,38 +109,43 @@ atlas {
 //          ]
 //        },
         {
-          name = "StatusCheckFailed_Instance"
-          alias = "aws.ec2.badInstances"
+          name = "StatusCheckFailed"
+          alias = "aws.ec2.statusCheckFailed"
           conversion = "max"
-          tags = [
-            {
-              key = "id"
-              value = "instance"
-            }
-          ]
         },
-        {
-          name = "StatusCheckFailed_System"
-          alias = "aws.ec2.badInstances"
-          conversion = "max"
-          tags = [
-            {
-              key = "id"
-              value = "system"
-            }
-          ]
-        },
-        {
-          name = "StatusCheckFailed_AttachedEBS"
-          alias = "aws.ec2.badInstances"
-          conversion = "max"
-          tags = [
-            {
-              key = "id"
-              value = "ebs"
-            }
-          ]
-        }
+//        {
+//          name = "StatusCheckFailed_Instance"
+//          alias = "aws.ec2.badInstances"
+//          conversion = "max"
+//          tags = [
+//            {
+//              key = "id"
+//              value = "instance"
+//            }
+//          ]
+//        },
+//        {
+//          name = "StatusCheckFailed_System"
+//          alias = "aws.ec2.badInstances"
+//          conversion = "max"
+//          tags = [
+//            {
+//              key = "id"
+//              value = "system"
+//            }
+//          ]
+//        },
+//        {
+//          name = "StatusCheckFailed_AttachedEBS"
+//          alias = "aws.ec2.badInstances"
+//          conversion = "max"
+//          tags = [
+//            {
+//              key = "id"
+//              value = "ebs"
+//            }
+//          ]
+//        }
       ]
     }
 

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -341,6 +341,10 @@ atlas {
           alias = "aws.hostedZone"
         },
         {
+          name = "InstanceId"
+          alias = "nf.node"
+        },
+        {
           name = "LinkedAccount"
           alias = "aws.account"
         },

--- a/atlas-cloudwatch/src/test/resources/application.conf
+++ b/atlas-cloudwatch/src/test/resources/application.conf
@@ -29,6 +29,11 @@ atlas {
 
     account {
       polling = {
+        requestLimit = 300 // per second request limit for AWS.
+        fastPolling = [
+          "000000000001",
+          "000000000002"
+        ]
         default-regions = ["us-east-1", "us-west-2"]
         accounts = [
           {

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchPollerSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchPollerSuite.scala
@@ -114,6 +114,8 @@ class CloudWatchPollerSuite extends FunSuite with TestKitBase {
     val cfg = ConfigFactory.parseString("""
         |atlas {
         |  cloudwatch {
+        |    account.polling.requestLimit = 100
+        |    account.polling.fastPolling = []
         |    categories = ["cfg1", "cfg2"]
         |    poller.frequency = "5m"
         |
@@ -302,8 +304,8 @@ class CloudWatchPollerSuite extends FunSuite with TestKitBase {
     mockMetricStats()
     child.ListMetrics(req, mdef, promise).process(metrics)
 
-    assertCounters(droppedTags = 1, droppedFilter = 1)
     Await.result(promise.future, 1.seconds)
+    assertCounters(droppedTags = 1, droppedFilter = 1)
   }
 
   test("Poller#ListMetrics empty") {
@@ -325,10 +327,10 @@ class CloudWatchPollerSuite extends FunSuite with TestKitBase {
     val metrics = getListResponse(req)
     child.ListMetrics(req, mdef, promise).process(metrics)
 
-    assertCounters(droppedTags = 1, droppedFilter = 1)
     intercept[RuntimeException] {
       Await.result(promise.future, 1.seconds)
     }
+    assertCounters(droppedTags = 1, droppedFilter = 1)
   }
 
   test("Poller#ListMetrics client throws") {


### PR DESCRIPTION
Pick up the EC2 StatusCheckFailed metric as the others were not incrementing under test.
Add an allow list for the 60s polling as a hack to avoid cost overruns. TODO - clean up the code for proper per-account overrides on multiple levels.