### PR TITLE
lwc-cloudwatch: add flag to disable put

### DIFF
--- a/iep-lwc-cloudwatch/src/main/resources/application.conf
+++ b/iep-lwc-cloudwatch/src/main/resources/application.conf
@@ -8,6 +8,10 @@ iep.lwc.cloudwatch {
   filter = ".*"
 
   admin-uri = "http://localhost:7103/api/v1/cw/report"
+
+  // Should it actually try to perform the put call to CloudWatch? This can be used to disable
+  // for purposes of debugging.
+  put-enabled = true
 }
 
 atlas {

--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ForwardingService.scala
@@ -102,6 +102,7 @@ class ForwardingService(
   private var killSwitch: KillSwitch = _
 
   override def startImpl(): Unit = {
+    val putEnabled = config.getBoolean("iep.lwc.cloudwatch.put-enabled")
     val pattern = Pattern.compile(config.getString("iep.lwc.cloudwatch.filter"))
     val uri = config.getString("iep.lwc.cloudwatch.uri")
     val namespace = config.getString("iep.lwc.cloudwatch.namespace")
@@ -113,8 +114,12 @@ class ForwardingService(
       account: String,
       request: PutMetricDataRequest
     ): PutMetricDataResponse = {
-      val cwClient = clientFactory.getInstance(region, classOf[CloudWatchClient], account)
-      cwClient.putMetricData(request)
+      if (putEnabled) {
+        val cwClient = clientFactory.getInstance(region, classOf[CloudWatchClient], account)
+        cwClient.putMetricData(request)
+      } else {
+        PutMetricDataResponse.builder().build()
+      }
     }
 
     killSwitch = autoReconnectHttpSource(uri, client)


### PR DESCRIPTION
Allows put calls to be disabled. This can be useful to run in parallel for testing without actually sending data to CloudWatch.