### PR TITLE
lwc-cloudwatch: add gauge for stale expressions

### DIFF
--- a/iep-lwc-cloudwatch/src/main/resources/application.conf
+++ b/iep-lwc-cloudwatch/src/main/resources/application.conf
@@ -18,7 +18,8 @@ atlas {
   pekko {
     api-endpoints = [
       "com.netflix.atlas.pekko.ConfigApi",
-      "com.netflix.atlas.pekko.HealthcheckApi"
+      "com.netflix.atlas.pekko.HealthcheckApi",
+      "com.netflix.iep.lwc.StatsApi"
     ]
   }
 }

--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/AppConfiguration.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/AppConfiguration.scala
@@ -31,15 +31,21 @@ import java.util.Optional
 class AppConfiguration {
 
   @Bean
+  def configStats: ConfigStats = {
+    new ConfigStats
+  }
+
+  @Bean
   def forwardingService(
     config: Optional[Config],
     registry: Optional[Registry],
+    configStats: ConfigStats,
     evaluator: Evaluator,
     factory: AwsClientFactory,
     system: ActorSystem
   ): ForwardingService = {
     val c = config.orElseGet(() => ConfigFactory.load())
     val r = registry.orElseGet(() => new NoopRegistry)
-    new ForwardingService(c, r, evaluator, factory, system)
+    new ForwardingService(c, r, configStats, evaluator, factory, system)
   }
 }

--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ConfigStats.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ConfigStats.scala
@@ -1,0 +1,105 @@
+package com.netflix.iep.lwc
+
+import com.netflix.iep.lwc.fwd.cw.ClusterConfig
+
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import scala.collection.immutable.ListMap
+import scala.collection.immutable.SortedMap
+
+class ConfigStats {
+
+  import ConfigStats.*
+  import scala.jdk.CollectionConverters.*
+
+  // cluster -> atlasUri -> UriInfo
+  private val stats = new ConcurrentHashMap[String, ConcurrentHashMap[String, UriInfo]]()
+
+  /** Sync stats information with the current set of configs. */
+  def updateConfigs(configs: Map[String, ClusterConfig]): Unit = {
+    removeMissingKeys(stats, configs.keySet)
+    configs.foreachEntry { (cluster, config) =>
+      val configInfo = stats.computeIfAbsent(cluster, _ => new ConcurrentHashMap[String, UriInfo]())
+      removeMissingKeys(configInfo, config.expressions.map(_.atlasUri).toSet)
+      config.expressions.foreach { expr =>
+        configInfo.computeIfAbsent(expr.atlasUri, _ => UriInfo())
+      }
+    }
+  }
+
+  private def removeMissingKeys(map: ConcurrentHashMap[String, ?], keys: Set[String]): Unit = {
+    val currentKeys = map.keySet().asScala
+    val removedKeys = currentKeys.diff(keys)
+    removedKeys.foreach(map.remove)
+  }
+
+  /** Update stats for a given uri. */
+  def updateStats(cluster: String, uri: String, timestamp: Long): Unit = {
+    val configInfo = stats.get(cluster)
+    if (configInfo != null) {
+      val uriInfo = configInfo.get(uri)
+      if (uriInfo != null) {
+        uriInfo.timestamp.set(timestamp)
+        uriInfo.datapoints.incrementAndGet()
+      }
+    }
+  }
+
+  /** Return a snapshot of the stats. */
+  def snapshot: Map[String, List[Map[String, Any]]] = {
+    val snapshot = stats
+      .entrySet()
+      .asScala
+      .toList
+      .map { entry =>
+        val cluster = entry.getKey
+        val configInfo = entry.getValue
+        cluster -> snapshotConfigInfo(configInfo)
+      }
+    SortedMap.from(snapshot)
+  }
+
+  def snapshotForCluster(cluster: String): List[Map[String, Any]] = {
+    val configInfo = stats.get(cluster)
+    if (configInfo == null)
+      Nil
+    else
+      snapshotConfigInfo(configInfo)
+  }
+
+  private def snapshotConfigInfo(configInfo: ConcurrentHashMap[String, UriInfo]): List[Map[String, Any]] = {
+    configInfo
+      .entrySet()
+      .asScala
+      .toList
+      .sortWith(_.getKey < _.getKey)
+      .map { entry =>
+        val uri = entry.getKey
+        val info = entry.getValue
+        ListMap(
+          "uri" -> uri,
+          "timestamp" -> Instant.ofEpochMilli(info.timestamp.get()).toString,
+          "datapoints" -> info.datapoints.get()
+        )
+      }
+  }
+
+  /** Number of expressions that haven't received an update in the last 5m. */
+  def staleExpressions: Int = {
+    stats.values().asScala.map(_.values().asScala.count(_.isStale)).sum
+  }
+}
+
+object ConfigStats {
+
+  case class UriInfo(
+    timestamp: AtomicLong = new AtomicLong(System.currentTimeMillis()),
+    datapoints: AtomicLong = new AtomicLong()
+  ) {
+
+    def isStale: Boolean = {
+      System.currentTimeMillis() - timestamp.get() > 300_000
+    }
+  }
+}

