### PR TITLE
cloudwatch: Rework to improve data accuracy.

### DIFF
--- a/atlas-cloudwatch/src/main/protobuf/CloudWatchMetric.proto
+++ b/atlas-cloudwatch/src/main/protobuf/CloudWatchMetric.proto
@@ -12,11 +12,13 @@ message CloudWatchDimension {
 }
 
 message CloudWatchValue {
-  required int64 timestamp = 1;
+  required int64 timestamp = 1; // epoch millis
   optional double sum = 2;
   optional double min = 3;
   optional double max = 4;
   optional double count = 5;
+  optional int64 updateTimestamp = 6; // 60s normalized epoch millis
+  optional bool published = 7;
 }
 
 message CloudWatchCacheEntry {

--- a/atlas-cloudwatch/src/main/resources/cloudhsm.conf
+++ b/atlas-cloudwatch/src/main/resources/cloudhsm.conf
@@ -141,7 +141,7 @@ atlas {
         {
           name = "HsmUnhealthy"
           alias = "aws.hsm.unhealthy"
-          conversion = "max"
+          conversion = "max" // not good enough, we get double samples and this misses the sum sometimes.
           tags = [
             {
               key = "nf.app"

--- a/atlas-cloudwatch/src/main/resources/dynamodb.conf
+++ b/atlas-cloudwatch/src/main/resources/dynamodb.conf
@@ -138,7 +138,7 @@ atlas {
     dynamodb-capacity = {
       namespace = "AWS/DynamoDB"
       period = 1m
-      end-period-offset = 6
+      grace-override = 5
 
       dimensions = [
         "TableName"

--- a/atlas-cloudwatch/src/main/resources/opensearch.conf
+++ b/atlas-cloudwatch/src/main/resources/opensearch.conf
@@ -1,0 +1,176 @@
+
+atlas {
+  cloudwatch {
+
+    // https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managedomains-cloudwatchmetrics.html
+    opensearch = {
+      namespace = "ES/OpenSearchService"
+      period = 1m
+      end-period-offset = 7
+
+      dimensions = [
+        "ClientId",
+        "DomainName"
+      ]
+
+      metrics = [
+        {
+          name = "Nodes"
+          alias = "aws.es.clusterSize"
+          conversion = "max"
+        },
+        {
+          name = "SearchableDocuments"
+          alias = "aws.es.indexSize"
+          conversion = "max"
+          tags = [
+            {
+              key = "status"
+              value = "searchable"
+            }
+          ]
+        },
+        {
+          name = "DeletedDocuments"
+          alias = "aws.es.indexSize"
+          conversion = "max"
+          tags = [
+            {
+              key = "status"
+              value = "deleted"
+            }
+          ]
+        },
+        {
+          name = "DiskQueueDepth"
+          alias = "aws.es.diskQueueDepth"
+          conversion = "max"
+        },
+        {
+          name = "ReadLatency"
+          alias = "aws.es.ioLatency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteLatency"
+          alias = "aws.es.ioLatency"
+          conversion = "timer"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "ReadThroughput"
+          alias = "aws.es.ioThroughput"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteThroughput"
+          alias = "aws.es.ioThroughput"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "ReadIOPS"
+          alias = "aws.es.iops"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "WriteIOPS"
+          alias = "aws.es.iops"
+          conversion = "sum"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "FreeStorageSpace"
+          alias = "aws.es.freeStorageSpace"
+          conversion = "min"
+        },
+        {
+          name = "JVMMemoryPressure"
+          alias = "aws.es.jvmMemoryPressure"
+          conversion = "max"
+        },
+        {
+          name = "MasterJVMMemoryPressure"
+          alias = "aws.esmaster.jvmMemoryPressure"
+          conversion = "max"
+        },
+        {
+          name = "CPUUtilization"
+          alias = "aws.es.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "MasterCPUUtilization"
+          alias = "aws.esmaster.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "ClusterStatus.green"
+          alias = "aws.es.clusterStatus"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "green"
+            }
+          ]
+        },
+        {
+          name = "ClusterStatus.yellow"
+          alias = "aws.es.clusterStatus"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "yellow"
+            }
+          ]
+        },
+        {
+          name = "ClusterStatus.red"
+          alias = "aws.es.clusterStatus"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "red"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -120,6 +120,9 @@ atlas {
     // Whether or not metrics should be pre-pended with TEST.
     testMode = false
 
+    // How many periods to look back from the scrape time for unpublished values.
+    grace = 3
+
     // How often to run the publish thread.
     step = 60s
 
@@ -141,6 +144,10 @@ atlas {
 
     metrics-get-buffer-size = 10
     metrics-get-max-rate-per-second = 400
+
+    // How many entries to keep in the cache. We iterate over the values on each publish to determine
+    // the optimal value to write.
+    min-cache-entries = 6
 
     // Class to use for mapping AWS dimensions to a tag map for use in Atlas
     tagger = {
@@ -543,6 +550,7 @@ atlas {
       "nlb",
       "nlb-zone",
       "nlb-tg-zone",
+      "opensearch",
       "rds",
       "rds-cluster",
       "rds-cpu",
@@ -591,6 +599,7 @@ include "memorydb.conf"
 include "nat-gateway.conf"
 include "neptune.conf"
 include "nlb.conf"
+include "opensearch.conf"
 include "rds.conf"
 include "redshift.conf"
 include "route53.conf"

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
@@ -265,6 +265,7 @@ class CloudWatchPoller(
     offset: Int
   ) {
 
+    private val minCacheEntries = config.getInt("atlas.cloudwatch.min-cache-entries")
     private val nowMillis = now.toEpochMilli
     private[cloudwatch] val expecting = new AtomicInteger()
     private[cloudwatch] val got = new AtomicInteger()
@@ -387,7 +388,7 @@ class CloudWatchPoller(
 
       @Override def run(): Unit = {
         try {
-          val start = now.minusSeconds(category.periodCount * category.period)
+          val start = now.minusSeconds(minCacheEntries * category.period)
           val request = MetricMetadata(category, definition, metric.dimensions.asScala.toList)
             .toGetRequest(start, now)
           val response = client.getMetricStatistics(request)

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricData.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/MetricData.scala
@@ -16,7 +16,6 @@
 package com.netflix.atlas.cloudwatch
 
 import com.netflix.atlas.cloudwatch.MetricData.DatapointNaN
-import com.netflix.atlas.cloudwatch.MetricData.Zero
 import software.amazon.awssdk.services.cloudwatch.model.Datapoint
 import software.amazon.awssdk.services.cloudwatch.model.StandardUnit
 
@@ -50,31 +49,9 @@ case class MetricData(
           .build()
       }
     } else {
-      current.getOrElse {
-        // We send 0 values for gaps in CloudWatch data because previously, users were
-        // confused or concerned when they saw spans of NaN values in the data reported.
-        // Those spans occur especially for low-volume resources and resources where the
-        // only available period is greater than than the period configured for the
-        // `MetricCategory` (although, that may indicate a misconfiguration).
-        //
-        // This implementation reports `0` if there's no configured timeout or if we've
-        // received at least one datapoint until the timeout is exceeded. It reports `NaN`
-        // until the first datapoint is received or for no data within and beyond the
-        // timeout threshold.
-        //
-        // Requiring at least one datapoint prevents interpolating `0` from startup until
-        // the timeout for obsolete resources.  It may result in NaN gaps for low volume
-        // resources when deploying. But that is likely preferable to suddenly and briefly
-        // reporting `0` for obsolete resources and possibly triggering alerts for those
-        // with expressions that use wildcards for the resource selector.
-        val reportNaN = meta.category.timeout.exists { timeout =>
-          lastReportedTimestamp.fold(true) { timestamp =>
-            java.time.Duration.between(timestamp, now).compareTo(timeout) > 0
-          }
-        }
-
-        if (reportNaN) DatapointNaN else Zero
-      }
+      // now reporting NaN to better align with CloudWatch were values will be missing.
+      // Timeouts were rarely used.
+      current.getOrElse(DatapointNaN)
     }
   }
 }
@@ -91,13 +68,4 @@ object MetricData {
     .unit(StandardUnit.NONE)
     .build()
 
-  private val Zero = Datapoint
-    .builder()
-    .minimum(0.0)
-    .maximum(0.0)
-    .sum(0.0)
-    .sampleCount(0.0)
-    .timestamp(Instant.now())
-    .unit(StandardUnit.NONE)
-    .build()
 }

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/webapi/CloudWatchFirehoseEndpoint.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/webapi/CloudWatchFirehoseEndpoint.scala
@@ -103,14 +103,14 @@ class CloudWatchFirehoseEndpoint(
                     incrementException(ex, true)
                 }
               case unknown => // Ignore unknown fields
-                logger.debug("Skipping unknown firehose record field: {}", unknown)
+                logger.warn("Skipping unknown firehose record field: {}", unknown)
                 parser.nextToken()
                 parser.skipChildren()
                 unknownField.increment()
             }
           }
         case unknown => // Ignore unknown fields
-          logger.debug("Skipping unknown firehose field: {}", unknown)
+          logger.warn("Skipping unknown firehose field: {}", unknown)
           parser.nextToken()
           parser.skipChildren()
           unknownField.increment()
@@ -160,7 +160,7 @@ object CloudWatchFirehoseEndpoint extends StrictLogging {
           dp.timestamp(Instant.ofEpochMilli(parser.nextLongValue(0L)))
         case "value" => decodeValue(parser, dp)
         case unknown => // Ignore unknown fields
-          logger.debug("Skipping unknown firehose metric field: {}", unknown)
+          logger.warn("Skipping unknown firehose metric field: {}", unknown)
           parser.nextToken()
           parser.skipChildren()
       }
@@ -238,7 +238,7 @@ object CloudWatchFirehoseEndpoint extends StrictLogging {
       case unknown => // Ignore unknown fields
         // TODO - Extend this if we need to record any of the other fields offered by AWS.
         // Note that each field is an additional financial cost though.
-        logger.debug("Skipping unknown value field: {}", unknown)
+        logger.warn("Skipping unknown value field: {}", unknown)
         parser.nextToken()
         parser.skipChildren()
     }

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/webapi/RulesEndpoint.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/webapi/RulesEndpoint.scala
@@ -77,16 +77,12 @@ class RulesEndpoint(
           val (category, definitions) = tuple
           json.writeObjectFieldStart(metric)
           json.writeNumberField("period", category.period)
-          json.writeNumberField("periodCount", category.periodCount)
-          json.writeNumberField("endPeriodOffset", category.endPeriodOffset)
+          json.writeNumberField("graceOverride", category.graceOverride)
 
           json.writeArrayFieldStart("dimensions")
           category.dimensions.foreach(json.writeString(_))
           json.writeEndArray()
 
-          if (category.timeout.isDefined) {
-            json.writeStringField("timeout", category.timeout.get.toString)
-          }
           if (category.filter.isDefined) {
             json.writeStringField("filter", category.filter.get.toString)
           }

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/BaseCloudWatchMetricsProcessorSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/BaseCloudWatchMetricsProcessorSuite.scala
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.makeFirehoseMetric
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.nts
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.ts
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.newCacheEntry
+import com.netflix.spectator.api.DefaultRegistry
+import com.netflix.spectator.api.Registry
+import com.typesafe.config.ConfigFactory
+import munit.Assertions.assertEquals
+import munit.FunSuite
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.testkit.ImplicitSender
+import org.apache.pekko.testkit.TestKitBase
+import org.junit.Ignore
+import org.mockito.MockitoSugar.mock
+import org.mockito.captor.ArgCaptor
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+
+import java.time.Instant
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters.IterableHasAsJava
+
+@Ignore
+class BaseCloudWatchMetricsProcessorSuite extends FunSuite with TestKitBase with ImplicitSender {
+
+  override implicit def system: ActorSystem = ActorSystem("Test")
+
+  var registry: Registry = null
+  var publishRouter: PublishRouter = null
+  var processor: CloudWatchMetricsProcessor = null
+  var routerCaptor = ArgCaptor[AtlasDatapoint]
+  var debugger: CloudWatchDebugger = null
+  val config = ConfigFactory.load()
+  val tagger = new NetflixTagger(config.getConfig("atlas.cloudwatch.tagger"))
+  val rules: CloudWatchRules = new CloudWatchRules(config)
+  val category = MetricCategory("AWS/DynamoDB", 60, -1, List("MyTag"), List.empty, null)
+  val category5m = MetricCategory("AWS/DynamoDB", 300, -1, List("MyTag"), List.empty, null)
+
+  val cwDP = newCacheEntry(
+    makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), ts(-2.minutes)),
+    category,
+    nts
+  )
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    registry = new DefaultRegistry()
+    publishRouter = mock[PublishRouter]
+    debugger = new CloudWatchDebugger(config, registry)
+    processor =
+      new LocalCloudWatchMetricsProcessor(config, registry, rules, tagger, publishRouter, debugger)
+    routerCaptor = ArgCaptor[AtlasDatapoint]
+  }
+
+}
+
+object BaseCloudWatchMetricsProcessorSuite {
+
+  val ts = 1672531745000L
+
+  /** To the next minute */
+  val nts = 1672531800000L
+
+  def ts(duration: Duration): Long = ts + duration.toMillis
+
+  def nts(duration: Duration): Long = nts + duration.toMillis
+
+  def offset(duration: Duration): Long = duration.toMillis
+
+  def ce(
+    entries: Seq[CloudWatchValue]
+  ): CloudWatchCacheEntry = {
+    val builder = CloudWatchCacheEntry
+      .newBuilder()
+      .setMetric("SumRate")
+      .setNamespace("AWS/UT1")
+      .setUnit("Count")
+      .addAllData(entries.toList.asJava)
+    builder.build()
+  }
+
+  def cwv(
+    timestamp: Duration,
+    update: Duration,
+    published: Boolean,
+    values: Option[Array[Double]] = None
+  ): CloudWatchValue = {
+    val bldr = CloudWatchValue
+      .newBuilder()
+      .setTimestamp(ts(timestamp))
+      .setUpdateTimestamp(nts(update))
+      .setPublished(published)
+    if (values.isDefined) {
+      val v = values.get
+      bldr.setSum(v(0))
+      bldr.setMin(v(1))
+      bldr.setMax(v(2))
+      bldr.setCount(v(3))
+    } else {
+      bldr.setSum(1.0)
+      bldr.setMin(1.0)
+      bldr.setMax(1.0)
+      bldr.setCount(1.0)
+    }
+    bldr.build()
+  }
+
+  def assertCWDP(
+    cwdp: CloudWatchValue,
+    timestamp: Long,
+    values: Array[Double],
+    updateTimestamp: Long = nts
+  ): Unit = {
+    assertEquals(cwdp.getTimestamp, timestamp)
+    assertEquals(cwdp.getUpdateTimestamp, updateTimestamp)
+    assertEquals(cwdp.getSum, values(0))
+    assertEquals(cwdp.getMin, values(1))
+    assertEquals(cwdp.getMax, values(2))
+    assertEquals(cwdp.getCount, values(3))
+  }
+
+  def assertAWSDP(dp: Datapoint, values: Array[Double], ts: Long, unit: String): Unit = {
+    assertEquals(dp.sum().asInstanceOf[Double], values(0))
+    assertEquals(dp.minimum().asInstanceOf[Double], values(1))
+    assertEquals(dp.maximum().asInstanceOf[Double], values(2))
+    assertEquals(dp.sampleCount().asInstanceOf[Double], values(3))
+    assertEquals(dp.timestamp().toEpochMilli, ts)
+    assertEquals(dp.unit().toString, unit)
+  }
+
+  def makeFirehoseMetric(values: Array[Double], ts: Long): FirehoseMetric = {
+    makeFirehoseMetric(
+      "AWS/UT1",
+      "SumRate",
+      List(Dimension.builder().name("MyTag").value("Val").build()),
+      values,
+      "Count",
+      ts
+    )
+  }
+
+  def makeFirehoseMetric(
+    ns: String,
+    metric: String,
+    dimensions: List[Dimension],
+    values: Array[Double],
+    unit: String,
+    ts: Long = ts,
+    streamName: String = "unitTest"
+  ): FirehoseMetric = {
+    FirehoseMetric(
+      streamName,
+      ns,
+      metric,
+      dimensions,
+      Datapoint
+        .builder()
+        .timestamp(Instant.ofEpochMilli(ts))
+        .sum(values(0))
+        .minimum(values(1))
+        .maximum(values(2))
+        .sampleCount(values(3))
+        .unit(unit)
+        .build()
+    )
+  }
+
+  def makeDatapoint(
+    values: Array[Double],
+    ts: Long = ts,
+    unit: String = "Rate"
+  ): Datapoint = {
+    Datapoint
+      .builder()
+      .timestamp(Instant.ofEpochMilli(ts))
+      .sum(values(0))
+      .minimum(values(1))
+      .maximum(values(2))
+      .sampleCount(values(3))
+      .unit(unit)
+      .build()
+  }
+
+  case class CWDP(
+    metric: String,
+    values: Array[Double],
+    dimensions: Int = 3,
+    wTimestamp: Boolean = true
+  ) {
+
+    def encode(json: JsonGenerator): Unit = {
+      json.writeStartObject()
+      json.writeStringField("metric_stream_name", "Stream1")
+      for (i <- 0 until Math.min(dimensions, 2)) {
+        if (i == 0) json.writeStringField("account_id", "1234")
+        if (i == 1) json.writeStringField("region", "us-west-2")
+      }
+      json.writeStringField("namespace", "UT/Test")
+      if (metric != null) {
+        json.writeStringField("metric_name", metric)
+      }
+      json.writeStringField("unit", "None")
+      if (wTimestamp) {
+        json.writeNumberField("timestamp", ts)
+      }
+      if (dimensions >= 3) {
+        json.writeObjectFieldStart("dimensions")
+        json.writeStringField("AwsTag", "AwsVal")
+        json.writeEndObject()
+      }
+      if (values != null) {
+        json.writeObjectFieldStart("value")
+        for (i <- 0 until values.length) {
+          if (i == 0) json.writeNumberField("sum", values(i))
+          if (i == 1) json.writeNumberField("min", values(i))
+          if (i == 2) json.writeNumberField("max", values(i))
+          if (i == 3) json.writeNumberField("count", values(i))
+          if (i > 3) json.writeNumberField(s"val${i}", values(i))
+        }
+        json.writeEndObject()
+      }
+      json.writeEndObject()
+    }
+
+  }
+
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CWMPInsertSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CWMPInsertSuite.scala
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.assertCWDP
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.ce
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.cwv
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.makeFirehoseMetric
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.nts
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.ts
+
+import scala.concurrent.duration.DurationInt
+
+class CWMPInsertSuite extends BaseCloudWatchMetricsProcessorSuite {
+
+  test("insertDatapoint empty") {
+    val updated = processor.insertDatapoint(
+      cwDP.toBuilder.clearData().build().toByteArray,
+      makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), ts(-1.minutes)),
+      category,
+      nts
+    )
+    assertEquals(updated.getDataCount, 1)
+    assertCWDP(updated.getData(0), ts(-1.minutes), Array(39.0, 1.0, 7.0, 19))
+    assertCounters(appended = 1)
+  }
+
+  test("insertDatapoint after") {
+    val updated = processor.insertDatapoint(
+      ce(
+        List(
+          cwv(-2.minutes, -1.minutes, false, Some(Array(39.0, 1.0, 7.0, 19)))
+        )
+      ).toByteArray,
+      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), ts(-1.minute)),
+      category,
+      nts
+    )
+    assertEquals(updated.getDataCount, 2)
+    assertCWDP(updated.getData(0), ts(-2.minute), Array(39.0, 1.0, 7.0, 19), nts(-1.minute))
+    assertCWDP(updated.getData(1), ts(-1.minute), Array(80.0, 2.0, 6.0, 5))
+    assertCounters(appended = 1)
+  }
+
+  test("insertDatapoint before") {
+    val updated = processor.insertDatapoint(
+      ce(
+        List(
+          cwv(-2.minutes, -1.minutes, false, Some(Array(39.0, 1.0, 7.0, 19)))
+        )
+      ).toByteArray,
+      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), ts(-3.minute)),
+      category,
+      nts
+    )
+    assertEquals(updated.getDataCount, 2)
+    assertCWDP(updated.getData(0), ts(-3.minute), Array(80.0, 2.0, 6.0, 5))
+    assertCWDP(updated.getData(1), ts(-2.minute), Array(39.0, 1.0, 7.0, 19), nts(-1.minutes))
+    assertCounters(ooo = 1)
+  }
+
+  test("insertDatapoint before published") {
+    val updated = processor.insertDatapoint(
+      ce(
+        List(
+          cwv(-2.minutes, -1.minutes, true, Some(Array(39.0, 1.0, 7.0, 19)))
+        )
+      ).toByteArray,
+      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), ts(-3.minute)),
+      category,
+      nts
+    )
+    assertEquals(updated.getDataCount, 2)
+    assertCWDP(updated.getData(0), ts(-3.minute), Array(80.0, 2.0, 6.0, 5))
+    assertCWDP(updated.getData(1), ts(-2.minute), Array(39.0, 1.0, 7.0, 19), nts(-1.minutes))
+    assertCounters(beforePublished = 1)
+  }
+
+  test("insertDatapoint between") {
+    val updated = processor.insertDatapoint(
+      ce(
+        List(
+          cwv(-4.minutes, -3.minutes, false, Some(Array(80.0, 2.0, 6.0, 5))),
+          cwv(-2.minutes, -1.minutes, false, Some(Array(39.0, 1.0, 7.0, 19)))
+        )
+      ).toByteArray,
+      makeFirehoseMetric(Array(2.0, 0.0, 1.0, 2), ts(-3.minutes)),
+      category,
+      nts
+    )
+    assertEquals(updated.getDataCount, 3)
+    assertCWDP(updated.getData(0), ts(-4.minutes), Array(80.0, 2.0, 6.0, 5), nts(-3.minutes))
+    assertCWDP(updated.getData(1), ts(-3.minutes), Array(2.0, 0.0, 1.0, 2))
+    assertCWDP(updated.getData(2), ts(-2.minutes), Array(39.0, 1.0, 7.0, 19), nts(-1.minute))
+    assertCounters(ooo = 1)
+  }
+
+  test("insertDatapoint duplicate same value") {
+    val updated = processor.insertDatapoint(
+      ce(
+        List(
+          cwv(-2.minutes, -1.minutes, false, Some(Array(39.0, 1.0, 7.0, 19)))
+        )
+      ).toByteArray,
+      makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), ts(-2.minutes)),
+      category,
+      nts
+    )
+    assertEquals(updated.getDataCount, 1)
+    assertCWDP(updated.getData(0), ts(-2.minutes), Array(39.0, 1.0, 7.0, 19), nts(-1.minute))
+    assertCounters(dupes = 1)
+  }
+
+  test("insertDatapoint update oldest entry") {
+    val updated = processor.insertDatapoint(
+      ce(
+        List(
+          cwv(-3.minutes, -2.minutes, false, Some(Array(2.0, 0.0, 1.0, 2))),
+          cwv(-2.minutes, -1.minutes, false, Some(Array(39.0, 1.0, 7.0, 19))),
+          cwv(-1.minutes, 0.minutes, false, Some(Array(80.0, 2.0, 6.0, 5)))
+        )
+      ).toByteArray,
+      makeFirehoseMetric(Array(-1.0, -1.0, -1.0, -2), ts(-3.minutes)),
+      category,
+      nts
+    )
+    assertEquals(updated.getDataCount, 3)
+    assertCWDP(updated.getData(0), ts(-3.minutes), Array(-1.0, -1.0, -1.0, -2))
+    assertCWDP(updated.getData(1), ts(-2.minutes), Array(39.0, 1.0, 7.0, 19), nts(-1.minutes))
+    assertCWDP(updated.getData(2), ts(-1.minutes), Array(80.0, 2.0, 6.0, 5), nts)
+    assertCounters(updates = 1)
+  }
+
+  test("insertDatapoint same middle") {
+    val updated = processor.insertDatapoint(
+      ce(
+        List(
+          cwv(-3.minutes, -2.minutes, false, Some(Array(2.0, 0.0, 1.0, 2))),
+          cwv(-2.minutes, -1.minutes, false, Some(Array(39.0, 1.0, 7.0, 19))),
+          cwv(-1.minutes, 0.minutes, false, Some(Array(80.0, 2.0, 6.0, 5)))
+        )
+      ).toByteArray,
+      makeFirehoseMetric(Array(-1.0, -1.0, -1.0, -2), ts(-2.minute)),
+      category,
+      nts
+    )
+    assertEquals(updated.getDataCount, 3)
+    assertCWDP(updated.getData(0), ts(-3.minutes), Array(2.0, 0.0, 1.0, 2), nts(-2.minutes))
+    assertCWDP(updated.getData(1), ts(-2.minutes), Array(-1.0, -1.0, -1.0, -2))
+    assertCWDP(updated.getData(2), ts(-1.minute), Array(80.0, 2.0, 6.0, 5))
+    assertCounters(updates = 1)
+  }
+
+  test("insertDatapoint same last") {
+    val updated = processor.insertDatapoint(
+      ce(
+        List(
+          cwv(-3.minutes, -2.minutes, false, Some(Array(2.0, 0.0, 1.0, 2))),
+          cwv(-2.minutes, -1.minutes, false, Some(Array(39.0, 1.0, 7.0, 19))),
+          cwv(-1.minutes, 0.minutes, false, Some(Array(80.0, 2.0, 6.0, 5)))
+        )
+      ).toByteArray,
+      makeFirehoseMetric(Array(-1.0, -1.0, -1.0, -2), ts(-1.minute)),
+      category,
+      nts
+    )
+    assertEquals(updated.getDataCount, 3)
+    assertCWDP(updated.getData(0), ts(-3.minutes), Array(2.0, 0.0, 1.0, 2), nts(-2.minutes))
+    assertCWDP(updated.getData(1), ts(-2.minutes), Array(39.0, 1.0, 7.0, 19), nts(-1.minute))
+    assertCWDP(updated.getData(2), ts(-1.minute), Array(-1.0, -1.0, -1.0, -2))
+    assertCounters(updates = 1)
+  }
+
+  test("insertDatapoint evict") {
+    var updated: CloudWatchCacheEntry = null
+    for (i <- 15 until 2 by -1) {
+      updated = processor.insertDatapoint(
+        if (updated == null) {
+          cwDP.toBuilder.clearData().build().toByteArray
+        } else {
+          updated.toByteArray
+        },
+        makeFirehoseMetric(Array(i, i, i, i), ts(-i.minutes)),
+        category,
+        nts(-i.minutes)
+      )
+    }
+    assertEquals(updated.getDataCount, 6)
+    var idx = 0
+    for (i <- 8 until 2 by -1) {
+      assertCWDP(updated.getData(idx), ts(-i.minutes), Array(i, i, i, i), nts(-i.minutes))
+      idx += 1
+    }
+    assertCounters(appended = 13)
+  }
+
+  def assertCounters(
+    updates: Long = 0,
+    dupes: Long = 0,
+    ooo: Long = 0,
+    beforePublished: Long = 0,
+    inserted: Long = 0,
+    appended: Long = 0
+  ): Unit = {
+    assertEquals(
+      registry
+        .counter(
+          processor.insert.withTags(
+            "aws.namespace",
+            category.namespace,
+            "aws.metric",
+            "SumRate",
+            "state",
+            "updated"
+          )
+        )
+        .count(),
+      updates
+    )
+    assertEquals(
+      registry
+        .counter(
+          processor.insert.withTags(
+            "aws.namespace",
+            category.namespace,
+            "aws.metric",
+            "SumRate",
+            "state",
+            "duplicates"
+          )
+        )
+        .count(),
+      dupes
+    )
+    assertEquals(
+      registry
+        .counter(
+          processor.insert
+            .withTags("aws.namespace", category.namespace, "aws.metric", "SumRate", "state", "ooo")
+        )
+        .count(),
+      ooo
+    )
+    assertEquals(
+      registry
+        .counter(
+          processor.insert.withTags(
+            "aws.namespace",
+            category.namespace,
+            "aws.metric",
+            "SumRate",
+            "state",
+            "beforePublished"
+          )
+        )
+        .count(),
+      beforePublished
+    )
+    assertEquals(
+      registry
+        .counter(
+          processor.insert.withTags(
+            "aws.namespace",
+            category.namespace,
+            "aws.metric",
+            "SumRate",
+            "state",
+            "inserted"
+          )
+        )
+        .count(),
+      inserted
+    )
+    assertEquals(
+      registry
+        .counter(
+          processor.insert.withTags(
+            "aws.namespace",
+            category.namespace,
+            "aws.metric",
+            "SumRate",
+            "state",
+            "appended"
+          )
+        )
+        .count(),
+      appended
+    )
+  }
+
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CWMPProcessSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CWMPProcessSuite.scala
@@ -1,0 +1,620 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.makeDatapoint
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.makeFirehoseMetric
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.ts
+import com.netflix.atlas.core.model.Query
+import org.mockito.Mockito.when
+import org.mockito.MockitoSugar.spy
+import org.mockito.MockitoSugar.times
+import org.mockito.MockitoSugar.verify
+import software.amazon.awssdk.services.cloudwatch.model.Dimension
+
+import scala.concurrent.duration.DurationInt
+
+class CWMPProcessSuite extends BaseCloudWatchMetricsProcessorSuite {
+
+  test("processDatapoints Empty") {
+    val hash = makeFirehoseMetric(Array(1.0, 1.0, 1.0, 1), ts).xxHash
+    processor
+      .asInstanceOf[LocalCloudWatchMetricsProcessor]
+      .inject(hash, cwDP.toBuilder.clearData().build().toByteArray, ts, 3600)
+
+    assertPublished(List.empty, ts(10.minutes))
+    assertCounters(0, publishEmpty = 1, scraped = 1)
+  }
+
+  test("processDatapoints No namespace config") {
+    processor.processDatapoints(
+      List(
+        makeFirehoseMetric(
+          "AWS/SomeNoneExistingNS",
+          "MyMetric",
+          List.empty,
+          Array(1.0, 1.0, 1.0, 1),
+          "Bytes"
+        )
+      ),
+      ts
+    )
+    assertPublished(List.empty)
+    assertCounters(1, filtered = Map("namespace" -> (1, "AWS/SomeNoneExistingNS")))
+  }
+
+  test("processDatapoints no metric match") {
+    processor.processDatapoints(
+      List(
+        makeFirehoseMetric(
+          "AWS/UT1",
+          "SomeUnknownMetric",
+          List(Dimension.builder().name("Key").value("Value").build()),
+          Array(39.0, 1.0, 7.0, 19),
+          "Count"
+        )
+      ),
+      ts
+    )
+    assertPublished(List.empty)
+    assertCounters(1, filtered = Map("metric" -> (1, "AWS/UT1")))
+  }
+
+  test("processDatapoints missing tag") {
+    processor.processDatapoints(
+      List(
+        makeFirehoseMetric(
+          "AWS/UT1",
+          "SumRate",
+          List(Dimension.builder().name("NotTheRightTag").value("Whoops").build()),
+          Array(39.0, 1.0, 7.0, 19),
+          "Count"
+        )
+      ),
+      ts
+    )
+    assertPublished(List.empty)
+    assertCounters(1, filtered = Map("tags" -> (1, "AWS/UT1")))
+  }
+
+  test("processDatapoints Filter by query") {
+    processor.processDatapoints(
+      List(
+        makeFirehoseMetric(
+          "AWS/UTQueryFilter",
+          "MyTestMetric",
+          List(Dimension.builder().name("Key").value("Whoops").build()),
+          Array(39.0, 1.0, 7.0, 19),
+          "Count"
+        )
+      ),
+      ts
+    )
+    assertPublished(List.empty)
+    assertCounters(1, filtered = Map("query" -> (1, "AWS/UTQueryFilter")))
+  }
+
+  test("processDatapoints matched dist-summary") {
+    val dp = makeFirehoseMetric(
+      "AWS/UT1",
+      "Dist",
+      List(Dimension.builder().name("MyTag").value("Val").build()),
+      Array(39.0, 1.0, 7.0, 19),
+      "Count",
+      ts(-1.minute)
+    )
+    processor.processDatapoints(List(dp), ts(-1.minute))
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.dist",
+            "statistic"    -> "count",
+            "nf.region"    -> "us-west-2",
+            "aws.tag"      -> "Val",
+            "atlas.dstype" -> "rate"
+          ),
+          ts,
+          0.31666666666666665
+        ),
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.dist",
+            "statistic"    -> "totalAmount",
+            "nf.region"    -> "us-west-2",
+            "aws.tag"      -> "Val",
+            "atlas.dstype" -> "rate"
+          ),
+          ts,
+          0.65
+        ),
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.dist",
+            "statistic"    -> "max",
+            "nf.region"    -> "us-west-2",
+            "aws.tag"      -> "Val",
+            "atlas.dstype" -> "gauge"
+          ),
+          ts,
+          7.0
+        )
+      )
+    )
+    assertCounters(1)
+  }
+
+  test("processDatapoints matched timer") {
+    val dp = makeFirehoseMetric(
+      "AWS/UT1",
+      "Timer",
+      List(
+        Dimension.builder().name("LoadBalancerName").value("some-elb").build(),
+        Dimension.builder().name("AvailabilityZone").value("a").build()
+      ),
+      Array(0.1226732730865479, 0.1226732730865479, 0.1226732730865479, 1),
+      "Timer",
+      ts(-1.minute)
+    )
+    processor.processDatapoints(List(dp), ts(-1.minute))
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.timer",
+            "aws.elb"      -> "some-elb",
+            "statistic"    -> "count",
+            "nf.region"    -> "us-west-2",
+            "nf.cluster"   -> "some-elb",
+            "nf.stack"     -> "elb",
+            "nf.app"       -> "some",
+            "nf.zone"      -> "a",
+            "atlas.dstype" -> "rate"
+          ),
+          ts,
+          0.016666666666666666
+        ),
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.timer",
+            "aws.elb"      -> "some-elb",
+            "statistic"    -> "totalTime",
+            "nf.region"    -> "us-west-2",
+            "nf.cluster"   -> "some-elb",
+            "nf.stack"     -> "elb",
+            "nf.app"       -> "some",
+            "nf.zone"      -> "a",
+            "atlas.dstype" -> "rate"
+          ),
+          ts,
+          0.0020445545514424647
+        ),
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.timer",
+            "aws.elb"      -> "some-elb",
+            "statistic"    -> "max",
+            "nf.region"    -> "us-west-2",
+            "nf.cluster"   -> "some-elb",
+            "nf.stack"     -> "elb",
+            "nf.app"       -> "some",
+            "nf.zone"      -> "a",
+            "atlas.dstype" -> "gauge"
+          ),
+          ts,
+          0.1226732730865479
+        )
+      )
+    )
+    assertCounters(1)
+  }
+
+  test("processDatapoints matched bytes") {
+    val dp = makeFirehoseMetric(
+      "AWS/UT1",
+      "Bytes",
+      List(
+        Dimension.builder().name("LoadBalancerName").value("some-elb").build(),
+        Dimension.builder().name("AvailabilityZone").value("a").build()
+      ),
+      Array(1.6903156e7, 8378272.0, 8524884.0, 2),
+      "Bytes",
+      ts(-1.minute)
+    )
+    processor.processDatapoints(List(dp), ts(-1.minute))
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.bytes",
+            "aws.elb"      -> "some-elb",
+            "nf.region"    -> "us-west-2",
+            "nf.zone"      -> "a",
+            "nf.cluster"   -> "some-elb",
+            "nf.stack"     -> "elb",
+            "nf.app"       -> "some",
+            "atlas.dstype" -> "rate"
+          ),
+          ts,
+          281719.26666666666
+        )
+      )
+    )
+    assertCounters(1)
+  }
+
+  test("processDatapoints matched percent") {
+    processor.processDatapoints(
+      List(
+        makeFirehoseMetric(
+          "AWS/UT1",
+          "Max",
+          List(Dimension.builder().name("MyTag").value("Val").build()),
+          Array(4.1320470343685605, 4.1320470343685605, 4.1320470343685605, 1),
+          "Percent",
+          ts(-1.minute)
+        )
+      ),
+      ts
+    )
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.max",
+            "aws.tag"      -> "Val",
+            "nf.region"    -> "us-west-2",
+            "atlas.dstype" -> "gauge"
+          ),
+          ts,
+          4.1320470343685605
+        )
+      )
+    )
+    assertCounters(1)
+  }
+
+  test("processDatapoints config with end period offset") {
+    // 1 end period offset so we back date.
+    val dp = makeFirehoseMetric(
+      "AWS/UT1",
+      "Offset",
+      List(Dimension.builder().name("MyTag").value("Val").build()),
+      Array(1, 1, 1, 1),
+      "None",
+      ts
+    )
+    processor.processDatapoints(List(dp), ts)
+    processor.processDatapoints(
+      List(
+        dp.copy(
+          datapoint = makeDatapoint(Array(2, 2, 2, 1), ts(1.minute), "None")
+        )
+      ),
+      ts(1.minute)
+    )
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.offset",
+            "aws.tag"      -> "Val",
+            "nf.region"    -> "us-west-2",
+            "atlas.dstype" -> "gauge"
+          ),
+          ts(1.minute),
+          1
+        )
+      ),
+      ts(1.minute)
+    )
+    assertCounters(2)
+  }
+
+  test("processDatapoints config with monotonic") {
+    var dp = makeFirehoseMetric(
+      "AWS/UT1",
+      "Mono",
+      List(Dimension.builder().name("MyTag").value("Val").build()),
+      Array(60, 60, 60, 1),
+      "None",
+      ts(-2.minute)
+    )
+    processor.processDatapoints(List(dp), ts(-2.minute))
+
+    dp = dp.copy(datapoint = makeDatapoint(Array(120, 120, 120, 1), ts(-1.minute)))
+    processor.processDatapoints(List(dp), ts(-1.minute))
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.mono",
+            "nf.region"    -> "us-west-2",
+            "aws.tag"      -> "Val",
+            "atlas.dstype" -> "rate"
+          ),
+          ts,
+          1.0
+        )
+      )
+    )
+    assertCounters(2)
+  }
+
+  test("processDatapoints rate") {
+    val dp = makeFirehoseMetric(
+      "AWS/UT1",
+      "5Min",
+      List(Dimension.builder().name("MyTag").value("Val").build()),
+      Array(1, 1, 1, 1),
+      "None",
+      ts(-5.minute)
+    )
+    processor.processDatapoints(List(dp), ts(-5.minute))
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.5min",
+            "nf.region"    -> "us-west-2",
+            "aws.tag"      -> "Val",
+            "atlas.dstype" -> "rate"
+          ),
+          ts,
+          0.0033333333333333335
+        )
+      )
+    )
+    assertCounters(1)
+  }
+
+  test("processDatapoints purged namespace") {
+    val ruleSpy = spy(rules)
+    when(ruleSpy.rules)
+      .thenCallRealMethod()
+      .thenReturn(Map.empty)
+    processor = new LocalCloudWatchMetricsProcessor(
+      config,
+      registry,
+      ruleSpy,
+      tagger,
+      publishRouter,
+      debugger
+    )
+    processor.processDatapoints(
+      List(makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), ts)),
+      ts
+    )
+
+    assertPublished(List.empty)
+    assertCounters(1, purged = Map("namespace" -> 1), scraped = 1)
+  }
+
+  test("processDatapoints purged metric") {
+    val ruleSpy = spy(rules)
+    when(ruleSpy.rules)
+      .thenCallRealMethod()
+      .thenReturn(Map("AWS/UT1" -> Map("SomeMetric" -> (category, List.empty))))
+    processor = new LocalCloudWatchMetricsProcessor(
+      config,
+      registry,
+      ruleSpy,
+      tagger,
+      publishRouter,
+      debugger
+    )
+    processor.processDatapoints(
+      List(makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), ts)),
+      ts
+    )
+
+    assertPublished(List.empty)
+    assertCounters(1, purged = Map("metric" -> 1), scraped = 1)
+  }
+
+  test("processDatapoints purged tags") {
+    val ruleSpy = spy(rules)
+    when(ruleSpy.rules)
+      .thenCallRealMethod()
+      .thenReturn(
+        Map(
+          "AWS/UT1" -> Map(
+            "SumRate" ->
+              (category.copy(dimensions = List("SomeOtherTag")), List.empty)
+          )
+        )
+      )
+    processor = new LocalCloudWatchMetricsProcessor(
+      config,
+      registry,
+      ruleSpy,
+      tagger,
+      publishRouter,
+      debugger
+    )
+    processor.processDatapoints(
+      List(makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), ts)),
+      ts
+    )
+
+    assertPublished(List.empty)
+    assertCounters(1, purged = Map("tags" -> 1), scraped = 1)
+  }
+
+  test("processDatapoints purged query") {
+    val ruleSpy = spy(rules)
+    when(ruleSpy.rules)
+      .thenCallRealMethod()
+      .thenReturn(
+        Map(
+          "AWS/UT1" -> Map(
+            "SumRate" ->
+              (category.copy(filter = Some(Query.HasKey("MyTag"))), List.empty)
+          )
+        )
+      )
+    processor = new LocalCloudWatchMetricsProcessor(
+      config,
+      registry,
+      ruleSpy,
+      tagger,
+      publishRouter,
+      debugger
+    )
+    processor.processDatapoints(
+      List(makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), ts)),
+      ts
+    )
+
+    assertPublished(List.empty)
+    assertCounters(1, purged = Map("query" -> 1), scraped = 1)
+  }
+
+  test("processDatapoints 2 rules match") {
+    processor.processDatapoints(
+      List(
+        makeFirehoseMetric(
+          "AWS/UT1",
+          "TwoRuleMatch",
+          List(Dimension.builder().name("MyTag").value("Val").build()),
+          Array(39.0, 1.0, 7.0, 19),
+          "None",
+          ts
+        )
+      ),
+      ts
+    )
+
+    // yup, two values with the same tag set. Just the min and max values.
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.2rulematch",
+            "nf.region"    -> "us-west-2",
+            "aws.tag"      -> "Val",
+            "atlas.dstype" -> "gauge"
+          ),
+          ts,
+          1
+        ),
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.utm.2rulematch",
+            "nf.region"    -> "us-west-2",
+            "aws.tag"      -> "Val",
+            "atlas.dstype" -> "gauge"
+          ),
+          ts,
+          7
+        )
+      )
+    )
+    assertCounters(1)
+  }
+
+  def assertPublished(dps: List[AtlasDatapoint], ts: Long = ts): Unit = {
+    processor.publish(ts)
+    verify(publishRouter, times(dps.size)).publish(routerCaptor)
+    assertEquals(routerCaptor.values.size, dps.size)
+
+    dps.foreach { dp =>
+      val metric = routerCaptor.values.filter(_.equals(dp)).headOption match {
+        case Some(d) => d
+        case None =>
+          throw new AssertionError(s"Data point not found: ${dp} in ${routerCaptor.values}")
+      }
+      assertEquals(metric.value, dp.value, s"Wrong value for ${dp.tags}")
+      assertEquals(metric.timestamp, dp.timestamp, s"Wrong value for timestamp ${dp.tags}")
+    }
+  }
+
+  def assertCounters(
+    received: Long,
+    filtered: Map[String, (Long, String)] = Map.empty,
+    droppedOld: Long = 0,
+    purged: Map[String, Long] = Map.empty,
+    publishEmpty: Long = 0,
+    updates: Long = 0,
+    scraped: Long = 0
+  ): Unit = {
+    assertEquals(processor.received.count(), received)
+    List("namespace", "metric", "tags", "query").foreach { reason =>
+      val (count, ns) = filtered.getOrElse(reason, (0L, "NA"))
+      assertEquals(
+        registry
+          .counter("atlas.cloudwatch.datapoints.filtered", "aws.namespace", ns, "reason", reason)
+          .count(),
+        count,
+        s"Count differs for ${reason}"
+      )
+    }
+
+    assertEquals(
+      registry
+        .counter(
+          "atlas.cloudwatch.datapoints.dropped",
+          "reason",
+          "tooOld",
+          "aws.namespace",
+          "AWS/DynamoDB",
+          "aws.metric",
+          "SumRate"
+        )
+        .count(),
+      droppedOld
+    )
+
+    List("namespace", "metric", "tags", "query").foreach { reason =>
+      assertEquals(
+        registry.counter("atlas.cloudwatch.datapoints.purged", "reason", reason).count(),
+        purged.getOrElse(reason, 0L),
+        s"Count differs for ${reason}"
+      )
+    }
+    assertEquals(
+      registry
+        .counter(
+          processor.publishEmpty.withTags("aws.namespace", "AWS/UT1", "aws.metric", "SumRate")
+        )
+        .count(),
+      publishEmpty
+    )
+    assertEquals(
+      registry
+        .counter(
+          processor.cacheUpdates.withTags("aws.namespace", "AWS/UT1", "aws.metric", "SumRate")
+        )
+        .count(),
+      updates
+    )
+    assertEquals(
+      registry
+        .counter(
+          processor.scraped.withTags("aws.namespace", "AWS/UT1", "aws.metric", "SumRate")
+        )
+        .count(),
+      scraped
+    )
+  }
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CWMPPublishPointSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CWMPPublishPointSuite.scala
@@ -1,0 +1,597 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.cloudwatch
+
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.ce
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.cwv
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.nts
+
+import scala.concurrent.duration.DurationInt
+
+class CWMPPublishPointSuite extends BaseCloudWatchMetricsProcessorSuite {
+
+  test("getPublishPoint - empty") {
+    // shouldn't happen
+    val cache = ce(List.empty)
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), -1, cache, false)
+    assertMetrics()
+  }
+
+  test("getPublishPoint - 1 unpublished") {
+    val cache = ce(
+      List(cwv(-2.minutes, -1.minutes, false))
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), 0, cache)
+    assertMetrics(
+      current = 1.minutes.toMillis,
+      wall = 2.minutes.plus(55.seconds).toMillis,
+      pubIndex = 0
+    )
+  }
+
+  test("getPublishPoint - 1 unpublished, within grace period") {
+    val cache = ce(
+      List(cwv(-3.minutes, -2.minutes, false))
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), 0, cache)
+    assertMetrics(
+      grace = 2.minutes.toMillis,
+      wall = 3.minutes.plus(55.seconds).toMillis,
+      pubIndex = 0
+    )
+  }
+
+  test("getPublishPoint - 1 unpublished, out of grace period") {
+    val cache = ce(
+      List(cwv(-5.minutes, -4.minutes, false))
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), -1, cache, false)
+    assertMetrics(unpublished = 4.minutes.toMillis)
+  }
+
+  test("getPublishPoint - 1 unpublished, grace override") {
+    val cache = ce(
+      List(cwv(-5.minutes, -4.minutes, false))
+    )
+    val category = MetricCategory("AWS/DynamoDB", 60, 4, List("MyTag"), List.empty, null)
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), 0, cache, true)
+    assertMetrics(
+      grace = 4.minutes.toMillis,
+      wall = 5.minutes.plus(55.seconds).toMillis,
+      pubIndex = 0
+    )
+  }
+
+  test("getPublishPoint - 1 expired") {
+    val cache = ce(
+      List(cwv(-6.minutes, -5.minutes, false))
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), -1, cache, false)
+    assertMetrics()
+  }
+
+  test("getPublishPoint - 2 values, newest unpublished") {
+    val cache = ce(
+      List(
+        cwv(-3.minutes, -2.minutes, true),
+        cwv(-2.minutes, -1.minutes, false)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), 1, cache)
+    assertMetrics(
+      current = 1.minutes.toMillis,
+      wall = 2.minutes.plus(55.seconds).toMillis,
+      pubIndex = 0
+    )
+  }
+
+  test("getPublishPoint - 2 values, newest unpublished, within grace period") {
+    val cache = ce(
+      List(
+        cwv(-4.minutes, -3.minutes, true),
+        cwv(-3.minutes, -2.minutes, false)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), 1, cache)
+    assertMetrics(
+      grace = 2.minutes.toMillis,
+      wall = 3.minutes.plus(55.seconds).toMillis,
+      pubIndex = 0
+    )
+  }
+
+  test("getPublishPoint - 2 values, newest unpublished, out of grace period") {
+    val cache = ce(
+      List(
+        cwv(-6.minutes, -5.minutes, true),
+        cwv(-5.minutes, -4.minutes, false)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), -1, cache, false)
+    assertMetrics(unpublished = 4.minutes.toMillis)
+  }
+
+  test("getPublishPoint - 2 values, newest expired") {
+    val cache = ce(
+      List(
+        cwv(-7.minutes, -6.minutes, true),
+        cwv(-6.minutes, -5.minutes, false)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), -1, cache, false)
+    assertMetrics()
+  }
+
+  test("getPublishPoint - 2 unpublished, ordered") {
+    val cache = ce(
+      List(
+        cwv(-2.minutes, -1.minutes, false),
+        cwv(-1.minutes, -0.minutes, false)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), 0, cache)
+    assertMetrics(
+      current = 1.minutes.toMillis,
+      wall = 2.minutes.plus(55.seconds).toMillis,
+      pubIndex = 1
+    )
+  }
+
+  test("getPublishPoint - 2 unpublished, out of order") {
+    val cache = ce(
+      List(
+        cwv(-2.minutes, -0.minutes, false),
+        cwv(-1.minutes, -1.minutes, false)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), 0, cache)
+    assertMetrics(
+      current = 0,
+      wall = 2.minutes.plus(55.seconds).toMillis,
+      pubIndex = 1
+    )
+  }
+
+  test("getPublishPoint - 2, newest already published, within cutoff") {
+    val cache = ce(
+      List(
+        cwv(-2.minutes, -1.minutes, false),
+        cwv(-1.minutes, -1.minutes, true)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), -1, cache, false)
+    assertMetrics(alreadyPublished = 1.minutes.toMillis)
+  }
+
+  test("getPublishPoint - 2, newest already published") {
+    val cache = ce(
+      List(
+        cwv(-3.minutes, -2.minutes, false),
+        cwv(-2.minutes, -2.minutes, true)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), -1, cache, false)
+    assertMetrics()
+  }
+
+  test("getPublishPoint - 2, oldest unpublished, out of order") {
+    val cache = ce(
+      List(
+        cwv(-2.minutes, -0.minutes, false),
+        cwv(-1.minutes, -1.minutes, true)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), -1, cache, false)
+    assertMetrics(alreadyPublished = 1.minutes.toMillis)
+  }
+
+  test("getPublishPoint - 2 all published") {
+    val cache = ce(
+      List(
+        cwv(-3.minutes, -2.minutes, true),
+        cwv(-2.minutes, -1.minutes, true)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), -1, cache, false)
+    assertMetrics(alreadyPublished = 1.minutes.toMillis)
+  }
+
+  test("getPublishPoint - 2 all published and expired") {
+    val cache = ce(
+      List(
+        cwv(-4.minutes, -3.minutes, true),
+        cwv(-3.minutes, -2.minutes, true)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), -1, cache, false)
+    assertMetrics()
+  }
+
+  test("getPublishPoint - 3 values, newest unpublished, ordered") {
+    val cache = ce(
+      List(
+        cwv(-4.minutes, -3.minutes, true),
+        cwv(-3.minutes, -2.minutes, true),
+        cwv(-2.minutes, -1.minutes, false)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), 2, cache)
+    assertMetrics(
+      current = 1.minutes.toMillis,
+      wall = 2.minutes.plus(55.seconds).toMillis,
+      pubIndex = 0
+    )
+  }
+
+  test("getPublishPoint - 3 unpublished, oldest within grace") {
+    val cache = ce(
+      List(
+        cwv(-3.minutes, -2.minutes, false),
+        cwv(-2.minutes, -1.minutes, false),
+        cwv(-1.minutes, -0.minutes, false)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), 0, cache)
+    assertMetrics(
+      grace = 2.minutes.toMillis,
+      wall = 3.minutes.plus(55.seconds).toMillis,
+      pubIndex = 2
+    )
+  }
+
+  test("getPublishPoint - 3 unpublished, out of order, oldest within grace") {
+    val cache = ce(
+      List(
+        cwv(-3.minutes, -1.minutes, false),
+        cwv(-2.minutes, -1.minutes, false),
+        cwv(-1.minutes, -2.minutes, false)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), 0, cache)
+    assertMetrics(
+      current = 1.minutes.toMillis,
+      wall = 3.minutes.plus(55.seconds).toMillis,
+      pubIndex = 2
+    )
+  }
+
+  test("getPublishPoint - 3, middle published, out of order, oldest within grace") {
+    val cache = ce(
+      List(
+        cwv(-3.minutes, -1.minutes, false),
+        cwv(-2.minutes, -1.minutes, true),
+        cwv(-1.minutes, -2.minutes, false)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), 2, cache)
+    assertMetrics(
+      grace = 2.minutes.toMillis,
+      wall = 1.minutes.plus(55.seconds).toMillis,
+      pubIndex = 0
+    )
+  }
+
+  test("getPublishPoint - 3 unpublished, oldest out of grace") {
+    val cache = ce(
+      List(
+        cwv(-5.minutes, -4.minutes, false),
+        cwv(-4.minutes, -3.minutes, false),
+        cwv(-3.minutes, -2.minutes, false)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), 1, cache)
+    assertMetrics(
+      grace = 3.minutes.toMillis,
+      unpublished = 4.minutes.toMillis,
+      wall = 4.minutes.plus(55.seconds).toMillis,
+      pubIndex = 1
+    )
+  }
+
+  test("getPublishPoint - 3 unpublished, middle unpublished") {
+    val cache = ce(
+      List(
+        cwv(-4.minutes, -3.minutes, true),
+        cwv(-3.minutes, -2.minutes, false),
+        cwv(-2.minutes, -1.minutes, true)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category), -1, cache, false)
+    assertMetrics(
+      alreadyPublished = 1.minutes.toMillis
+    )
+  }
+
+  test("getPublishPoint - 5m: 1 published, republished") {
+    val cache = ce(
+      List(cwv(-6.minutes, -5.minutes, true))
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category5m), 0, cache, false)
+    assertMetrics(
+      republished = 5.minutes.toMillis,
+      wall = 6.minutes.plus(55.seconds).toMillis,
+      pubIndex = 0,
+      fiveMin = true
+    )
+  }
+
+  test("getPublishPoint - 5m: 1 published, in grace period") {
+    val cache = ce(
+      List(cwv(-7.minutes, -6.minutes, true))
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category5m), 0, cache, false)
+    assertMetrics(
+      republished = 6.minutes.toMillis,
+      wall = 7.minutes.plus(55.seconds).toMillis,
+      pubIndex = 0,
+      fiveMin = true
+    )
+  }
+
+  test("getPublishPoint - 5m: 1 published, expired") {
+    val cache = ce(
+      List(cwv(-9.minutes, -8.minutes, true))
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category5m), -1, cache, false)
+    assertMetrics()
+  }
+
+  test("getPublishPoint - 5m: 2, oldest grace") {
+    val cache = ce(
+      List(
+        cwv(-10.minutes, -9.minutes, false),
+        cwv(-5.minutes, -4.minutes, false)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category5m), 0, cache)
+    assertMetrics(
+      grace = 9.minutes.toMillis,
+      wall = 10.minutes.plus(55.seconds).toMillis,
+      pubIndex = 1,
+      fiveMin = true
+    )
+  }
+
+  test("getPublishPoint - 5m: 2, oldest published") {
+    val cache = ce(
+      List(
+        cwv(-10.minutes, -9.minutes, true),
+        cwv(-5.minutes, -4.minutes, false)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category5m), 1, cache)
+    assertMetrics(
+      current = 4.minutes.toMillis,
+      wall = 5.minutes.plus(55.seconds).toMillis,
+      pubIndex = 0,
+      fiveMin = true
+    )
+  }
+
+  test("getPublishPoint - 5m: 2, republished") {
+    val cache = ce(
+      List(
+        cwv(-10.minutes, -9.minutes, true),
+        cwv(-5.minutes, -4.minutes, true)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category5m), 1, cache, false)
+    assertMetrics(
+      republished = 4.minutes.toMillis,
+      wall = 5.minutes.plus(55.seconds).toMillis,
+      pubIndex = 0,
+      fiveMin = true
+    )
+  }
+
+  test("getPublishPoint - 5m: 2, oldest unpublished, republish of latest") {
+    val cache = ce(
+      List(
+        cwv(-10.minutes, -9.minutes, false),
+        cwv(-5.minutes, -4.minutes, true)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category5m), 1, cache, false)
+    assertMetrics(
+      republished = 4.minutes.toMillis,
+      wall = 5.minutes.plus(55.seconds).toMillis,
+      pubIndex = 0,
+      fiveMin = true
+    )
+  }
+
+  test("getPublishPoint - 5m: 2, oldest unpublished") {
+    val cache = ce(
+      List(
+        cwv(-20.minutes, -19.minutes, false),
+        cwv(-15.minutes, -14.minutes, false)
+      )
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, category5m), 1, cache)
+    assertMetrics(
+      unpublished = 19.minutes.toMillis,
+      grace = 14.minutes.toMillis,
+      wall = 15.minutes.plus(55.seconds).toMillis,
+      pubIndex = 0,
+      fiveMin = true
+    )
+  }
+
+  test("getPublishPoint - need two, one value") {
+    val cache = ce(
+      List(cwv(-2.minutes, -1.minutes, false))
+    )
+    val mono = MetricCategory(
+      "AWS/DynamoDB",
+      60,
+      -1,
+      List("MyTag"),
+      List(MetricDefinition("SumRate", "sum.rate", null, true, Map.empty)),
+      null
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, mono), -1, cache, false)
+    assertMetrics(
+      needTwo = 1
+    )
+  }
+
+  test("getPublishPoint - need two") {
+    val cache = ce(
+      List(cwv(-3.minutes, -2.minutes, false), cwv(-2.minutes, -1.minutes, false))
+    )
+    val mono = MetricCategory(
+      "AWS/DynamoDB",
+      60,
+      -1,
+      List("MyTag"),
+      List(MetricDefinition("SumRate", "sum.rate", null, true, Map.empty)),
+      null
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, mono), 1, cache)
+    assertMetrics(
+      current = 1.minutes.toMillis,
+      wall = 2.minutes.plus(55.seconds).toMillis,
+      pubIndex = 0
+    )
+  }
+
+  test("getPublishPoint - need two, large gap") {
+    val cache = ce(
+      List(cwv(-7.minutes, -6.minutes, false), cwv(-2.minutes, -1.minutes, false))
+    )
+    val mono = MetricCategory(
+      "AWS/DynamoDB",
+      60,
+      -1,
+      List("MyTag"),
+      List(MetricDefinition("SumRate", "sum.rate", null, true, Map.empty)),
+      null
+    )
+    assertPublishPoint(processor.getPublishPoint(cache, nts, mono), -1, cache, false)
+    assertMetrics(needTwo = 1)
+  }
+
+  def assertPublishPoint(
+    tuple: (Int, CloudWatchCacheEntry),
+    index: Int,
+    original: CloudWatchCacheEntry,
+    updated: Boolean = true
+  ): Unit = {
+    assertEquals(tuple._1, index)
+    if (updated) {
+      assertNotEquals(original, tuple._2)
+    } else {
+      assertEquals(original, tuple._2)
+    }
+  }
+
+  def assertMetrics(
+    current: Long = 0,
+    grace: Long = 0,
+    republished: Long = 0,
+    unpublished: Long = 0,
+    alreadyPublished: Long = 0,
+    wall: Long = 0,
+    pubIndex: Long = 0,
+    needTwo: Long = 0,
+    fiveMin: Boolean = false
+  ): Unit = {
+    assertEquals(
+      registry
+        .distributionSummary(
+          processor.published
+            .withTags("aws.namespace", "AWS/UT1", "aws.metric", "SumRate", "state", "current")
+        )
+        .totalAmount(),
+      current
+    )
+    assertEquals(
+      registry
+        .distributionSummary(
+          processor.published
+            .withTags("aws.namespace", "AWS/UT1", "aws.metric", "SumRate", "state", "grace")
+        )
+        .totalAmount(),
+      grace
+    )
+    assertEquals(
+      registry
+        .distributionSummary(
+          processor.published
+            .withTags("aws.namespace", "AWS/UT1", "aws.metric", "SumRate", "state", "republished")
+        )
+        .totalAmount(),
+      republished
+    )
+    assertEquals(
+      registry
+        .distributionSummary(
+          processor.unpublished.withTags("aws.namespace", "AWS/UT1", "aws.metric", "SumRate")
+        )
+        .totalAmount(),
+      unpublished
+    )
+    assertEquals(
+      registry
+        .distributionSummary(
+          processor.invalid.withTags(
+            "aws.namespace",
+            "AWS/UT1",
+            "aws.metric",
+            "SumRate",
+            "reason",
+            "alreadyPublished"
+          )
+        )
+        .totalAmount(),
+      alreadyPublished
+    )
+    val period = if (fiveMin) "300" else "60"
+    assertEquals(
+      registry
+        .distributionSummary(
+          processor.wallOffset
+            .withTags("aws.namespace", "AWS/UT1", "aws.metric", "SumRate", "period", period)
+        )
+        .totalAmount(),
+      wall
+    )
+    assertEquals(
+      registry
+        .distributionSummary(
+          processor.indexOffset
+            .withTags("aws.namespace", "AWS/UT1", "aws.metric", "SumRate", "period", period)
+        )
+        .totalAmount(),
+      pubIndex
+    )
+    assertEquals(
+      registry
+        .counter(
+          processor.invalid.withTags(
+            "aws.namespace",
+            "AWS/UT1",
+            "aws.metric",
+            "SumRate",
+            "reason",
+            "needTwoValues"
+          )
+        )
+        .count(),
+      needTwo
+    )
+  }
+}

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessorSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessorSuite.scala
@@ -15,719 +15,23 @@
  */
 package com.netflix.atlas.cloudwatch
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.testkit.ImplicitSender
-import org.apache.pekko.testkit.TestKitBase
-import com.fasterxml.jackson.core.JsonGenerator
-import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.newCacheEntry
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.assertAWSDP
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.assertCWDP
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.ce
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.cwv
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.nts
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.ts
+import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.merge
 import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.newValue
 import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.normalize
 import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.toAWSDatapoint
 import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor.toAWSDimensions
