### PR TITLE
Update GetItemRequest Builder with TableName Param

### DIFF
--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/ExpressionDetailsDao.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/ExpressionDetailsDao.scala
@@ -102,6 +102,7 @@ class ExpressionDetailsDaoImpl(
   override def read(id: ExpressionId): Option[ExpressionDetails] = {
     val request = GetItemRequest
       .builder()
+      .tableName(TableName)
       .key(createValueMap(ExpressionIdAttr -> string(Json.encode(id))))
       .build()
     val itemResponse = record(


### PR DESCRIPTION
TableName is a required field for GetItem command on DDD 
https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_GetItem.html#DDB-GetItem-request-TableName


AWS SDK Exception
```
software.amazon.awssdk.services.dynamodb.model.DynamoDbException: 1 validation error detected: Value null at 'tableName' failed to satisfy constraint: Member must not be null (Service: DynamoDb, Status Code: 400, Request ID: VRR1NLEMF2J180HKII229KAK57VV4KQNSO5AEMVJF66Q9ASUAAJG)
```
