### PR TITLE
[Druid] Adjust metadata query to be compatible with Druid v29.x

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -286,7 +286,7 @@ object DruidClient {
     toInclude: Option[ToInclude] = None,
     merge: Boolean = true,
     analysisTypes: List[String] = List("aggregators"),
-    lenientAggregatorMerge: Boolean = true
+    aggregatorMergeStrategy: String = "latest"
   ) {
     val queryType: String = "segmentMetadata"
   }


### PR DESCRIPTION
Druid 29 deprecated the `lenientAggregatorMerge` option and replaced it with `aggregatorMergeStrategy`
Docs: https://druid.apache.org/docs/latest/querying/segmentmetadataquery/#aggregatormergestrategy