-import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.assertAWSDP
-import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.assertCWDP
-import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.makeDatapoint
-import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.makeFirehoseMetric
-import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.timestamp
-import com.netflix.atlas.core.model.Query
-import com.netflix.spectator.api.DefaultRegistry
-import com.netflix.spectator.api.Registry
-import com.typesafe.config.ConfigFactory
-import munit.Assertions.assertEquals
-import munit.FunSuite
-import org.mockito.Mockito.when
-import org.mockito.MockitoSugar.mock
-import org.mockito.MockitoSugar.spy
-import org.mockito.MockitoSugar.times
-import org.mockito.MockitoSugar.verify
-import org.mockito.captor.ArgCaptor
 import software.amazon.awssdk.services.cloudwatch.model.Datapoint
-import software.amazon.awssdk.services.cloudwatch.model.Dimension
 
 import java.time.Instant
+import scala.concurrent.duration.DurationInt
 
-class CloudWatchMetricsProcessorSuite extends FunSuite with TestKitBase with ImplicitSender {
-
-  override implicit def system: ActorSystem = ActorSystem("Test")
-
-  var registry: Registry = null
-  var publishRouter: PublishRouter = null
-  var processor: CloudWatchMetricsProcessor = null
-  var routerCaptor = ArgCaptor[AtlasDatapoint]
-  var debugger: CloudWatchDebugger = null
-  val config = ConfigFactory.load()
-  val tagger = new NetflixTagger(config.getConfig("atlas.cloudwatch.tagger"))
-  val rules: CloudWatchRules = new CloudWatchRules(config)
-  val category = MetricCategory("AWS/DynamoDB", 60, 0, 2, None, List("MyTag"), List.empty, null)
-
-  val cwDP = newCacheEntry(
-    makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp),
-    category
-  )
-
-  override def beforeEach(context: BeforeEach): Unit = {
-    registry = new DefaultRegistry()
-    publishRouter = mock[PublishRouter]
-    debugger = new CloudWatchDebugger(config, registry)
-    processor =
-      new LocalCloudWatchMetricsProcessor(config, registry, rules, tagger, publishRouter, debugger)
-    routerCaptor = ArgCaptor[AtlasDatapoint]
-  }
-
-  test("processDatapoints Empty") {
-    val hash = makeFirehoseMetric(Array(1.0, 1.0, 1.0, 1), timestamp).xxHash
-    processor
-      .asInstanceOf[LocalCloudWatchMetricsProcessor]
-      .inject(hash, cwDP.toBuilder.clearData().build().toByteArray, timestamp, 3600)
-
-    assertPublished(List.empty, timestamp + (60_000 * 10))
-    assertCounters(0, publishEmpty = 1)
-  }
-
-  test("processDatapoints No namespace config") {
-    processor.processDatapoints(
-      List(
-        makeFirehoseMetric(
-          "AWS/SomeNoneExistingNS",
-          "MyMetric",
-          List.empty,
-          Array(1.0, 1.0, 1.0, 1),
-          "Bytes"
-        )
-      ),
-      timestamp
-    )
-    assertPublished(List.empty)
-    assertCounters(1, filtered = Map("namespace" -> (1, "AWS/SomeNoneExistingNS")))
-  }
-
-  test("processDatapoints no metric match") {
-    processor.processDatapoints(
-      List(
-        makeFirehoseMetric(
-          "AWS/UT1",
-          "SomeUnknownMetric",
-          List(Dimension.builder().name("Key").value("Value").build()),
-          Array(39.0, 1.0, 7.0, 19),
-          "Count"
-        )
-      ),
-      timestamp
-    )
-    assertPublished(List.empty)
-    assertCounters(1, filtered = Map("metric" -> (1, "AWS/UT1")))
-  }
-
-  test("processDatapoints missing tag") {
-    processor.processDatapoints(
-      List(
-        makeFirehoseMetric(
-          "AWS/UT1",
-          "SumRate",
-          List(Dimension.builder().name("NotTheRightTag").value("Whoops").build()),
-          Array(39.0, 1.0, 7.0, 19),
-          "Count"
-        )
-      ),
-      timestamp
-    )
-    assertPublished(List.empty)
-    assertCounters(1, filtered = Map("tags" -> (1, "AWS/UT1")))
-  }
-
-  test("processDatapoints Filter by query") {
-    processor.processDatapoints(
-      List(
-        makeFirehoseMetric(
-          "AWS/UTQueryFilter",
-          "MyTestMetric",
-          List(Dimension.builder().name("Key").value("Whoops").build()),
-          Array(39.0, 1.0, 7.0, 19),
-          "Count"
-        )
-      ),
-      timestamp
-    )
-    assertPublished(List.empty)
-    assertCounters(1, filtered = Map("query" -> (1, "AWS/UTQueryFilter")))
-  }
-
-  test("processDatapoints matched dist-summary") {
-    processor.processDatapoints(
-      List(
-        makeFirehoseMetric(
-          "AWS/UT1",
-          "Dist",
-          List(Dimension.builder().name("MyTag").value("Val").build()),
-          Array(39.0, 1.0, 7.0, 19),
-          "Count",
-          timestamp - 60_000
-        )
-      ),
-      timestamp - 60_000
-    )
-
-    assertPublished(
-      List(
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.dist",
-            "statistic"    -> "count",
-            "nf.region"    -> "us-west-2",
-            "aws.tag"      -> "Val",
-            "atlas.dstype" -> "rate"
-          ),
-          timestamp,
-          0.31666666666666665
-        ),
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.dist",
-            "statistic"    -> "totalAmount",
-            "nf.region"    -> "us-west-2",
-            "aws.tag"      -> "Val",
-            "atlas.dstype" -> "rate"
-          ),
-          timestamp,
-          0.65
-        ),
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.dist",
-            "statistic"    -> "max",
-            "nf.region"    -> "us-west-2",
-            "aws.tag"      -> "Val",
-            "atlas.dstype" -> "gauge"
-          ),
-          timestamp,
-          7.0
-        )
-      )
-    )
-    assertCounters(1)
-  }
-
-  test("processDatapoints matched timer") {
-    processor.processDatapoints(
-      List(
-        makeFirehoseMetric(
-          "AWS/UT1",
-          "Timer",
-          List(
-            Dimension.builder().name("LoadBalancerName").value("some-elb").build(),
-            Dimension.builder().name("AvailabilityZone").value("a").build()
-          ),
-          Array(0.1226732730865479, 0.1226732730865479, 0.1226732730865479, 1),
-          "Timer",
-          timestamp - 60_000
-        )
-      ),
-      timestamp - 60_000
-    )
-
-    assertPublished(
-      List(
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.timer",
-            "aws.elb"      -> "some-elb",
-            "statistic"    -> "count",
-            "nf.region"    -> "us-west-2",
-            "nf.cluster"   -> "some-elb",
-            "nf.stack"     -> "elb",
-            "nf.app"       -> "some",
-            "nf.zone"      -> "a",
-            "atlas.dstype" -> "rate"
-          ),
-          timestamp,
-          0.016666666666666666
-        ),
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.timer",
-            "aws.elb"      -> "some-elb",
-            "statistic"    -> "totalTime",
-            "nf.region"    -> "us-west-2",
-            "nf.cluster"   -> "some-elb",
-            "nf.stack"     -> "elb",
-            "nf.app"       -> "some",
-            "nf.zone"      -> "a",
-            "atlas.dstype" -> "rate"
-          ),
-          timestamp,
-          0.0020445545514424647
-        ),
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.timer",
-            "aws.elb"      -> "some-elb",
-            "statistic"    -> "max",
-            "nf.region"    -> "us-west-2",
-            "nf.cluster"   -> "some-elb",
-            "nf.stack"     -> "elb",
-            "nf.app"       -> "some",
-            "nf.zone"      -> "a",
-            "atlas.dstype" -> "gauge"
-          ),
-          timestamp,
-          0.1226732730865479
-        )
-      )
-    )
-    assertCounters(1)
-  }
-
-  test("processDatapoints matched bytes") {
-    processor.processDatapoints(
-      List(
-        makeFirehoseMetric(
-          "AWS/UT1",
-          "Bytes",
-          List(
-            Dimension.builder().name("LoadBalancerName").value("some-elb").build(),
-            Dimension.builder().name("AvailabilityZone").value("a").build()
-          ),
-          Array(1.6903156e7, 8378272.0, 8524884.0, 2),
-          "Bytes",
-          timestamp - 60_000
-        )
-      ),
-      timestamp - 60_000
-    )
-
-    assertPublished(
-      List(
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.bytes",
-            "aws.elb"      -> "some-elb",
-            "nf.region"    -> "us-west-2",
-            "nf.zone"      -> "a",
-            "nf.cluster"   -> "some-elb",
-            "nf.stack"     -> "elb",
-            "nf.app"       -> "some",
-            "atlas.dstype" -> "rate"
-          ),
-          timestamp,
-          281719.26666666666
-        )
-      )
-    )
-    assertCounters(1)
-  }
-
-  test("processDatapoints matched percent") {
-    processor.processDatapoints(
-      List(
-        makeFirehoseMetric(
-          "AWS/UT1",
-          "Max",
-          List(Dimension.builder().name("MyTag").value("Val").build()),
-          Array(4.1320470343685605, 4.1320470343685605, 4.1320470343685605, 1),
-          "Percent",
-          timestamp - 60_000
-        )
-      ),
-      timestamp - 60_000
-    )
-
-    assertPublished(
-      List(
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.max",
-            "aws.tag"      -> "Val",
-            "nf.region"    -> "us-west-2",
-            "atlas.dstype" -> "gauge"
-          ),
-          timestamp,
-          4.1320470343685605
-        )
-      )
-    )
-    assertCounters(1)
-  }
-
-  test("processDatapoints config with timeout - single value not timedout") {
-    // 15m timeout so we make sure the data sticks around that long at least and we keep posting the last
-    // value.
-    val dp = makeFirehoseMetric(
-      "AWS/UT1",
-      "TimeOut",
-      List(Dimension.builder().name("MyTag").value("Val").build()),
-      Array(1, 1, 1, 1),
-      "None",
-      timestamp - (60_000 * 1)
-    )
-    processor.processDatapoints(List(dp), timestamp - (60_000 * 1))
-
-    assertPublished(
-      List(
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.timeout",
-            "aws.tag"      -> "Val",
-            "nf.region"    -> "us-west-2",
-            "atlas.dstype" -> "gauge"
-          ),
-          timestamp,
-          1
-        )
-      )
-    )
-    assertCounters(1)
-  }
-
-  test("processDatapoints config with timeout - single value timedout") {
-    // 15m timeout so we make sure the data sticks around that long at least and we keep posting the last
-    // value.
-    val dp = makeFirehoseMetric(
-      "AWS/UT1",
-      "TimeOut",
-      List(Dimension.builder().name("MyTag").value("Val").build()),
-      Array(1, 1, 1, 1),
-      "None",
-      timestamp - (60_000 * 14)
-    )
-    processor.processDatapoints(List(dp), timestamp - (60_000 * 14))
-
-    assertPublished(
-      List(
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.timeout",
-            "aws.tag"      -> "Val",
-            "nf.region"    -> "us-west-2",
-            "atlas.dstype" -> "gauge"
-          ),
-          timestamp,
-          0
-        )
-      )
-    )
-    assertCounters(1)
-  }
-
-  test("processDatapoints config with timeout - two values timedout") {
-    // 15m timeout so we make sure the data sticks around that long at least and we keep posting the last
-    // value.
-    var dp = makeFirehoseMetric(
-      "AWS/UT1",
-      "TimeOut",
-      List(Dimension.builder().name("MyTag").value("Val").build()),
-      Array(1, 1, 1, 1),
-      "None",
-      timestamp - (60_000 * 15)
-    )
-    processor.processDatapoints(List(dp), timestamp - (60_000 * 15))
-
-    dp = dp.copy(datapoint = makeDatapoint(Array(2, 2, 2, 2), timestamp - (60_000 * 14)))
-    processor.processDatapoints(List(dp), timestamp - (60_000 * 14))
-
-    assertPublished(
-      List(
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.timeout",
-            "aws.tag"      -> "Val",
-            "nf.region"    -> "us-west-2",
-            "atlas.dstype" -> "gauge"
-          ),
-          timestamp,
-          0
-        )
-      )
-    )
-    assertCounters(2)
-  }
-
-  test("processDatapoints config with timeout - two values past timed") {
-    // 15m timeout so we make sure the data sticks around that long at least and we keep posting the last
-    // value.
-    var dp = makeFirehoseMetric(
-      "AWS/UT1",
-      "TimeOut",
-      List(Dimension.builder().name("MyTag").value("Val").build()),
-      Array(1, 1, 1, 1),
-      "None",
-      timestamp - (60_000 * 17)
-    )
-    processor.processDatapoints(List(dp), timestamp - (60_000 * 17))
-
-    dp = dp.copy(datapoint = makeDatapoint(Array(2, 2, 2, 2), timestamp - (60_000 * 16)))
-    processor.processDatapoints(List(dp), timestamp - (60_000 * 16))
-
-    assertPublished(List.empty)
-    assertCounters(2)
-  }
-
-  test("processDatapoints config with end period offset") {
-    // 1 end period offset so we back date.
-    val dp = makeFirehoseMetric(
-      "AWS/UT1",
-      "Offset",
-      List(Dimension.builder().name("MyTag").value("Val").build()),
-      Array(1, 1, 1, 1),
-      "None",
-      timestamp
-    )
-    processor.processDatapoints(List(dp), timestamp)
-    processor.processDatapoints(
-      List(
-        dp.copy(
-          datapoint = makeDatapoint(Array(2, 2, 2, 1), timestamp + 60_000, "None")
-        )
-      ),
-      timestamp + 60_000
-    )
-
-    assertPublished(
-      List(
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.offset",
-            "aws.tag"      -> "Val",
-            "nf.region"    -> "us-west-2",
-            "atlas.dstype" -> "gauge"
-          ),
-          timestamp + 60_000,
-          1
-        )
-      ),
-      timestamp + 60_000
-    )
-    assertCounters(2)
-  }
-
-  test("processDatapoints config with monotonic") {
-    var dp = makeFirehoseMetric(
-      "AWS/UT1",
-      "Mono",
-      List(Dimension.builder().name("MyTag").value("Val").build()),
-      Array(60, 60, 60, 1),
-      "None",
-      timestamp - (60_000 * 2)
-    )
-    processor.processDatapoints(List(dp), timestamp - (60_000 * 2))
-
-    dp = dp.copy(datapoint = makeDatapoint(Array(120, 120, 120, 1), timestamp - 60_000))
-    processor.processDatapoints(List(dp), timestamp - 60_000)
-
-    assertPublished(
-      List(
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.mono",
-            "nf.region"    -> "us-west-2",
-            "aws.tag"      -> "Val",
-            "atlas.dstype" -> "rate"
-          ),
-          timestamp,
-          1.0
-        )
-      )
-    )
-    assertCounters(2)
-  }
-
-  test("processDatapoints config 5m") {
-    var dp = makeFirehoseMetric(
-      "AWS/UT1",
-      "5Min",
-      List(Dimension.builder().name("MyTag").value("Val").build()),
-      Array(1, 1, 1, 1),
-      "None",
-      timestamp - (60_000 * 5)
-    )
-    processor.processDatapoints(List(dp), timestamp - (60_000 * 5))
-
-    dp = dp.copy(datapoint = makeDatapoint(Array(2, 2, 2, 1), timestamp))
-    processor.processDatapoints(List(dp), timestamp)
-
-    assertPublished(
-      List(
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.5min",
-            "nf.region"    -> "us-west-2",
-            "aws.tag"      -> "Val",
-            "atlas.dstype" -> "rate"
-          ),
-          timestamp,
-          0.0033333333333333335
-        )
-      )
-    )
-    assertCounters(2)
-  }
-
-  test("processDatapoints purged namespace") {
-    val ruleSpy = spy(rules)
-    when(ruleSpy.rules)
-      .thenCallRealMethod()
-      .thenReturn(Map.empty)
-    processor = new LocalCloudWatchMetricsProcessor(
-      config,
-      registry,
-      ruleSpy,
-      tagger,
-      publishRouter,
-      debugger
-    )
-    processor.processDatapoints(
-      List(makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp)),
-      timestamp
-    )
-
-    assertPublished(List.empty)
-    assertCounters(1, purged = Map("namespace" -> 1))
-  }
-
-  test("processDatapoints purged metric") {
-    val ruleSpy = spy(rules)
-    when(ruleSpy.rules)
-      .thenCallRealMethod()
-      .thenReturn(Map("AWS/UT1" -> Map("SomeMetric" -> (category, List.empty))))
-    processor = new LocalCloudWatchMetricsProcessor(
-      config,
-      registry,
-      ruleSpy,
-      tagger,
-      publishRouter,
-      debugger
-    )
-    processor.processDatapoints(
-      List(makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp)),
-      timestamp
-    )
-
-    assertPublished(List.empty)
-    assertCounters(1, purged = Map("metric" -> 1))
-  }
-
-  test("processDatapoints purged tags") {
-    val ruleSpy = spy(rules)
-    when(ruleSpy.rules)
-      .thenCallRealMethod()
-      .thenReturn(
-        Map(
-          "AWS/UT1" -> Map(
-            "SumRate" ->
-              (category.copy(dimensions = List("SomeOtherTag")), List.empty)
-          )
-        )
-      )
-    processor = new LocalCloudWatchMetricsProcessor(
-      config,
-      registry,
-      ruleSpy,
-      tagger,
-      publishRouter,
-      debugger
-    )
-    processor.processDatapoints(
-      List(makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp)),
-      timestamp
-    )
-
-    assertPublished(List.empty)
-    assertCounters(1, purged = Map("tags" -> 1))
-  }
-
-  test("processDatapoints purged query") {
-    val ruleSpy = spy(rules)
-    when(ruleSpy.rules)
-      .thenCallRealMethod()
-      .thenReturn(
-        Map(
-          "AWS/UT1" -> Map(
-            "SumRate" ->
-              (category.copy(filter = Some(Query.HasKey("MyTag"))), List.empty)
-          )
-        )
-      )
-    processor = new LocalCloudWatchMetricsProcessor(
-      config,
-      registry,
-      ruleSpy,
-      tagger,
-      publishRouter,
-      debugger
-    )
-    processor.processDatapoints(
-      List(makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp)),
-      timestamp
-    )
-
-    assertPublished(List.empty)
-    assertCounters(1, purged = Map("query" -> 1))
-  }
-
-  test("processDatapoints future data point") {
-    processor.processDatapoints(
-      List(makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp + 60_000)),
-      timestamp + 60_000
-    )
-
-    assertPublished(
-      List(
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.sumrate",
-            "nf.region"    -> "us-west-2",
-            "aws.tag"      -> "Val",
-            "atlas.dstype" -> "rate"
-          ),
-          timestamp,
-          0.65
-        )
-      )
-    )
-    assertCounters(1, publishFuture = 1)
-  }
-
-  test("processDatapoints 2 rules match") {
-    processor.processDatapoints(
-      List(
-        makeFirehoseMetric(
-          "AWS/UT1",
-          "TwoRuleMatch",
-          List(Dimension.builder().name("MyTag").value("Val").build()),
-          Array(39.0, 1.0, 7.0, 19),
-          "None",
-          timestamp - 60_00
-        )
-      ),
-      timestamp - 60_00
-    )
-
-    // yup, two values with the same tag set. Just the min and max values.
-    assertPublished(
-      List(
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.2rulematch",
-            "nf.region"    -> "us-west-2",
-            "aws.tag"      -> "Val",
-            "atlas.dstype" -> "gauge"
-          ),
-          timestamp,
-          1
-        ),
-        com.netflix.atlas.core.model.Datapoint(
-          Map(
-            "name"         -> "aws.utm.2rulematch",
-            "nf.region"    -> "us-west-2",
-            "aws.tag"      -> "Val",
-            "atlas.dstype" -> "gauge"
-          ),
-          timestamp,
-          7
-        )
-      )
-    )
-    assertCounters(1)
-  }
+class CloudWatchMetricsProcessorSuite extends BaseCloudWatchMetricsProcessorSuite {
 
   test("normalize") {
     assertEquals(1677706140000L, normalize(1677706164123L, 60))
@@ -748,225 +52,30 @@ class CloudWatchMetricsProcessorSuite extends FunSuite with TestKitBase with Imp
         .build()
     )
     assertEquals(cwDP.getDataCount, 1)
-    assertCWDP(cwDP.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
+    assertCWDP(cwDP.getData(0), ts(-2.minutes), Array(39.0, 1.0, 7.0, 19))
     assertEquals(cwDP.getUnit, "Count")
   }
 
   test("newValue") {
     val nv = newValue(
-      timestamp,
       Datapoint
         .builder()
+        .timestamp(Instant.ofEpochMilli(ts))
         .sum(39.0)
         .minimum(1.0)
         .maximum(7.0)
         .sampleCount(19)
-        .build()
+        .build(),
+      nts
     )
-    assertCWDP(nv, timestamp, Array(39.0, 1.0, 7.0, 19))
-  }
-
-  test("insertDatapoint empty") {
-    val updated = processor.insertDatapoint(
-      cwDP.toBuilder.clearData().build().toByteArray,
-      makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp),
-      category,
-      0
-    )
-    assertEquals(updated.getDataCount, 1)
-    assertCWDP(updated.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
-    assertCounters(0)
-  }
-
-  test("insertDatapoint after") {
-    val updated = processor.insertDatapoint(
-      cwDP.toByteArray,
-      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp + 60_000),
-      category,
-      0
-    )
-    assertEquals(updated.getDataCount, 2)
-    assertCWDP(updated.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
-    assertCWDP(updated.getData(1), timestamp + 60_000, Array(80.0, 2.0, 6.0, 5))
-    assertCounters(0)
-  }
-
-  test("insertDatapoint before") {
-    val updated = processor.insertDatapoint(
-      cwDP.toByteArray,
-      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp - 60_000),
-      category,
-      0
-    )
-    assertEquals(updated.getDataCount, 2)
-    assertCWDP(updated.getData(0), timestamp - 60_000, Array(80.0, 2.0, 6.0, 5))
-    assertCWDP(updated.getData(1), timestamp, Array(39.0, 1.0, 7.0, 19))
-    assertCounters(0, ooo = 1)
-  }
-
-  test("insertDatapoint between") {
-    var updated = processor.insertDatapoint(
-      cwDP.toByteArray,
-      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp + (60_000 * 2)),
-      category,
-      0
-    )
-    updated = processor.insertDatapoint(
-      updated.toByteArray,
-      makeFirehoseMetric(Array(2.0, 0.0, 1.0, 2), timestamp + 60_000),
-      category,
-      0
-    )
-    assertEquals(updated.getDataCount, 3)
-    assertCWDP(updated.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
-    assertCWDP(updated.getData(1), timestamp + 60_000, Array(2.0, 0.0, 1.0, 2))
-    assertCWDP(updated.getData(2), timestamp + (60_000 * 2), Array(80.0, 2.0, 6.0, 5))
-    assertCounters(0, ooo = 1)
-  }
-
-  test("insertDatapoint same first") {
-    var updated = processor.insertDatapoint(
-      cwDP.toByteArray,
-      makeFirehoseMetric(Array(2.0, 0.0, 1.0, 2), timestamp + 60_000),
-      category,
-      0
-    )
-    updated = processor.insertDatapoint(
-      updated.toByteArray,
-      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp + (60_000 * 2)),
-      category,
-      0
-    )
-    updated = processor.insertDatapoint(
-      updated.toByteArray,
-      makeFirehoseMetric(Array(-1.0, -1.0, -1.0, -2), timestamp),
-      category,
-      0
-    )
-    assertEquals(updated.getDataCount, 3)
-    assertCWDP(updated.getData(0), timestamp, Array(-1.0, -1.0, -1.0, -2))
-    assertCWDP(updated.getData(1), timestamp + 60_000, Array(2.0, 0.0, 1.0, 2))
-    assertCWDP(updated.getData(2), timestamp + (60_000 * 2), Array(80.0, 2.0, 6.0, 5))
-    assertCounters(0, dupes = 1)
-  }
-
-  test("insertDatapoint same middle") {
-    var updated = processor.insertDatapoint(
-      cwDP.toByteArray,
-      makeFirehoseMetric(Array(2.0, 0.0, 1.0, 2), timestamp + 60_000),
-      category,
-      0
-    )
-    updated = processor.insertDatapoint(
-      updated.toByteArray,
-      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp + (60_000 * 2)),
-      category,
-      0
-    )
-    updated = processor.insertDatapoint(
-      updated.toByteArray,
-      makeFirehoseMetric(Array(-1.0, -1.0, -1.0, -2), timestamp + 60_000),
-      category,
-      0
-    )
-    assertEquals(updated.getDataCount, 3)
-    assertCWDP(updated.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
-    assertCWDP(updated.getData(1), timestamp + 60_000, Array(-1.0, -1.0, -1.0, -2))
-    assertCWDP(updated.getData(2), timestamp + (60_000 * 2), Array(80.0, 2.0, 6.0, 5))
-    assertCounters(0, dupes = 1)
-  }
-
-  test("insertDatapoint same last") {
-    var updated = processor.insertDatapoint(
-      cwDP.toByteArray,
-      makeFirehoseMetric(Array(2.0, 0.0, 1.0, 2), timestamp + 60_000),
-      category,
-      0
-    )
-    updated = processor.insertDatapoint(
-      updated.toByteArray,
-      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp + (60_000 * 2)),
-      category,
-      0
-    )
-    updated = processor.insertDatapoint(
-      updated.toByteArray,
-      makeFirehoseMetric(Array(-1.0, -1.0, -1.0, -2), timestamp + (60_000 * 2)),
-      category,
-      0
-    )
-    assertEquals(updated.getDataCount, 3)
-    assertCWDP(updated.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
-    assertCWDP(updated.getData(1), timestamp + 60_000, Array(2.0, 0.0, 1.0, 2))
-    assertCWDP(updated.getData(2), timestamp + (60_000 * 2), Array(-1.0, -1.0, -1.0, -2))
-    assertCounters(0, dupes = 1)
-  }
-
-  test("insertDatapoint after and keep previous") {
-    val updated = processor.insertDatapoint(
-      cwDP.toByteArray,
-      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp + 60_000),
-      category,
-      timestamp + 60_000
-    )
-    assertEquals(updated.getDataCount, 2)
-    assertCWDP(updated.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
-    assertCWDP(updated.getData(1), timestamp + 60_000, Array(80.0, 2.0, 6.0, 5))
-    assertCounters(0)
-  }
-
-  test("insertDatapoint data point too old") {
-    val updated = processor.insertDatapoint(
-      cwDP.toByteArray,
-      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp - (60_000 * 2)),
-      category,
-      timestamp
-    )
-    assertEquals(updated.getDataCount, 1)
-    assertCWDP(updated.getData(0), timestamp, Array(39.0, 1.0, 7.0, 19))
-    assertCounters(0, droppedOld = 1)
-  }
-
-  test("insertDatapoint expire old") {
-    var updated = processor.insertDatapoint(
-      cwDP.toBuilder.clearData().build().toByteArray,
-      makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp - (60_000 * 2)),
-      category,
-      0
-    )
-    updated = processor.insertDatapoint(
-      updated.toByteArray,
-      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp),
-      category,
-      timestamp
-    )
-    assertEquals(updated.getDataCount, 1)
-    assertCWDP(updated.getData(0), timestamp, Array(80.0, 2.0, 6.0, 5))
-    assertCounters(0)
-  }
-
-  test("insertDatapoint data point too old and expire old data to empty array") {
-    var updated = processor.insertDatapoint(
-      cwDP.toBuilder.clearData().build().toByteArray,
-      makeFirehoseMetric(Array(39.0, 1.0, 7.0, 19), timestamp - (60_000 * 2)),
-      category,
-      0
-    )
-    updated = processor.insertDatapoint(
-      updated.toByteArray,
-      makeFirehoseMetric(Array(80.0, 2.0, 6.0, 5), timestamp - (60_000 * 2)),
-      category,
-      timestamp
-    )
-    assertEquals(updated.getDataCount, 0)
-    assertCounters(0, droppedOld = 1)
+    assertCWDP(nv, ts, Array(39.0, 1.0, 7.0, 19))
   }
 
   test("toAWSDatapoint") {
     assertAWSDP(
       toAWSDatapoint(cwDP.getData(0), cwDP.getUnit),
       Array(39.0, 1.0, 7.0, 19),
-      timestamp,
+      ts(-2.minute),
       "Count"
     )
   }
