### PR TITLE
lwc-cloudwatch: trim messages before parsing

### DIFF
--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
@@ -233,8 +233,8 @@ object ForwardingService extends StrictLogging {
 
     Flow[ByteString]
       .via(Framing.delimiter(ByteString("\n"), MaxFrameLength, allowTruncation = true))
-      .map(_.decodeString(StandardCharsets.UTF_8))
-      .filter(s => s.trim.nonEmpty)
+      .map(_.decodeString(StandardCharsets.UTF_8).trim)
+      .filter(_.nonEmpty)
       .map { s =>
         val msg = Message(s)
         logger.debug(s"message [${msg.str}]")


### PR DESCRIPTION
This helps avoid some confusion if the last character is a carriage return. When viewing logs on the console that can make it hard to view properly.