### PR TITLE
cw admin: fix step for streaming check

### DIFF
--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/Api.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/Api.scala
@@ -59,7 +59,6 @@ class Api(
           complete {
             schemaValidation.validate(key, json)
             cwExprValidations.validate(key, json)
-
             HttpResponse(StatusCodes.OK)
           }
         }

--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/CwExprValidations.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/CwExprValidations.scala
@@ -85,7 +85,7 @@ class CwExprValidations(interpreter: ExprInterpreter, evaluator: Evaluator) exte
 
   def validStreamingExpr(expr: ForwardingExpression, styleExprs: List[StyleExpr]): Unit = {
     evaluator.validate(
-      new Evaluator.DataSource("_", Duration.ZERO, expr.atlasUri)
+      new Evaluator.DataSource("_", expr.atlasUri)
     )
   }
 


### PR DESCRIPTION
Derive step from the URI rather than using a hardcoded value of zero.