### PR TITLE
cloudwatch: Enable detailed and non-detailed metrics.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/api-gateway.conf
+++ b/atlas-cloudwatch/src/main/resources/api-gateway.conf
@@ -2,7 +2,7 @@
 atlas {
   cloudwatch {
 
-    // http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-dashboard.html
+    // https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html
     api-gateway = {
       namespace = "AWS/ApiGateway"
       period = 1m
@@ -48,5 +48,53 @@ atlas {
         }
       ]
     }
+
+    api-gateway-detail = {
+      namespace = "AWS/ApiGateway"
+      period = 1m
+
+      dimensions = [
+        "ApiName",
+        "Method",
+        "Resource",
+        "Stage"
+      ]
+
+      metrics = [
+        {
+          name = "Count"
+          alias = "aws.apigateway.requests"
+          conversion = "sum,rate"
+        },
+        {
+          name = "4XXError"
+          alias = "aws.apigateway.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "4xx"
+            }
+          ]
+        },
+        {
+          name = "5XXError"
+          alias = "aws.apigateway.errors"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "status"
+              value = "5xx"
+            }
+          ]
+        },
+        {
+          name = "Latency"
+          alias = "aws.apigateway.latency"
+          conversion = "timer-millis"
+        }
+      ]
+    }
   }
+
 }

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -253,7 +253,7 @@ atlas {
         },
         {
           name = "ApiName"
-          alias = "aws.resource"
+          alias = "aws.api"
         },
         {
           name = "AudioDescriptionName"
@@ -370,6 +370,10 @@ atlas {
         {
           name = "LoadBalancerName"
           alias = "aws.elb"
+        },
+        {
+          name = "Method"
+          alias = "aws.method"
         },
         {
           name = "MetricStreamName"
@@ -515,6 +519,7 @@ atlas {
       "alb-zone",
       "alb-tg-zone",
       "api-gateway",
+      "api-gateway-detail",
       "billing",
       "cloudhsm",
       "cw-metric-streams",

--- a/atlas-cloudwatch/src/test/resources/application.conf
+++ b/atlas-cloudwatch/src/test/resources/application.conf
@@ -24,7 +24,9 @@ atlas {
       "ut-mono",
       "ut-redis",
       "ut-daily",
-      "queryfilter"
+      "queryfilter",
+      "nswithoutdetails",
+      "nswithdetails"
     ]
 
     account {

--- a/atlas-cloudwatch/src/test/resources/test-rules.conf
+++ b/atlas-cloudwatch/src/test/resources/test-rules.conf
@@ -200,5 +200,44 @@ atlas {
       filter = "Key,:has"
     }
 
+    nswithoutdetails = {
+      namespace = "AWS/DetailsMeMaybe"
+      period = 1m
+
+      dimensions = [
+        "Key"
+      ]
+
+      metrics = [
+        {
+          name = "MyTestMetric"
+          alias = "aws.details.mytestmetric"
+          conversion = "max"
+        }
+      ]
+
+      filter = "Key,:has"
+    }
+
+    nswithdetails = {
+      namespace = "AWS/DetailsMeMaybe"
+      period = 1m
+
+      dimensions = [
+        "Key",
+        "Details"
+      ]
+
+      metrics = [
+        {
+          name = "MyTestMetric"
+          alias = "aws.details.mytestmetric"
+          conversion = "max"
+        }
+      ]
+
+      filter = "Key,:has"
+    }
+
   }
 }


### PR DESCRIPTION
Some accounts opt in to detailed metrics, meanin additional tags. This change lets us supply configurations for multiple dimension sets.
Fixes the API gateway metrics to have both detailed and non-detailed.