### PR TITLE
aggr: fix validation checks for name

### DIFF
--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PayloadDecoder.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PayloadDecoder.scala
@@ -163,6 +163,8 @@ class PayloadDecoder(
         // incorrectly flagged as missing name if another check fails
         name = v
         numUserTags += 1
+        if (result == TagRule.Pass)
+          result = validator.validate("name", v)
       } else if (result == TagRule.Pass) {
         // Avoid doing unnecessary work if it has already failed validation. We still need
         // to process the entry as subsequent entries may be fine.

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
@@ -243,6 +243,14 @@ class UpdateApiSuite extends FunSuite {
     assertEquals(msg.message, List("missing key 'name' (tags={\"foo\":\"bar\"})"))
   }
 
+  test("validation: name too long") {
+    val name = "a" * 300
+    val tags = SmallHashMap("name" -> name)
+    val msg = validationTest(tags, StatusCodes.BadRequest)
+    assertEquals(msg.errorCount, 1)
+    assertEquals(msg.message, List(s"value too long: name = [$name] (300 > 255) (tags={\"name\":\"$name\"})"))
+  }
+
   test("validation: too many user tags") {
     val tags = Map("name" -> "foo") ++ (0 until 20)
       .map(v => Strings.zeroPad(v, 5))

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
@@ -248,7 +248,10 @@ class UpdateApiSuite extends FunSuite {
     val tags = SmallHashMap("name" -> name)
     val msg = validationTest(tags, StatusCodes.BadRequest)
     assertEquals(msg.errorCount, 1)
-    assertEquals(msg.message, List(s"value too long: name = [$name] (300 > 255) (tags={\"name\":\"$name\"})"))
+    assertEquals(
+      msg.message,
+      List(s"value too long: name = [$name] (300 > 255) (tags={\"name\":\"$name\"})")
+    )
   }
 
   test("validation: too many user tags") {


### PR DESCRIPTION
The name key was special cased for the existence check, but wasn't checking other conditions like the length.