### PR TITLE
aggr: add support for sharding

### DIFF
--- a/atlas-aggregator/src/main/resources/application.conf
+++ b/atlas-aggregator/src/main/resources/application.conf
@@ -26,6 +26,27 @@ atlas.aggregator {
     queue-size = 10000
   }
 
+  shards {
+    // Ratio of traffic to send to report to shards instead of locally. Zero indicates
+    // all traffic should go locally. 1 indicates all should go to the set of remote shards.
+    // This setting is mainly used to transtion between a single aggregator cluster and a
+    // set of shards.
+    traffic-ratio = 0.0
+
+    // How many shards are there? Set to 0 to disable.
+    count = 0
+
+    // Pattern for shard URIs. The number for the shard , [0, count), will be substituted
+    // into the pattern. Use java format string accepting an integer.
+    uri-pattern = ""
+
+    // Size of the queue for each shard
+    queue-size = 50000
+
+    // Batch size for requests to publish to a shard
+    batch-size = 5000
+  }
+
   // Should the aggregation of gauges be delayed until the final eval step?
   delay-gauge-aggregation = true
 

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AggrConfig.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AggrConfig.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.atlas.aggregator
 
-import org.apache.pekko.actor.ActorSystem
-
 import java.security.SecureRandom
 import com.netflix.spectator.api.Clock
 import com.netflix.spectator.api.Registry
