### PR TITLE
atlas-cloudwatch: Neptune to db instance level metrics.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/neptune.conf
+++ b/atlas-cloudwatch/src/main/resources/neptune.conf
@@ -9,30 +9,19 @@ atlas {
       timeout = 15m
 
       dimensions = [
-        "DBClusterIdentifier",
-        "Role"
+        "DBInstanceIdentifier"
       ]
 
       metrics = [
         {
+          name = "BackupRetentionPeriodStorageUsed"
+          alias = "aws.neptune.backupStorageUsed"
+          conversion = "max"
+        }
+        {
           name = "BufferCacheHitRatio"
           alias = "aws.neptune.bufferCacheHitRatio"
           conversion = "max"
-        },
-        {
-          name = "CPUUtilization"
-          alias = "aws.neptune.cpuUtilization"
-          conversion = "max"
-        },
-        {
-          name = "EngineUptime"
-          alias = "aws.neptune.engineUptime"
-          conversion = "max"
-        },
-        {
-          name = "FreeableMemory"
-          alias = "aws.neptune.freeableMemoryBytes"
-          conversion = "min"
         },
         {
           name = "ClusterReplicaLag"
@@ -50,6 +39,21 @@ atlas {
           conversion = "min"
         },
         {
+          name = "CPUUtilization"
+          alias = "aws.neptune.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "EngineUptime"
+          alias = "aws.neptune.engineUptime"
+          conversion = "max"
+        },
+        {
+          name = "FreeableMemory"
+          alias = "aws.neptune.freeableMemoryBytes"
+          conversion = "min"
+        },
+        {
           name = "GremlinRequestsPerSec"
           alias = "aws.neptune.requests"
           conversion = "sum,rate"
@@ -57,17 +61,6 @@ atlas {
             {
               key = "engine"
               value = "gremlin"
-            }
-          ]
-        },
-        {
-          name = "SparqlRequestsPerSec"
-          alias = "aws.neptune.requests"
-          conversion = "sum,rate"
-          tags = [
-            {
-              key = "engine"
-              value = "sparql"
             }
           ]
         },
@@ -90,6 +83,11 @@ atlas {
         {
           name = "MainRequestQueuePendingRequests"
           alias = "aws.neptune.pendingRequests"
+          conversion = "max"
+        },
+        {
+          name = "NCUUtilization",
+          alias = "aws.neptune.ncuUtilization"
           conversion = "max"
         },
         {
@@ -148,6 +146,53 @@ atlas {
           ]
         },
         {
+          name = "OpenCypherRequestsPerSec",
+          alias = "aws.neptune.openCypher.requests"
+          conversion = "sum,rate"
+        },
+        {
+          name = "OpenCypherBoltOpenConnections"
+          alias = "aws.neptune.openCypher.boltConnections"
+          conversion = "max"
+        },
+        {
+          name = "ServerlessDatabaseCapacity"
+          alias = "aws.neptune.serverless.capacity"
+          conversion = "max"
+        },
+        {
+          name = "SnapshotStorageUsed"
+          alias = "aws.neptune.snapshotStorageUsed"
+          conversion = "max"
+        },
+        {
+          name = "SparqlRequestsPerSec"
+          alias = "aws.neptune.requests"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "engine"
+              value = "sparql"
+            }
+          ]
+        },
+        {
+          name = "StatsNumStatementsScanned"
+          alias = "aws.neptune.statementsScanned"
+          conversion = "max,rate"
+          monotonic = true
+        },
+        {
+          name = "TotalBackupStorageBilled"
+          alias = "aws.neptune.totalBackupStorageBytes"
+          conversion = "max"
+        },
+        {
+          name = "TotalRequestsPerSec"
+          alias = "aws.neptune.requests"
+          conversion = "sum,rate"
+        },
+        {
           name = "TotalClientErrorsPerSec"
           alias = "aws.neptune.errors"
           conversion = "sum,rate"
@@ -166,6 +211,38 @@ atlas {
             {
               key = "id"
               value = "server"
+            }
+          ]
+        },
+        {
+          name = "UndoLogListSize"
+          alias = "aws.neptune.undoLogListSize"
+          conversion = "max"
+        },
+        {
+          name = "VolumeBytesUsed"
+          alias = "aws.neptune.volumeBytesUsed"
+          conversion = "max"
+        },
+        {
+          name = "VolumeReadIOPs",
+          alias = "aws.neptune.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "VolumeWriteIOPs",
+          alias = "aws.neptune.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "write"
             }
           ]
         }


### PR DESCRIPTION
Also sync with latest metrics from AWS docs.