### PR TITLE
slotting: avoid ByteBuffer conversions

### DIFF
--- a/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/DynamoOps.scala
+++ b/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/DynamoOps.scala
@@ -15,7 +15,6 @@
  */
 package com.netflix.atlas.slotting
 
-import java.nio.ByteBuffer
 import java.time.Duration
 import com.netflix.iep.config.NetflixEnvironment
 import com.netflix.spectator.api.Counter
@@ -58,8 +57,8 @@ trait DynamoOps extends StrictLogging {
     javaMap[String, AttributeValue](pairs)
   }
 
-  private def binary(value: ByteBuffer): AttributeValue = {
-    AttributeValue.builder().b(SdkBytes.fromByteBuffer(value)).build()
+  private def binary(value: Array[Byte]): AttributeValue = {
+    AttributeValue.builder().b(SdkBytes.fromByteArray(value)).build()
   }
 
   private def bool(value: Boolean): AttributeValue = {
@@ -122,7 +121,7 @@ trait DynamoOps extends StrictLogging {
       .build()
   }
 
-  def putAsgItemRequest(table: String, name: String, newData: ByteBuffer): PutItemRequest = {
+  def putAsgItemRequest(table: String, name: String, newData: Array[Byte]): PutItemRequest = {
     PutItemRequest
       .builder()
       .tableName(table)
@@ -140,8 +139,8 @@ trait DynamoOps extends StrictLogging {
   def updateAsgItemRequest(
     table: String,
     name: String,
-    oldData: ByteBuffer,
-    newData: ByteBuffer
+    oldData: Array[Byte],
+    newData: Array[Byte]
   ): UpdateItemRequest = {
     val nameMap = createNameMap(
       "#d" -> Data,

--- a/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/Util.scala
+++ b/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/Util.scala
@@ -15,7 +15,6 @@
  */
 package com.netflix.atlas.slotting
 
-import java.nio.ByteBuffer
 import java.time.Duration
 import java.util.concurrent.ScheduledFuture
 
@@ -35,21 +34,6 @@ object Util extends StrictLogging {
       config.getLong(s"$basePath.$env.$region")
     else
       config.getLong(s"$basePath.default")
-  }
-
-  def compress(s: String): ByteBuffer = {
-    ByteBuffer.wrap(Gzip.compressString(s))
-  }
-
-  def decompress(buf: ByteBuffer): String = {
-    Gzip.decompressString(toByteArray(buf))
-  }
-
-  def toByteArray(buf: ByteBuffer): Array[Byte] = {
-    val bytes = new Array[Byte](buf.remaining)
-    buf.get(bytes, 0, bytes.length)
-    buf.clear()
-    bytes
   }
 
   def startScheduler(

--- a/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/DynamoOpsSuite.scala
+++ b/atlas-slotting/src/test/scala/com/netflix/atlas/slotting/DynamoOpsSuite.scala
@@ -23,16 +23,6 @@ import munit.FunSuite
 
 class DynamoOpsSuite extends FunSuite with DynamoOps {
 
-  def mkByteBuffer(s: String): ByteBuffer = {
-    ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8))
-  }
-
-  test("compress and decompress") {
-    val input = "Atlas Slotting Service"
-    val compressed = Util.compress(input)
-    assertEquals(input, Util.decompress(compressed))
-  }
-
   test("active items spec") {
     val scanSpec = activeItemsScanRequest("test")
     assertEquals(scanSpec.filterExpression, "#a = :v1")
@@ -48,7 +38,8 @@ class DynamoOpsSuite extends FunSuite with DynamoOps {
   }
 
   test("new asg item") {
-    val newData = mkByteBuffer("""{"name": "atlas_app-main-all-v001", "desiredCapacity": 3}""")
+    val newData =
+      Gzip.compressString("""{"name": "atlas_app-main-all-v001", "desiredCapacity": 3}""")
     val item = putAsgItemRequest("test", "atlas_app-main-all-v001", newData).item()
     assert(item.containsKey(Name))
     assert(item.containsKey(Data))
@@ -57,8 +48,10 @@ class DynamoOpsSuite extends FunSuite with DynamoOps {
   }
 
   test("update asg spec") {
-    val oldData = mkByteBuffer("""{"name": "atlas_app-main-all-v001", "desiredCapacity": 3}""")
-    val newData = mkByteBuffer("""{"name": "atlas_app-main-all-v001", "desiredCapacity": 6}""")
+    val oldData =
+      Gzip.compressString("""{"name": "atlas_app-main-all-v001", "desiredCapacity": 3}""")
+    val newData =
+      Gzip.compressString("""{"name": "atlas_app-main-all-v001", "desiredCapacity": 6}""")
     val updateSpec = updateAsgItemRequest("test", "atlas_app-main-all-v001", oldData, newData)
     assertEquals(updateSpec.conditionExpression, "#d = :v1")
     assertEquals(updateSpec.updateExpression, s"set #d = :v2, #a = :v3, #t = :v4")


### PR DESCRIPTION
Just keep the data as String/Array[Byte] and avoid unecessary conversions to and from ByteBuffer. All operations were first converting to intermediate byte array or other type anyway.

Also update log messages to properly log the exception so the stack trace will be present in the logs.