--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ConfigStats.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/ConfigStats.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.iep.lwc
 
 import com.netflix.iep.lwc.fwd.cw.ClusterConfig
@@ -68,7 +83,9 @@ class ConfigStats {
       snapshotConfigInfo(configInfo)
   }
 
-  private def snapshotConfigInfo(configInfo: ConcurrentHashMap[String, UriInfo]): List[Map[String, Any]] = {
+  private def snapshotConfigInfo(
+    configInfo: ConcurrentHashMap[String, UriInfo]
+  ): List[Map[String, Any]] = {
     configInfo
       .entrySet()
       .asScala
@@ -78,8 +95,8 @@ class ConfigStats {
         val uri = entry.getKey
         val info = entry.getValue
         ListMap(
-          "uri" -> uri,
-          "timestamp" -> Instant.ofEpochMilli(info.timestamp.get()).toString,
+          "uri"        -> uri,
+          "timestamp"  -> Instant.ofEpochMilli(info.timestamp.get()).toString,
           "datapoints" -> info.datapoints.get()
         )
       }

--- a/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/StatsApi.scala
+++ b/iep-lwc-cloudwatch/src/main/scala/com/netflix/iep/lwc/StatsApi.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc
+
+import org.apache.pekko.http.scaladsl.model.HttpEntity
+import org.apache.pekko.http.scaladsl.model.HttpResponse
+import org.apache.pekko.http.scaladsl.model.MediaTypes
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.server.Directives.*
+import org.apache.pekko.http.scaladsl.server.Route
+import com.netflix.atlas.pekko.CustomDirectives.*
+import com.netflix.atlas.pekko.WebApi
+import com.netflix.atlas.json.Json
+
+/**
+  * Dump the stats for the expressions flowing through the bridge.
+  */
+class StatsApi(configStats: ConfigStats) extends WebApi {
+
+  override def routes: Route = {
+    endpointPathPrefix("api" / "v1" / "stats") {
+      pathEndOrSingleSlash {
+        get {
+          val stats = Json.encode(configStats.snapshot)
+          val entity = HttpEntity(MediaTypes.`application/json`, stats)
+          val response = HttpResponse(StatusCodes.OK, Nil, entity)
+          complete(response)
+        }
+      } ~
+      path(Remaining) { cluster =>
+        get {
+          val stats = Json.encode(configStats.snapshotForCluster(cluster))
+          val entity = HttpEntity(MediaTypes.`application/json`, stats)
+          val response = HttpResponse(StatusCodes.OK, Nil, entity)
+          complete(response)
+        }
+      }
+    }
+  }
+}

--- a/iep-lwc-cloudwatch/src/test/scala/com/netflix/iep/lwc/ForwardingServiceSuite.scala
+++ b/iep-lwc-cloudwatch/src/test/scala/com/netflix/iep/lwc/ForwardingServiceSuite.scala
@@ -231,7 +231,7 @@ class ForwardingServiceSuite extends FunSuite {
   def runToMetricDatum(env: Evaluator.MessageEnvelope): ForwardingMsgEnvelope = {
     val future = Source
       .single(env)
-      .via(toMetricDatum(ConfigFactory.load(), new NoopRegistry))
+      .via(toMetricDatum(ConfigFactory.load(), new NoopRegistry, new ConfigStats))
       .runWith(Sink.head)
     Await.result(future, Duration.Inf)
   }


### PR DESCRIPTION
Keep track of number of expressions that are not receiving any data. Also adds stats API to get a detailed breakdown.