### PR TITLE
Add aws.metric tag to filter metric counter

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
@@ -176,12 +176,24 @@ abstract class CloudWatchMetricsProcessor(
         case Some(namespaceRules) =>
           namespaceRules.get(dp.metricName) match {
             case None =>
-              registry.counter(filteredMetric.withTag("aws.namespace", dp.namespace).withTag("aws.metric", dp.metricName)).increment()
+              registry
+                .counter(
+                  filteredMetric
+                    .withTag("aws.namespace", dp.namespace)
+                    .withTag("aws.metric", dp.metricName)
+                )
+                .increment()
               debugger.debugIncoming(dp, IncomingMatch.DroppedMetric, receivedTimestamp)
             case Some(tuple) =>
               val (category, _) = tuple
               if (!category.dimensionsMatch(dp.dimensions)) {
-                registry.counter(filteredTags.withTag("aws.namespace", dp.namespace).withTag("aws.metric", dp.metricName)).increment()
+                registry
+                  .counter(
+                    filteredTags
+                      .withTag("aws.namespace", dp.namespace)
+                      .withTag("aws.metric", dp.metricName)
+                  )
+                  .increment()
                 debugger.debugIncoming(
                   dp,
                   IncomingMatch.DroppedTag,

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
@@ -176,12 +176,12 @@ abstract class CloudWatchMetricsProcessor(
         case Some(namespaceRules) =>
           namespaceRules.get(dp.metricName) match {
             case None =>
-              registry.counter(filteredMetric.withTag("aws.namespace", dp.namespace)).increment()
+              registry.counter(filteredMetric.withTag("aws.namespace", dp.namespace).withTag("aws.metric", dp.metricName)).increment()
               debugger.debugIncoming(dp, IncomingMatch.DroppedMetric, receivedTimestamp)
             case Some(tuple) =>
               val (category, _) = tuple
               if (!category.dimensionsMatch(dp.dimensions)) {
-                registry.counter(filteredTags.withTag("aws.namespace", dp.namespace)).increment()
+                registry.counter(filteredTags.withTag("aws.namespace", dp.namespace).withTag("aws.metric", dp.metricName)).increment()
                 debugger.debugIncoming(
                   dp,
                   IncomingMatch.DroppedTag,

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CWMPProcessSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CWMPProcessSuite.scala
@@ -53,8 +53,10 @@ class CWMPProcessSuite extends BaseCloudWatchMetricsProcessorSuite {
       ts
     )
     assertPublished(List.empty)
-    assertCounters(1, filtered = Map("namespace" -> (1, "AWS/SomeNoneExistingNS"),
-      "metric" -> (0, "MyMetric")))
+    assertCounters(
+      1,
+      filtered = Map("namespace" -> (1, "AWS/SomeNoneExistingNS"), "metric" -> (0, "MyMetric"))
+    )
   }
 
   test("processDatapoints no metric match") {
@@ -71,8 +73,10 @@ class CWMPProcessSuite extends BaseCloudWatchMetricsProcessorSuite {
       ts
     )
     assertPublished(List.empty)
-    assertCounters(1, filtered = Map("namespace" -> (0, "AWS/UT1"),
-      "metric" -> (1, "SomeUnknownMetric")))
+    assertCounters(
+      1,
+      filtered = Map("namespace" -> (0, "AWS/UT1"), "metric" -> (1, "SomeUnknownMetric"))
+    )
   }
 
   test("processDatapoints missing tag") {
@@ -89,8 +93,7 @@ class CWMPProcessSuite extends BaseCloudWatchMetricsProcessorSuite {
       ts
     )
     assertPublished(List.empty)
-    assertCounters(1, filtered = Map("namespace" -> (0, "AWS/UT1"),
-      "tags" -> (1, "SumRate")))
+    assertCounters(1, filtered = Map("namespace" -> (0, "AWS/UT1"), "tags" -> (1, "SumRate")))
   }
 
   test("processDatapoints Filter by query") {
@@ -578,7 +581,15 @@ class CWMPProcessSuite extends BaseCloudWatchMetricsProcessorSuite {
       val (metricCount, metric) = filtered.getOrElse(reason, (0L, "NA"))
       assertEquals(
         registry
-          .counter("atlas.cloudwatch.datapoints.filtered", "aws.metric", metric, "aws.namespace", ns, "reason", reason)
+          .counter(
+            "atlas.cloudwatch.datapoints.filtered",
+            "aws.metric",
+            metric,
+            "aws.namespace",
+            ns,
+            "reason",
+            reason
+          )
           .count(),
         metricCount,
         s"Count differs for ${reason}"

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CWMPProcessSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CWMPProcessSuite.scala
@@ -53,7 +53,8 @@ class CWMPProcessSuite extends BaseCloudWatchMetricsProcessorSuite {
       ts
     )
     assertPublished(List.empty)
-    assertCounters(1, filtered = Map("namespace" -> (1, "AWS/SomeNoneExistingNS")))
+    assertCounters(1, filtered = Map("namespace" -> (1, "AWS/SomeNoneExistingNS"),
+      "metric" -> (0, "MyMetric")))
   }
 
   test("processDatapoints no metric match") {
@@ -70,7 +71,8 @@ class CWMPProcessSuite extends BaseCloudWatchMetricsProcessorSuite {
       ts
     )
     assertPublished(List.empty)
-    assertCounters(1, filtered = Map("metric" -> (1, "AWS/UT1")))
+    assertCounters(1, filtered = Map("namespace" -> (0, "AWS/UT1"),
+      "metric" -> (1, "SomeUnknownMetric")))
   }
 
   test("processDatapoints missing tag") {
@@ -87,7 +89,8 @@ class CWMPProcessSuite extends BaseCloudWatchMetricsProcessorSuite {
       ts
     )
     assertPublished(List.empty)
-    assertCounters(1, filtered = Map("tags" -> (1, "AWS/UT1")))
+    assertCounters(1, filtered = Map("namespace" -> (0, "AWS/UT1"),
+      "tags" -> (1, "SumRate")))
   }
 
   test("processDatapoints Filter by query") {
@@ -559,13 +562,25 @@ class CWMPProcessSuite extends BaseCloudWatchMetricsProcessorSuite {
     scraped: Long = 0
   ): Unit = {
     assertEquals(processor.received.count(), received)
-    List("namespace", "metric", "tags", "query").foreach { reason =>
+    List("namespace", "query").foreach { reason =>
       val (count, ns) = filtered.getOrElse(reason, (0L, "NA"))
       assertEquals(
         registry
           .counter("atlas.cloudwatch.datapoints.filtered", "aws.namespace", ns, "reason", reason)
           .count(),
         count,
+        s"Count differs for ${reason}"
+      )
+    }
+
+    List("metric", "tags").foreach { reason =>
+      val (nsCount, ns) = filtered.getOrElse("namespace", (0L, "NA"))
+      val (metricCount, metric) = filtered.getOrElse(reason, (0L, "NA"))
+      assertEquals(
+        registry
+          .counter("atlas.cloudwatch.datapoints.filtered", "aws.metric", metric, "aws.namespace", ns, "reason", reason)
+          .count(),
+        metricCount,
         s"Count differs for ${reason}"
       )
     }


### PR DESCRIPTION
Add aws.metric tag to filter metric counter, to confirm which all metrics names are getting filtered out