### PR TITLE
aggr: set dstype when loading tags

### DIFF
--- a/atlas-aggregator/src/main/resources/application.conf
+++ b/atlas-aggregator/src/main/resources/application.conf
@@ -29,10 +29,6 @@ atlas.aggregator {
   // Should the aggregation of gauges be delayed until the final eval step?
   delay-gauge-aggregation = true
 
-  // Determines whether or not to include the aggregator node as a tag on counters.
-  // If false it will use atlas.dstype=sum instead.
-  include-aggr-tag = false
-
   allowed-characters = "-._A-Za-z0-9^~"
 
   validation {

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
@@ -240,7 +240,7 @@ class UpdateApiSuite extends FunSuite {
     val tags = SmallHashMap("foo" -> "bar")
     val msg = validationTest(tags, StatusCodes.BadRequest)
     assertEquals(msg.errorCount, 1)
-    assertEquals(msg.message, List("missing key 'name' (tags={\"foo\":\"bar\"})"))
+    assertEquals(msg.message, List("missing key 'name' (tags={\"foo\":\"bar\",\"atlas.dstype\":\"sum\"})"))
   }
 
   test("validation: name too long") {
@@ -250,7 +250,7 @@ class UpdateApiSuite extends FunSuite {
     assertEquals(msg.errorCount, 1)
     assertEquals(
       msg.message,
-      List(s"value too long: name = [$name] (300 > 255) (tags={\"name\":\"$name\"})")
+      List(s"value too long: name = [$name] (300 > 255) (tags={\"name\":\"$name\",\"atlas.dstype\":\"sum\"})")
     )
   }
 
@@ -278,7 +278,7 @@ class UpdateApiSuite extends FunSuite {
     assertEquals(
       msg.message,
       List(
-        "invalid key for reserved prefix 'nf.': nf.foo (tags={\"name\":\"test\",\"nf.foo\":\"bar\"})"
+        "invalid key for reserved prefix 'nf.': nf.foo (tags={\"name\":\"test\",\"atlas.dstype\":\"sum\",\"nf.foo\":\"bar\"})"
       )
     )
   }
@@ -293,7 +293,7 @@ class UpdateApiSuite extends FunSuite {
     assertEquals(
       msg.message,
       List(
-        "invalid key for reserved prefix 'nf.': nf.foo (tags={\"name\":\"test\",\"nf.foo\":\"bar\"})"
+        "invalid key for reserved prefix 'nf.': nf.foo (tags={\"name\":\"test\",\"atlas.dstype\":\"sum\",\"nf.foo\":\"bar\"})"
       )
     )
   }

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
@@ -240,7 +240,10 @@ class UpdateApiSuite extends FunSuite {
     val tags = SmallHashMap("foo" -> "bar")
     val msg = validationTest(tags, StatusCodes.BadRequest)
     assertEquals(msg.errorCount, 1)
-    assertEquals(msg.message, List("missing key 'name' (tags={\"foo\":\"bar\",\"atlas.dstype\":\"sum\"})"))
+    assertEquals(
+      msg.message,
+      List("missing key 'name' (tags={\"foo\":\"bar\",\"atlas.dstype\":\"sum\"})")
+    )
   }
 
   test("validation: name too long") {
@@ -250,7 +253,9 @@ class UpdateApiSuite extends FunSuite {
     assertEquals(msg.errorCount, 1)
     assertEquals(
       msg.message,
-      List(s"value too long: name = [$name] (300 > 255) (tags={\"name\":\"$name\",\"atlas.dstype\":\"sum\"})")
+      List(
+        s"value too long: name = [$name] (300 > 255) (tags={\"name\":\"$name\",\"atlas.dstype\":\"sum\"})"
+      )
     )
   }
 


### PR DESCRIPTION
This avoids some allocations to add it in later when the counter or max gauge is created.