@@ -978,225 +87,99 @@ class CloudWatchMetricsProcessorSuite extends FunSuite with TestKitBase with Imp
     assertEquals(dimensions(0).value(), cwDP.getDimensions(0).getValue)
   }
 
-  def assertPublished(dps: List[AtlasDatapoint], ts: Long = timestamp): Unit = {
-    processor.publish(ts)
-    verify(publishRouter, times(dps.size)).publish(routerCaptor)
-    assertEquals(routerCaptor.values.size, dps.size)
-
-    dps.foreach { dp =>
-      val metric = routerCaptor.values.filter(_.equals(dp)).headOption match {
-        case Some(d) => d
-        case None =>
-          throw new AssertionError(s"Data point not found: ${dp} in ${routerCaptor.values}")
-      }
-      assertEquals(metric.value, dp.value, s"Wrong value for ${dp.tags}")
-      assertEquals(metric.timestamp, dp.timestamp, s"Wrong value for timestamp ${dp.tags}")
-    }
-  }
-
-  def assertCounters(
-    received: Long,
-    filtered: Map[String, (Long, String)] = Map.empty,
-    dupes: Long = 0,
-    droppedOld: Long = 0,
-    ooo: Long = 0,
-    purged: Map[String, Long] = Map.empty,
-    publishEmpty: Long = 0,
-    publishFuture: Long = 0
-  ): Unit = {
-    assertEquals(registry.counter("atlas.cloudwatch.datapoints.received").count(), received)
-    List("namespace", "metric", "tags", "query").foreach { reason =>
-      val (count, ns) = filtered.getOrElse(reason, (0L, "NA"))
-      assertEquals(
-        registry
-          .counter("atlas.cloudwatch.datapoints.filtered", "aws.namespace", ns, "reason", reason)
-          .count(),
-        count,
-        s"Count differs for ${reason}"
+  test("merge - new and published") {
+    val a = ce(
+      List(
+        cwv(-9.minutes, -8.minutes, true)
       )
-    }
-
-    assertEquals(
-      registry
-        .counter(
-          "atlas.cloudwatch.datapoints.dupes",
-          "aws.namespace",
-          "AWS/DynamoDB",
-          "aws.metric",
-          "SumRate"
-        )
-        .count(),
-      dupes
     )
-    assertEquals(
-      registry
-        .counter(
-          "atlas.cloudwatch.datapoints.dropped",
-          "reason",
-          "tooOld",
-          "aws.namespace",
-          "AWS/DynamoDB",
-          "aws.metric",
-          "SumRate"
-        )
-        .count(),
-      droppedOld
-    )
-    assertEquals(
-      registry
-        .counter(
-          "atlas.cloudwatch.datapoints.ooo",
-          "aws.namespace",
-          "AWS/DynamoDB",
-          "aws.metric",
-          "SumRate"
-        )
-        .count(),
-      ooo
-    )
-
-    List("namespace", "metric", "tags", "query").foreach { reason =>
-      assertEquals(
-        registry.counter("atlas.cloudwatch.datapoints.purged", "reason", reason).count(),
-        purged.getOrElse(reason, 0L),
-        s"Count differs for ${reason}"
+    val b = ce(
+      List(
+        cwv(-9.minutes, -8.minutes, false),
+        cwv(-8.minutes, -7.minutes, false)
       )
-    }
-    assertEquals(
-      registry.counter("atlas.cloudwatch.publish.empty", "aws.namespace", "AWS/UT1").count(),
-      publishEmpty
     )
-    assertEquals(
-      registry
-        .distributionSummary(
-          "atlas.cloudwatch.publish.future",
-          "aws.namespace",
-          "AWS/UT1",
-          "aws.metric",
-          "SumRate"
-        )
-        .count(),
-      publishFuture
+    val expected = ce(
+      List(
+        cwv(-9.minutes, -8.minutes, true),
+        cwv(-8.minutes, -7.minutes, false)
+      )
     )
+    assertEquals(merge(a, b), expected)
+    assertEquals(merge(b, a), expected)
   }
 
-}
-
-object CloudWatchMetricsProcessorSuite {
-
-  val timestamp = 1672531200000L
-
-  def assertCWDP(cwdp: CloudWatchValue, timestamp: Long, values: Array[Double]): Unit = {
-    assertEquals(cwdp.getTimestamp, timestamp)
-    assertEquals(cwdp.getSum, values(0))
-    assertEquals(cwdp.getMin, values(1))
-    assertEquals(cwdp.getMax, values(2))
-    assertEquals(cwdp.getCount, values(3))
-  }
-
-  def assertAWSDP(dp: Datapoint, values: Array[Double], ts: Long, unit: String): Unit = {
-    assertEquals(dp.sum().asInstanceOf[Double], values(0))
-    assertEquals(dp.minimum().asInstanceOf[Double], values(1))
-    assertEquals(dp.maximum().asInstanceOf[Double], values(2))
-    assertEquals(dp.sampleCount().asInstanceOf[Double], values(3))
-    assertEquals(dp.timestamp().toEpochMilli, ts)
-    assertEquals(dp.unit().toString, unit)
-  }
-
-  def makeFirehoseMetric(values: Array[Double], ts: Long): FirehoseMetric = {
-    makeFirehoseMetric(
-      "AWS/UT1",
-      "SumRate",
-      List(Dimension.builder().name("MyTag").value("Val").build()),
-      values,
-      "Count",
-      ts
+  test("merge - two values") {
+    val a = ce(
+      List(
+        cwv(-9.minutes, -8.minutes, false)
+      )
     )
-  }
-
-  def makeFirehoseMetric(
-    ns: String,
-    metric: String,
-    dimensions: List[Dimension],
-    values: Array[Double],
-    unit: String,
-    ts: Long = timestamp,
-    streamName: String = "unitTest"
-  ): FirehoseMetric = {
-    FirehoseMetric(
-      streamName,
-      ns,
-      metric,
-      dimensions,
-      Datapoint
-        .builder()
-        .timestamp(Instant.ofEpochMilli(ts))
-        .sum(values(0))
-        .minimum(values(1))
-        .maximum(values(2))
-        .sampleCount(values(3))
-        .unit(unit)
-        .build()
+    val b = ce(
+      List(
+        cwv(-8.minutes, -7.minutes, false)
+      )
     )
+    val expected = ce(
+      List(
+        cwv(-9.minutes, -8.minutes, false),
+        cwv(-8.minutes, -7.minutes, false)
+      )
+    )
+    assertEquals(merge(a, b), expected)
+    assertEquals(merge(b, a), expected)
   }
 
-  def makeDatapoint(
-    values: Array[Double],
-    ts: Long = timestamp,
-    unit: String = "Rate"
-  ): Datapoint = {
-    Datapoint
-      .builder()
-      .timestamp(Instant.ofEpochMilli(ts))
-      .sum(values(0))
-      .minimum(values(1))
-      .maximum(values(2))
-      .sampleCount(values(3))
-      .unit(unit)
-      .build()
+  test("merge - insert between values") {
+    val a = ce(
+      List(
+        cwv(-9.minutes, -8.minutes, false)
+      )
+    )
+    val b = ce(
+      List(
+        cwv(-10.minutes, -9.minutes, false),
+        cwv(-8.minutes, -7.minutes, false)
+      )
+    )
+    val expected = ce(
+      List(
+        cwv(-10.minutes, -9.minutes, false),
+        cwv(-9.minutes, -8.minutes, false),
+        cwv(-8.minutes, -7.minutes, false)
+      )
+    )
+    assertEquals(merge(a, b), expected)
+    assertEquals(merge(b, a), expected)
   }
 
-  case class CWDP(
-    metric: String,
-    values: Array[Double],
-    dimensions: Int = 3,
-    wTimestamp: Boolean = true
-  ) {
-
-    def encode(json: JsonGenerator): Unit = {
-      json.writeStartObject()
-      json.writeStringField("metric_stream_name", "Stream1")
-      for (i <- 0 until Math.min(dimensions, 2)) {
-        if (i == 0) json.writeStringField("account_id", "1234")
-        if (i == 1) json.writeStringField("region", "us-west-2")
-      }
-      json.writeStringField("namespace", "UT/Test")
-      if (metric != null) {
-        json.writeStringField("metric_name", metric)
-      }
-      json.writeStringField("unit", "None")
-      if (wTimestamp) {
-        json.writeNumberField("timestamp", timestamp)
-      }
-      if (dimensions >= 3) {
-        json.writeObjectFieldStart("dimensions")
-        json.writeStringField("AwsTag", "AwsVal")
-        json.writeEndObject()
-      }
-      if (values != null) {
-        json.writeObjectFieldStart("value")
-        for (i <- 0 until values.length) {
-          if (i == 0) json.writeNumberField("sum", values(i))
-          if (i == 1) json.writeNumberField("min", values(i))
-          if (i == 2) json.writeNumberField("max", values(i))
-          if (i == 3) json.writeNumberField("count", values(i))
-          if (i > 3) json.writeNumberField(s"val${i}", values(i))
-        }
-        json.writeEndObject()
-      }
-      json.writeEndObject()
-    }
-
+  test("merge - empty") {
+    val a = ce(List.empty)
+    val b = ce(
+      List(
+        cwv(-9.minutes, -8.minutes, false),
+        cwv(-8.minutes, -7.minutes, false)
+      )
+    )
+    val expected = ce(
+      List(
+        cwv(-9.minutes, -8.minutes, false),
+        cwv(-8.minutes, -7.minutes, false)
+      )
+    )
+    assertEquals(merge(a, b), expected)
+    assertEquals(merge(b, a), expected)
   }
+
+  //  test("print metrics") {
+  //    rules.rules.foreachEntry { (outerKey, nested) =>
+  //      nested.foreachEntry { (innerKey, catTuple) =>
+  //        val (category, metrics) = catTuple
+  //        val metric = metrics.head
+  //        println(s"${category.namespace}, ${metric.name}, ${metric.alias}, ${category.dimensions.mkString("; ")}")
+  //
+  //      }
+  //    }
+  //  }
 
 }

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchPollerSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchPollerSuite.scala
@@ -15,10 +15,10 @@
  */
 package com.netflix.atlas.cloudwatch
 
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.makeFirehoseMetric
 import org.apache.pekko.Done
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.testkit.TestKitBase
-import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.makeFirehoseMetric
 import com.netflix.atlas.cloudwatch.CloudWatchPoller.runKey
 import com.netflix.iep.aws2.AwsClientFactory
 import com.netflix.iep.leader.api.LeaderStatus
@@ -61,7 +61,7 @@ class CloudWatchPollerSuite extends FunSuite with TestKitBase {
 
   override implicit def system: ActorSystem = ActorSystem("Test")
 
-  val timestamp = Instant.ofEpochMilli(CloudWatchMetricsProcessorSuite.timestamp)
+  val timestamp = Instant.ofEpochMilli(BaseCloudWatchMetricsProcessorSuite.ts)
   val account = "123456789012"
   val region = Region.US_EAST_1
   val offset = Duration.ofHours(8).getSeconds.toInt

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionsSuite.scala
@@ -79,7 +79,7 @@ class ConversionsSuite extends FunSuite {
   test("rate") {
     val cnv = Conversions.fromName("sum,rate")
     val meta = MetricMetadata(
-      MetricCategory("NFLX/Test", 300, 1, 3, None, Nil, Nil, Some(Query.True)),
+      MetricCategory("NFLX/Test", 300, -1, Nil, Nil, Some(Query.True)),
       MetricDefinition("test", "test-alias", cnv, false, Map.empty),
       Nil
     )
@@ -90,7 +90,7 @@ class ConversionsSuite extends FunSuite {
   test("rate already") {
     val cnv = Conversions.fromName("sum,rate")
     val meta = MetricMetadata(
-      MetricCategory("NFLX/Test", 300, 1, 3, None, Nil, Nil, Some(Query.True)),
+      MetricCategory("NFLX/Test", 300, -1, Nil, Nil, Some(Query.True)),
       MetricDefinition("test", "test-alias", cnv, false, Map.empty),
       Nil
     )

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
@@ -116,7 +116,7 @@ class MetricCategorySuite extends FunSuite {
     assertEquals(category.filter, None)
   }
 
-  test("category without timeout") {
+  test("category without grace override") {
     val cfg = ConfigFactory.parseString("""
         |namespace = "AWS/ELB"
         |period = 1 m
@@ -125,21 +125,20 @@ class MetricCategorySuite extends FunSuite {
       """.stripMargin)
 
     val category = MetricCategory.fromConfig(cfg)
-    assert(category.timeout.isEmpty)
+    assertEquals(category.graceOverride, -1)
   }
 
-  test("category with timeout") {
+  test("category with grace override") {
     val cfg = ConfigFactory.parseString("""
         |namespace = "AWS/ELB"
         |period = 1 m
-        |timeout = 1d
+        |grace-override = 4
         |dimensions = ["LoadBalancerName"]
         |metrics = []
       """.stripMargin)
 
     val category = MetricCategory.fromConfig(cfg)
-    assert(category.timeout.nonEmpty)
-    assertEquals(category.timeout.get, Duration.ofDays(1))
+    assertEquals(category.graceOverride, 4)
   }
 
   test("config with filter") {

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
@@ -27,7 +27,7 @@ import java.time.Instant
 class MetricDefinitionSuite extends FunSuite {
 
   private val meta = MetricMetadata(
-    MetricCategory("AWS/ELB", 60, 1, 5, None, Nil, Nil, Some(Query.True)),
+    MetricCategory("AWS/ELB", 60, -1, Nil, Nil, Some(Query.True)),
     null,
     Nil
   )
@@ -97,17 +97,17 @@ class MetricDefinitionSuite extends FunSuite {
       .timestamp(Instant.now())
       .build()
 
-    definitions.find(_.tags("statistic") == "totalTime").foreach { d =>
+    definitions.find(_.tags("statistic") == "totalTime").map { d =>
       val m = meta.copy(definition = d)
       assertEquals(m.convert(dp), 10.0)
     }
 
-    definitions.find(_.tags("statistic") == "count").foreach { d =>
+    definitions.find(_.tags("statistic") == "count").map { d =>
       val m = meta.copy(definition = d)
       assertEquals(m.convert(dp), 1000.0 / 60.0)
     }
 
-    definitions.find(_.tags("statistic") == "max").foreach { d =>
+    definitions.find(_.tags("statistic") == "max").map { d =>
       val m = meta.copy(definition = d)
       assertEquals(m.convert(dp), 6.0)
     }
@@ -134,17 +134,17 @@ class MetricDefinitionSuite extends FunSuite {
       .timestamp(Instant.now())
       .build()
 
-    definitions.find(_.tags("statistic") == "totalTime").foreach { d =>
+    definitions.find(_.tags("statistic") == "totalTime").map { d =>
       val m = meta.copy(definition = d)
       assertEquals(m.convert(dp), 10.0 / 1000.0)
     }
 
-    definitions.find(_.tags("statistic") == "count").foreach { d =>
+    definitions.find(_.tags("statistic") == "count").map { d =>
       val m = meta.copy(definition = d)
       assertEquals(m.convert(dp), 1000.0 / 60.0)
     }
 
-    definitions.find(_.tags("statistic") == "max").foreach { d =>
+    definitions.find(_.tags("statistic") == "max").map { d =>
       val m = meta.copy(definition = d)
       assertEquals(m.convert(dp), 6.0 / 1000.0)
     }
@@ -171,17 +171,17 @@ class MetricDefinitionSuite extends FunSuite {
       .timestamp(Instant.now())
       .build()
 
-    definitions.find(_.tags("statistic") == "totalTime").foreach { d =>
+    definitions.find(_.tags("statistic") == "totalTime").map { d =>
       val m = meta.copy(definition = d)
       assertEquals(m.convert(dp), 10.0 / 1000.0)
     }
 
-    definitions.find(_.tags("statistic") == "count").foreach { d =>
+    definitions.find(_.tags("statistic") == "count").map { d =>
       val m = meta.copy(definition = d)
       assertEquals(m.convert(dp), 1000.0 / 60.0)
     }
 
-    definitions.find(_.tags("statistic") == "max").foreach { d =>
+    definitions.find(_.tags("statistic") == "max").map { d =>
       val m = meta.copy(definition = d)
       assertEquals(m.convert(dp), 6.0 / 1000.0)
     }
@@ -208,17 +208,17 @@ class MetricDefinitionSuite extends FunSuite {
       .timestamp(Instant.now())
       .build()
 
-    definitions.find(_.tags("statistic") == "totalAmount").foreach { d =>
+    definitions.find(_.tags("statistic") == "totalAmount").map { d =>
       val m = meta.copy(definition = d)
       assertEquals(m.convert(dp), 10.0)
     }
 
-    definitions.find(_.tags("statistic") == "count").foreach { d =>
+    definitions.find(_.tags("statistic") == "count").map { d =>
       val m = meta.copy(definition = d)
       assertEquals(m.convert(dp), 1000.0 / 60.0)
     }
 
-    definitions.find(_.tags("statistic") == "max").foreach { d =>
+    definitions.find(_.tags("statistic") == "max").map { d =>
       val m = meta.copy(definition = d)
       assertEquals(m.convert(dp), 6.0)
     }
@@ -248,7 +248,7 @@ class MetricDefinitionSuite extends FunSuite {
       .build()
 
     val metadata = MetricMetadata(
-      MetricCategory("AWS/RDS", 60, 1, 5, None, Nil, Nil, Some(Query.True)),
+      MetricCategory("AWS/RDS", 60, -1, Nil, Nil, Some(Query.True)),
       definition,
       Nil
     )

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/PublishRouterSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/PublishRouterSuite.scala
@@ -18,7 +18,7 @@ package com.netflix.atlas.cloudwatch
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.testkit.TestKitBase
 import com.netflix.atlas.pekko.PekkoHttpClient
-import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.timestamp
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.ts
 import com.netflix.atlas.core.model.Datapoint
 import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.Registry
@@ -43,42 +43,42 @@ class PublishRouterSuite extends FunSuite with TestKitBase {
   }
 
   test("publish main same region") {
-    val dp = Datapoint(Map("nf.account" -> "42", "nf.region" -> "us-east-1"), timestamp, 42.0)
+    val dp = Datapoint(Map("nf.account" -> "42", "nf.region" -> "us-east-1"), ts, 42.0)
     val queue = router.getQueue(dp).get
     assertEquals(queue.uri, "https://publish-main.us-east-1.foo.com/api/v1/publish")
     router.shutdown()
   }
 
   test("publish main same any region") {
-    val dp = Datapoint(Map("nf.account" -> "42", "nf.region" -> "ap-south-1"), timestamp, 42.0)
+    val dp = Datapoint(Map("nf.account" -> "42", "nf.region" -> "ap-south-1"), ts, 42.0)
     val queue = router.getQueue(dp).get
     assertEquals(queue.uri, "https://publish-main.us-east-1.foo.com/api/v1/publish")
     router.shutdown()
   }
 
   test("publish stackA acct 1 default") {
-    val dp = Datapoint(Map("nf.account" -> "1", "nf.region" -> "us-east-1"), timestamp, 42.0)
+    val dp = Datapoint(Map("nf.account" -> "1", "nf.region" -> "us-east-1"), ts, 42.0)
     val queue = router.getQueue(dp).get
     assertEquals(queue.uri, "https://publish-stackA.us-east-1.foo.com/api/v1/publish")
     router.shutdown()
   }
 
   test("publish stackA acct 2 default") {
-    val dp = Datapoint(Map("nf.account" -> "2", "nf.region" -> "us-east-1"), timestamp, 42.0)
+    val dp = Datapoint(Map("nf.account" -> "2", "nf.region" -> "us-east-1"), ts, 42.0)
     val queue = router.getQueue(dp).get
     assertEquals(queue.uri, "https://publish-stackA.us-east-1.foo.com/api/v1/publish")
     router.shutdown()
   }
 
   test("publish stackA us-west") {
-    val dp = Datapoint(Map("nf.account" -> "1", "nf.region" -> "us-west-1"), timestamp, 42.0)
+    val dp = Datapoint(Map("nf.account" -> "1", "nf.region" -> "us-west-1"), ts, 42.0)
     val queue = router.getQueue(dp).get
     assertEquals(queue.uri, "https://publish-stackA.us-west-1.foo.com/api/v1/publish")
     router.shutdown()
   }
 
   test("publish stackB us-west") {
-    val dp = Datapoint(Map("nf.account" -> "3", "nf.region" -> "us-west-1"), timestamp, 42.0)
+    val dp = Datapoint(Map("nf.account" -> "3", "nf.region" -> "us-west-1"), ts, 42.0)
     val queue = router.getQueue(dp).get
     assertEquals(queue.uri, "https://publish-stackB.us-east-1.foo.com/api/v1/publish")
     router.shutdown()

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/webapi/CloudWatchFirehoseEndpointSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/webapi/CloudWatchFirehoseEndpointSuite.scala
@@ -25,8 +25,8 @@ import org.apache.pekko.http.scaladsl.model.headers.RawHeader
 import com.fasterxml.jackson.core.io.JsonEOFException
 import com.netflix.atlas.pekko.testkit.MUnitRouteSuite
 import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessor
-import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.CWDP
-import com.netflix.atlas.cloudwatch.CloudWatchMetricsProcessorSuite.timestamp
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.CWDP
+import com.netflix.atlas.cloudwatch.BaseCloudWatchMetricsProcessorSuite.ts
 import com.netflix.atlas.cloudwatch.FirehoseMetric
 import com.netflix.atlas.core.util.FastGzipOutputStream
 import com.netflix.atlas.json.Json
@@ -324,7 +324,7 @@ class CloudWatchFirehoseEndpointSuite extends MUnitRouteSuite {
       assertEquals(decoded.timestamp, 0L)
     } else {
       assertEquals(decoded.requestId, "0001")
-      assertEquals(decoded.timestamp, timestamp + 35_000)
+      assertEquals(decoded.timestamp, ts + 35_000)
     }
     if (withException) {
       val string = new String(bs.toArray)
@@ -358,7 +358,7 @@ object CloudWatchFirehoseEndpointSuite {
       ),
       Datapoint
         .builder()
-        .timestamp(Instant.ofEpochMilli(timestamp))
+        .timestamp(Instant.ofEpochMilli(ts))
         .sum(42.0)
         .minimum(10.0)
         .maximum(32.0)
@@ -376,7 +376,7 @@ object CloudWatchFirehoseEndpointSuite {
       ),
       Datapoint
         .builder()
-        .timestamp(Instant.ofEpochMilli(timestamp))
+        .timestamp(Instant.ofEpochMilli(ts))
         .sum(1.0)
         .minimum(1.0)
         .maximum(1.0)
@@ -398,7 +398,7 @@ object CloudWatchFirehoseEndpointSuite {
       ),
       Datapoint
         .builder()
-        .timestamp(Instant.ofEpochMilli(timestamp))
+        .timestamp(Instant.ofEpochMilli(ts))
         .sum(2.0)
         .minimum(2.0)
         .maximum(2.0)
@@ -420,7 +420,7 @@ object CloudWatchFirehoseEndpointSuite {
       json.writeStartObject()
       if (!missingHeader) {
         json.writeStringField("requestId", "0001")
-        json.writeNumberField("timestamp", timestamp + 35_000)
+        json.writeNumberField("timestamp", ts + 35_000)
       }
       json.writeArrayFieldStart("records")
 


### PR DESCRIPTION
The manually configured offsets were error prone and added delay. Now we tag values as published and find the oldest valid non-published value and push that. We still need periods configured for each metric but this mechanism allows for out of order data and changes in publishing delays (now that AWS supports 0 time buffering on data firehoses.) The publish flag means additional writes during scrapes but it should still scale until we need to split scrapes for leaders across instances.
Timestamps in the cache are no longer normalized and we now record the time the value written to the cache. This will let us handle higher-resolution data eventually and help debug period missconfigurations. Data could also be lost when updates for the same series came in different threads from the firehose. One thread would update the cache while another would stomp the previous entry. Now we perform a compare and swap with merges to make sure both values are captured.
Timeouts are no longer used, instead prefering to drop values to mimic Cloud Watch's behavior.
Also log unexpected Firehose JSON at warn level instead of debug. Add AWS metrics to various counters and distributions for easier diagnosis. Splits up unit tests for the processor into separate files.