@@ -30,7 +28,7 @@ import com.typesafe.config.Config
 class AggrConfig(
   val config: Config,
   registry: Registry,
-  system: ActorSystem
+  client: PekkoClient
 ) extends AtlasConfig
     with EvaluatorConfig {
 
@@ -75,7 +73,7 @@ class AggrConfig(
   override def validTagCharacters(): String = null
 
   override def publisher(): Publisher = {
-    new PekkoPublisher(registry, this, system)
+    new PekkoPublisher(this, client)
   }
 
   override def evaluatorStepSize(): Long = {

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AtlasAggregatorService.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/AtlasAggregatorService.scala
@@ -15,7 +15,6 @@
  */
 package com.netflix.atlas.aggregator
 
-import org.apache.pekko.actor.ActorSystem
 import com.netflix.iep.service.AbstractService
 import com.netflix.spectator.api.Clock
 import com.netflix.spectator.api.Id
@@ -27,11 +26,11 @@ class AtlasAggregatorService(
   config: Config,
   clock: Clock,
   registry: Registry,
-  system: ActorSystem
+  client: PekkoClient
 ) extends AbstractService
     with Aggregator {
 
-  private val aggrCfg = new AggrConfig(config, registry, system)
+  private val aggrCfg = new AggrConfig(config, registry, client)
 
   private val aggrRegistry = new AtlasRegistry(clock, aggrCfg)
 

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PayloadDecoder.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PayloadDecoder.scala
@@ -183,6 +183,7 @@ class PayloadDecoder(
     val dsType = op match {
       case ADD => "sum"
       case MAX => "gauge"
+      case _   => "gauge"
     }
     tags(pos) = TagKey.dsType
     tags(pos + 1) = dsType

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PekkoClient.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PekkoClient.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.aggregator
+
+import com.fasterxml.jackson.core.StreamReadFeature
+import com.fasterxml.jackson.core.StreamWriteFeature
+import com.fasterxml.jackson.dataformat.smile.SmileFactory
+import com.netflix.atlas.pekko.AccessLogger
+import com.netflix.atlas.pekko.CustomMediaTypes
+import com.netflix.atlas.pekko.StreamOps
+import com.netflix.atlas.pekko.ThreadPools
+import com.netflix.spectator.api.Registry
+import org.apache.pekko.NotUsed
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model.HttpEntity
+import org.apache.pekko.http.scaladsl.model.HttpMethods
+import org.apache.pekko.http.scaladsl.model.HttpRequest
+import org.apache.pekko.http.scaladsl.model.HttpResponse
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.http.scaladsl.model.headers.HttpEncodings
+import org.apache.pekko.http.scaladsl.model.headers.`Content-Encoding`
+import org.apache.pekko.stream.Attributes
+import org.apache.pekko.stream.RestartSettings
+import org.apache.pekko.stream.scaladsl.Flow
+import org.apache.pekko.stream.scaladsl.Keep
+import org.apache.pekko.stream.scaladsl.RestartFlow
+import org.apache.pekko.stream.scaladsl.Sink
+import org.apache.pekko.util.ByteString
+
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.CompletableFuture
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration.*
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+class PekkoClient(registry: Registry, implicit val system: ActorSystem) {
+
+  import PekkoClient.*
+
+  private val encodingParallelism = math.max(2, Runtime.getRuntime.availableProcessors() / 2)
+
+  private val ec: ExecutionContext =
+    ThreadPools.fixedSize(registry, "PublishEncoding", encodingParallelism)
+
+  def createPublisherQueue(
+    name: String,
+    queueSize: Int
+  ): StreamOps.BlockingSourceQueue[RequestTuple] = {
+    val blockingQueue = new ArrayBlockingQueue[RequestTuple](queueSize)
+    StreamOps
+      .wrapBlockingQueue[RequestTuple](registry, name, blockingQueue)
+      .via(createPublisherFlow)
+      .toMat(Sink.ignore)(Keep.left)
+      .run()
+  }
+
+  def createPublisherFlow: Flow[RequestTuple, Unit, NotUsed] = {
+    val flow = Flow[RequestTuple]
+      .mapAsyncUnordered(encodingParallelism) { t =>
+        Future(t.mkRequest() -> t)(ec)
+      }
+      .via(Http().superPool[RequestTuple]())
+      .map {
+        case (response, t) =>
+          t.complete(response)
+          response.foreach(_.discardEntityBytes())
+      }
+    val restartSettings = RestartSettings(5.seconds, 5.seconds, 1.0)
+      .withLogSettings(RestartSettings.LogSettings(Attributes.LogLevels.Warning))
+    RestartFlow.onFailuresWithBackoff(restartSettings) { () =>
+      flow
+    }
+  }
+}
+
+object PekkoClient {
+
+  val VoidInstance: Void = null.asInstanceOf[Void]
+
+  private val headers = List(`Content-Encoding`(HttpEncodings.gzip))
+
+  class RequestTuple(uri: Uri, id: String, payload: AnyRef, encode: AnyRef => ByteString) {
+
+    private val promise: Promise[Void] = Promise()
+    private var logger: AccessLogger = _
+
+    def mkRequest(): HttpRequest = {
+      val entity = HttpEntity(CustomMediaTypes.`application/x-jackson-smile`, encode(payload))
+      val request = HttpRequest(HttpMethods.POST, uri, headers, entity)
+      logger = AccessLogger.newClientLogger(id, request)
+      request
+    }
+
+    def complete(result: Try[HttpResponse]): Unit = {
+      logger.complete(result)
+      result match {
+        case Success(_) => promise.success(VoidInstance)
+        case Failure(e) => promise.failure(e)
+      }
+    }
+
+    def future: CompletableFuture[Void] = {
+      import scala.jdk.FutureConverters.*
+      promise.future.asJava.toCompletableFuture
+    }
+  }
+
+  val factory: SmileFactory = SmileFactory
+    .builder()
+    .enable(StreamReadFeature.AUTO_CLOSE_SOURCE)
+    .enable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+    .build()
+
+  private val streams = new ThreadLocal[ByteArrayOutputStream]
+
+  /** Use thread local to reuse byte array buffers across calls. */
+  def getOrCreateStream: ByteArrayOutputStream = {
+    var baos = streams.get
+    if (baos == null) {
+      baos = new ByteArrayOutputStream
+      streams.set(baos)
+    } else {
+      baos.reset()
+    }
+    baos
+  }
+}

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PekkoPublisher.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PekkoPublisher.scala
@@ -15,45 +15,16 @@
  */
 package com.netflix.atlas.aggregator
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.http.scaladsl.Http
-import org.apache.pekko.http.scaladsl.model.HttpEntity
-import org.apache.pekko.http.scaladsl.model.HttpMethods
-import org.apache.pekko.http.scaladsl.model.HttpRequest
-import org.apache.pekko.http.scaladsl.model.HttpResponse
 import org.apache.pekko.http.scaladsl.model.Uri
-import org.apache.pekko.http.scaladsl.model.headers.*
-import org.apache.pekko.stream.Attributes
-import org.apache.pekko.stream.RestartSettings
-import org.apache.pekko.stream.scaladsl.Flow
-import org.apache.pekko.stream.scaladsl.Keep
-import org.apache.pekko.stream.scaladsl.RestartFlow
-import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.util.ByteString
 import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.core.StreamReadFeature
-import com.fasterxml.jackson.core.StreamWriteFeature
-import com.fasterxml.jackson.dataformat.smile.SmileFactory
 import com.netflix.atlas.core.util.FastGzipOutputStream
-import com.netflix.atlas.pekko.AccessLogger
-import com.netflix.atlas.pekko.CustomMediaTypes
-import com.netflix.atlas.pekko.StreamOps
-import com.netflix.atlas.pekko.ThreadPools
 import com.netflix.spectator.api.Measurement
-import com.netflix.spectator.api.Registry
 import com.netflix.spectator.atlas.Publisher
 import com.netflix.spectator.atlas.impl.EvalPayload
 import com.netflix.spectator.atlas.impl.PublishPayload
 
-import java.io.ByteArrayOutputStream
 import java.util.concurrent.CompletableFuture
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.concurrent.Promise
-import scala.concurrent.duration.*
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
 import scala.util.Using
 
 /**
@@ -61,52 +32,24 @@ import scala.util.Using
   * URLConnection class built into the JDK. This helps reduce the number of threads
   * needed overall.
   */
-class PekkoPublisher(registry: Registry, config: AggrConfig, implicit val system: ActorSystem)
-    extends Publisher {
+class PekkoPublisher(config: AggrConfig, client: PekkoClient) extends Publisher {
 
+  import PekkoClient.*
   import PekkoPublisher.*
 
   private val atlasUri = Uri(config.uri())
   private val evalUri = Uri(config.evalUri())
 
-  private val encodingParallelism = math.max(2, Runtime.getRuntime.availableProcessors() / 2)
-
-  private val ec: ExecutionContext =
-    ThreadPools.fixedSize(registry, "PublishEncoding", encodingParallelism)
-
   private val pubConfig = config.config.getConfig("atlas.aggregator.publisher")
   private val queueSize = pubConfig.getInt("queue-size")
 
-  private val atlasClient = createClient("publisher-atlas")
-  private val lwcClient = createClient("publisher-lwc")
-
-  private def createClient(name: String): StreamOps.SourceQueue[RequestTuple] = {
-    val flow = Flow[RequestTuple]
-      .mapAsyncUnordered(encodingParallelism) { t =>
-        Future(t.mkRequest() -> t)(ec)
-      }
-      .via(Http().superPool[RequestTuple]())
-      .map {
-        case (response, t) =>
-          t.complete(response)
-          response.foreach(_.discardEntityBytes())
-      }
-    val restartSettings = RestartSettings(5.seconds, 5.seconds, 1.0)
-      .withLogSettings(RestartSettings.LogSettings(Attributes.LogLevels.Warning))
-    val restartFlow = RestartFlow.onFailuresWithBackoff(restartSettings) { () =>
-      flow
-    }
-    StreamOps
-      .blockingQueue[RequestTuple](config.debugRegistry(), name, queueSize)
-      .via(restartFlow)
-      .toMat(Sink.ignore)(Keep.left)
-      .run()
-  }
+  private val atlasClient = client.createPublisherQueue("publisher-atlas", queueSize)
+  private val lwcClient = client.createPublisherQueue("publisher-lwc", queueSize)
 
   override def init(): Unit = {}
 
   override def publish(payload: PublishPayload): CompletableFuture[Void] = {
-    val t = new RequestTuple(atlasUri, "publisher-atlas", payload)
+    val t = new RequestTuple(atlasUri, "publisher-atlas", payload, encode)
     if (atlasClient.offer(t))
       CompletableFuture.completedFuture(VoidInstance)
     else
@@ -114,7 +57,7 @@ class PekkoPublisher(registry: Registry, config: AggrConfig, implicit val system
   }
 
   override def publish(payload: EvalPayload): CompletableFuture[Void] = {
-    val t = new RequestTuple(evalUri, "publisher-lwc", payload)
+    val t = new RequestTuple(evalUri, "publisher-lwc", payload, encode)
     if (lwcClient.offer(t))
       CompletableFuture.completedFuture(VoidInstance)
     else
@@ -129,66 +72,16 @@ class PekkoPublisher(registry: Registry, config: AggrConfig, implicit val system
 
 object PekkoPublisher {
 
-  private val VoidInstance = null.asInstanceOf[Void]
-
-  private val headers = List(`Content-Encoding`(HttpEncodings.gzip))
-
-  class RequestTuple(uri: Uri, id: String, payload: AnyRef) {
-
-    private val promise: Promise[Void] = Promise()
-    private var logger: AccessLogger = _
-
-    def mkRequest(): HttpRequest = {
-      val entity = HttpEntity(CustomMediaTypes.`application/x-jackson-smile`, encode(payload))
-      val request = HttpRequest(HttpMethods.POST, uri, headers, entity)
-      logger = AccessLogger.newClientLogger(id, request)
-      request
-    }
-
-    def complete(result: Try[HttpResponse]): Unit = {
-      logger.complete(result)
-      result match {
-        case Success(_) => promise.success(VoidInstance)
-        case Failure(e) => promise.failure(e)
-      }
-    }
-
-    def future: CompletableFuture[Void] = {
-      import scala.jdk.FutureConverters.*
-      promise.future.asJava.toCompletableFuture
-    }
-  }
-
-  private val factory = SmileFactory
-    .builder()
-    .enable(StreamReadFeature.AUTO_CLOSE_SOURCE)
-    .enable(StreamWriteFeature.AUTO_CLOSE_TARGET)
-    .build()
-
-  private val streams = new ThreadLocal[ByteArrayOutputStream]
-
-  /** Use thread local to reuse byte array buffers across calls. */
-  private def getOrCreateStream: ByteArrayOutputStream = {
-    var baos = streams.get
-    if (baos == null) {
-      baos = new ByteArrayOutputStream
-      streams.set(baos)
-    } else {
-      baos.reset()
-    }
-    baos
-  }
-
   /** Encode publish payload to a byte array. */
   private def encode(payload: AnyRef): ByteString = {
-    val baos = getOrCreateStream
+    val baos = PekkoClient.getOrCreateStream
     Using.resource(new FastGzipOutputStream(baos)) { out =>
-      Using.resource(factory.createGenerator(out)) { gen =>
+      Using.resource(PekkoClient.factory.createGenerator(out)) { gen =>
         payload match {
           case p: PublishPayload => encode(gen, p)
           case p: EvalPayload    => encode(gen, p)
           case p =>
-            throw new IllegalArgumentException("unknown payload type: " + p.getClass.getName)
+            throw new IllegalArgumentException(s"unknown payload type: ${p.getClass.getName}")
         }
       }
     }

--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/ShardedAggregatorService.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/ShardedAggregatorService.scala
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.aggregator
+
+import com.netflix.atlas.core.util.RefIntHashMap
+import com.netflix.atlas.pekko.StreamOps
+import com.netflix.iep.config.ConfigListener
+import com.netflix.iep.config.DynamicConfigManager
+import com.netflix.iep.service.AbstractService
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.impl.Hash64
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.StrictLogging
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.stream.scaladsl.Keep
+import org.apache.pekko.stream.scaladsl.Sink
+import org.apache.pekko.util.ByteString
+
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.TimeUnit
+import scala.collection.immutable.ArraySeq
+import scala.concurrent.duration.FiniteDuration
+import scala.util.Using
+
+class ShardedAggregatorService(
+  configManager: DynamicConfigManager,
+  registry: Registry,
+  client: PekkoClient,
+  localService: AtlasAggregatorService
+) extends AbstractService
+    with Aggregator
+    with StrictLogging {
+
+  import ShardedAggregatorService.*
+
+  private val listener = ConfigListener.forConfig("atlas.aggregator.shards", updateConfig)
+
+  private val queueManager =
+    new QueueManager(registry, configManager.get().getConfig("atlas.aggregator.shards"), client)
+
+  private val random = new java.util.Random()
+
+  @volatile private var trafficRatio: Double = 0.0
+
+  private def updateConfig(config: Config): Unit = {
+    logger.info(s"config updated: $config")
+    trafficRatio = config.getDouble("traffic-ratio")
+
+    val count = config.getInt("count")
+    val pattern = config.getString("uri-pattern")
+    val uris = (0 until count).map { i =>
+      pattern.formatted(i)
+    }.toList
+    queueManager.setUris(uris)
+  }
+
+  override def startImpl(): Unit = {
+    configManager.addListener(listener)
+  }
+
+  override def stopImpl(): Unit = {
+    configManager.removeListener(listener)
+  }
+
+  private def shouldUpdateLocally: Boolean = {
+    trafficRatio <= 0.0 || trafficRatio < random.nextDouble()
+  }
+
+  override def add(id: Id, value: Double): Unit = {
+    if (shouldUpdateLocally)
+      localService.add(id, value)
+    else
+      update(id, ADD, value)
+  }
+
+  override def max(id: Id, value: Double): Unit = {
+    if (shouldUpdateLocally)
+      localService.max(id, value)
+    else
+      update(id, MAX, value)
+  }
+
+  private def update(id: Id, op: Int, value: Double): Unit = {
+    val entry = UpdateEntry(id, op, value)
+    queueManager.offer(entry)
+  }
+}
+
+object ShardedAggregatorService {
+
+  private val ADD = 0
+  private val MAX = 10
+
+  case class UpdateEntry(id: Id, op: Int, value: Double)
+
+  case class UpdateQueue(uri: String, queue: StreamOps.BlockingSourceQueue[UpdateEntry])
+
+  class QueueManager(registry: Registry, config: Config, client: PekkoClient)
+      extends StrictLogging {
+
+    private val queueSize = config.getInt("queue-size")
+    private val batchSize = config.getInt("batch-size")
+
+    @volatile private var queues: ArraySeq[UpdateQueue] = ArraySeq.empty
+
+    def setUris(uris: List[String]): Unit = {
+      val qs = queues
+      val currentQueues = qs.map(q => q.uri -> q).toMap
+
+      // Setup new queues
+      val newQueues = uris.map { uri =>
+        currentQueues.get(uri) match {
+          case Some(q) => q
+          case None    => UpdateQueue(uri, createQueue(uri))
+        }
+      }
+
+      // Mark old queues as complete
+      val oldQueues = currentQueues -- uris
+      oldQueues.values.foreach { q =>
+        logger.info(s"shutting down queue: ${q.uri}")
+        q.queue.complete()
+      }
+
+      // Update queues reference
+      queues = newQueues.to(ArraySeq)
+    }
+
+    private def createQueue(uriStr: String): StreamOps.BlockingSourceQueue[UpdateEntry] = {
+      logger.info(s"creating queue: $uriStr (queue-size: $queueSize, batch-size: $batchSize)")
+      implicit val system: ActorSystem = client.system
+      val uri = Uri(uriStr)
+      val id = uri.authority.host.address()
+      val queue = new ArrayBlockingQueue[UpdateEntry](queueSize)
+      StreamOps
+        .wrapBlockingQueue(registry, id, queue)
+        .groupedWithin(batchSize, FiniteDuration(2, TimeUnit.SECONDS))
+        .map { batch =>
+          new PekkoClient.RequestTuple(uri, id, batch, encode)
+        }
+        .via(client.createPublisherFlow)
+        .toMat(Sink.ignore)(Keep.left)
+        .run()
+    }
+
+    private def encode(batch: AnyRef): ByteString = {
+      encodeEntries(batch.asInstanceOf[List[UpdateEntry]])
+    }
+
+    def offer(entry: UpdateEntry): Unit = {
+      val qs = queues
+      val i = Hash64.reduce(entry.id.hashCode(), qs.size)
+      qs(i).queue.offer(entry)
+    }
+  }
+
+  def encodeEntries(batch: List[UpdateEntry]): ByteString = {
+    // Create string table
+    val stringTable = new RefIntHashMap[String]()
+    batch.foreach { entry =>
+      val id = entry.id
+      id.forEach { (k, v) =>
+        stringTable.put(k, 0)
+        stringTable.put(v, 0)
+      }
+    }
+    val strings = new Array[String](stringTable.size)
+    var i = 0
+    stringTable.foreach { (k, _) =>
+      strings(i) = k
+      i += 1
+    }
+    java.util.Arrays.sort(strings.asInstanceOf[Array[AnyRef]])
+
+    // Start generating output
+    val baos = PekkoClient.getOrCreateStream
+    Using.resource(PekkoClient.factory.createGenerator(baos)) { gen =>
+      gen.writeStartArray()
+      gen.writeNumber(strings.length)
+      var i = 0
+      while (i < strings.length) {
+        gen.writeString(strings(i))
+        stringTable.put(strings(i), i)
+        i += 1
+      }
+
+      batch.foreach { entry =>
+        val id = entry.id
+        gen.writeNumber(id.size())
+        id.forEach { (k, v) =>
+          gen.writeNumber(stringTable.get(k, -1))
+          gen.writeNumber(stringTable.get(v, -1))
+        }
+        gen.writeNumber(entry.op)
+        gen.writeNumber(entry.value)
+      }
+      gen.writeEndArray()
+    }
+
+    ByteString.fromArrayUnsafe(baos.toByteArray)
+  }
+}

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/UpdateApiSuite.scala
@@ -41,7 +41,9 @@ class UpdateApiSuite extends FunSuite {
   private val aggrTag = Tag.of("atlas.dstype", "sum")
 
   private def createAggrService(clock: Clock): AtlasAggregatorService = {
-    new AtlasAggregatorService(ConfigFactory.load(), clock, new NoopRegistry, system)
+    val registry = new NoopRegistry
+    val client = new PekkoClient(registry, system)
+    new AtlasAggregatorService(ConfigFactory.load(), clock, registry, client)
   }
 
   test("simple payload") {

--- a/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/CwExprValidations.scala
+++ b/iep-lwc-fwding-admin/src/main/scala/com/netflix/iep/lwc/fwd/admin/CwExprValidations.scala
@@ -15,8 +15,6 @@
  */
 package com.netflix.iep.lwc.fwd.admin
 
-import java.time.Duration
-
 import com.fasterxml.jackson.databind.JsonNode
 import com.netflix.atlas.core.model.DataExpr
 import com.netflix.atlas.core.model.Query.*

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     val scala      = "2.13.14"
     val servo      = "0.13.2"
     val slf4j      = "1.7.36"
-    val spectator  = "1.7.17"
+    val spectator  = "1.7.18"
     val spring     = "6.0.7"
     val avroV      = "1.11.3"
 


### PR DESCRIPTION
Adds optional mode that can be used to shard the data across multiple aggregator clusters. This can be helpful to scale out while keeping the updates for the same meters on a small subset of nodes. Helps reduce duplication across the instances in the cluster.