### PR TITLE
cloudwatch: Disable polling on S3 now that AWS is streaming the data.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/ec2.conf
+++ b/atlas-cloudwatch/src/main/resources/ec2.conf
@@ -8,144 +8,143 @@ atlas {
       period = 1m
       timeout = 20m
       end-period-offset = 1
-      poll-offset = 1m
 
       dimensions = [
         "InstanceId"
       ]
 
       metrics = [
-//        {
-//          name = "CPUUtilization"
-//          alias = "aws.ec2.cpuUtilization"
-//          conversion = "max"
-//        },
-//        {
-//          name = "NetworkIn"
-//          alias = "aws.ec2.networkThroughput"
-//          conversion = "sum,rate"
-//          tags = [
-//            {
-//              key = "id"
-//              value = "in"
-//            }
-//          ]
-//        },
-//        {
-//          name = "NetworkOut"
-//          alias = "aws.ec2.networkThroughput"
-//          conversion = "sum,rate"
-//          tags = [
-//            {
-//              key = "id"
-//              value = "out"
-//            }
-//          ]
-//        },
-//        {
-//          name = "NetworkPacketsIn"
-//          alias = "aws.ec2.networkPackets"
-//          conversion = "sum,rate"
-//          tags = [
-//            {
-//              key = "id"
-//              value = "in"
-//            }
-//          ]
-//        },
-//        {
-//          name = "NetworkPacketsOut"
-//          alias = "aws.ec2.networkPackets"
-//          conversion = "sum,rate"
-//          tags = [
-//            {
-//              key = "id"
-//              value = "out"
-//            }
-//          ]
-//        },
-//        {
-//          name = "DiskReadBytes"
-//          alias = "aws.ec2.ioThroughput"
-//          conversion = "sum,rate"
-//          tags = [
-//            {
-//              key = "id"
-//              value = "read"
-//            }
-//          ]
-//        },
-//        {
-//          name = "DiskWriteBytes"
-//          alias = "aws.ec2.ioThroughput"
-//          conversion = "sum,rate"
-//          tags = [
-//            {
-//              key = "id"
-//              value = "write"
-//            }
-//          ]
-//        },
-//        {
-//          name = "DiskReadOps"
-//          alias = "aws.ec2.iops"
-//          conversion = "sum,rate"
-//          tags = [
-//            {
-//              key = "id"
-//              value = "read"
-//            }
-//          ]
-//        },
-//        {
-//          name = "DiskWriteOps"
-//          alias = "aws.ec2.iops"
-//          conversion = "sum,rate"
-//          tags = [
-//            {
-//              key = "id"
-//              value = "write"
-//            }
-//          ]
-//        },
+        {
+          name = "CPUUtilization"
+          alias = "aws.ec2.cpuUtilization"
+          conversion = "max"
+        },
+        {
+          name = "NetworkIn"
+          alias = "aws.ec2.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "NetworkOut"
+          alias = "aws.ec2.networkThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "NetworkPacketsIn"
+          alias = "aws.ec2.networkPackets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "NetworkPacketsOut"
+          alias = "aws.ec2.networkPackets"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "DiskReadBytes"
+          alias = "aws.ec2.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "DiskWriteBytes"
+          alias = "aws.ec2.ioThroughput"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
+        {
+          name = "DiskReadOps"
+          alias = "aws.ec2.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "read"
+            }
+          ]
+        },
+        {
+          name = "DiskWriteOps"
+          alias = "aws.ec2.iops"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "write"
+            }
+          ]
+        },
         {
           name = "StatusCheckFailed"
           alias = "aws.ec2.statusCheckFailed"
           conversion = "max"
         },
-//        {
-//          name = "StatusCheckFailed_Instance"
-//          alias = "aws.ec2.badInstances"
-//          conversion = "max"
-//          tags = [
-//            {
-//              key = "id"
-//              value = "instance"
-//            }
-//          ]
-//        },
-//        {
-//          name = "StatusCheckFailed_System"
-//          alias = "aws.ec2.badInstances"
-//          conversion = "max"
-//          tags = [
-//            {
-//              key = "id"
-//              value = "system"
-//            }
-//          ]
-//        },
-//        {
-//          name = "StatusCheckFailed_AttachedEBS"
-//          alias = "aws.ec2.badInstances"
-//          conversion = "max"
-//          tags = [
-//            {
-//              key = "id"
-//              value = "ebs"
-//            }
-//          ]
-//        }
+        {
+          name = "StatusCheckFailed_Instance"
+          alias = "aws.ec2.badInstances"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "instance"
+            }
+          ]
+        },
+        {
+          name = "StatusCheckFailed_System"
+          alias = "aws.ec2.badInstances"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "system"
+            }
+          ]
+        },
+        {
+          name = "StatusCheckFailed_AttachedEBS"
+          alias = "aws.ec2.badInstances"
+          conversion = "max"
+          tags = [
+            {
+              key = "id"
+              value = "ebs"
+            }
+          ]
+        }
       ]
     }
 
@@ -265,7 +264,6 @@ atlas {
       namespace = "AWS/EC2"
       period = 5m
       end-period-offset = 10
-      poll-offset = 5m
 
       dimensions = [
         "Per-VPC Metrics",

--- a/atlas-cloudwatch/src/main/resources/s3.conf
+++ b/atlas-cloudwatch/src/main/resources/s3.conf
@@ -7,7 +7,6 @@ atlas {
       namespace = "AWS/S3"
       period = 1d
       end-period-offset = 4
-      poll-offset = 8h
 
       dimensions = [
         "BucketName",


### PR DESCRIPTION
Re-enable metrics for EC2 and disable polling.