### PR TITLE
druid: ignore null metadata mappings

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -314,8 +314,9 @@ object DruidClient {
   ) {
 
     def toDatasource: Datasource = {
-      val dimensions = columns.filter(_._2.isDimension).keys.toList.sorted
+      val dimensions = columns.filter(c => c._2 != null && c._2.isDimension).keys.toList.sorted
       val metrics = aggregators
+        .filterNot(_._2 == null)
         .map {
           case (name, column) => Metric(name, column.`type`)
         }


### PR DESCRIPTION
In some cases if misconfigured the metric name can be mapped to `null` which was leading to an NPE. Filter them out to allow other data to be picked up.