### PR TITLE
lwc-cloudwatch: use step size from uri

### DIFF
--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
@@ -273,7 +273,7 @@ object ForwardingService extends StrictLogging {
 
   def toDataSource(expression: ForwardingExpression, key: String): Evaluator.DataSource = {
     val id = Json.encode(ExpressionId(key, expression))
-    new Evaluator.DataSource(id, Duration.ofSeconds(60L), expression.atlasUri)
+    new Evaluator.DataSource(id, expression.atlasUri)
   }
 
   def toMetricDatum(


### PR DESCRIPTION
Before it was hard-coded to 60 when creating the data source so the step on the URI would not get honored.