### PR TITLE
cloudwatch: add Stage to the API Gateway.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/api-gateway.conf
+++ b/atlas-cloudwatch/src/main/resources/api-gateway.conf
@@ -9,7 +9,8 @@ atlas {
       end-period-offset = 3
 
       dimensions = [
-        "ApiName"
+        "ApiName",
+        "Stage"
       ]
 
       metrics = [

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -252,6 +252,10 @@ atlas {
           alias = "aws.version"
         },
         {
+          name = "ApiName"
+          alias = "aws.resource"
+        },
+        {
           name = "AudioDescriptionName"
           alias = "aws.audio-description"
         },
@@ -434,6 +438,10 @@ atlas {
         {
           name = "ServiceName"
           alias = "aws.service"
+        },
+        {
+          name = "Stage"
+          alias = "aws.stage"
         },
         {
           name = "SourceBucket",


### PR DESCRIPTION
Also fix mappings for ApiName to aws.resource and Stage to aws.stage. The old pollers were mapping the ApiName to resource.