### PR TITLE
atlas cloudwatch: add standard tags for Lambda.

### DIFF
--- a/atlas-cloudwatch/README.md
+++ b/atlas-cloudwatch/README.md
@@ -102,10 +102,11 @@ than the configuration will be dropped. The dimensions may be verified in docume
 checking the groupings in the AWS Console. Within some AWS metrics namespaces, the different
 metrics have different dimensions, so you may need to break up the definition of metrics.
 
-**Warning**
-Do not configure categories for the same metrics with different dimensions. E.g. LBs post aggregated
-values with the `LoadBalancer` and `LoadBalancer`, `AvailabilityZone` dimensions. Choose one
-combination of tags or users are likely to see errant data in Atlas when the tags are combined.
+**NOTE**
+Be careful when defining configurations with multiple dimension sets for the same data. Cloudwatch has
+multiple aggregates. Some metrics are emitted with a standard set of dimensions and users can opt-in to
+a set of more detailed metrics that include extra dimensions. Generally, choose the standard set and
+add the detailed set if users request.
 
 See [route53.conf](src/main/resources/route53.conf) as an example.
 

--- a/atlas-cloudwatch/src/main/resources/lambda.conf
+++ b/atlas-cloudwatch/src/main/resources/lambda.conf
@@ -8,9 +8,92 @@ atlas {
       period = 1m
       end-period-offset = 5
 
-      dimensions = []
+      dimensions = [
+        "FunctionName",
+        "Resource"
+      ]
 
       metrics = [
+        {
+          name = "TimeToLastByteLatency"
+          alias = "aws.lambda.timeToLastByteLatency"
+          conversion = "timer-millis"
+        },
+        {
+          name = "TimeToFirstByteLatency"
+          alias = "aws.lambda.timeToFirstByteLatency"
+          conversion = "timer-millis"
+        },
+        {
+          name = "ProvisionedConcurrencyInvocations"
+          alias = "aws.lambda.provisionedConcurrencyInvocations"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ProvisionedConcurrencySpilloverInvocations"
+          alias = "aws.lambda.provisionedConcurrencySpilloverInvocations"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ProvisionedConcurrencyUtilization"
+          alias = "aws.lambda.provisionedConcurrencyUtilization"
+          conversion = "max"
+        },
+        {
+          name = "AsyncEventsReceived",
+          alias = "aws.lambda.asyncEventsReceived",
+          conversion = "sum,rate"
+        },
+        {
+          name = "AsyncEventAge",
+          alias = "aws.lambda.asyncEventAge",
+          conversion = "max"
+        },
+        {
+          name = "AsyncEventsDropped",
+          alias = "aws.lambda.asyncEventsDropped",
+          conversion = "sum,rate"
+        },
+        {
+          name = "ConcurrentExecutions"
+          alias = "aws.lambda.concurrentExecutions"
+          conversion = "max"
+        },
+        {
+          name = "ProvisionedConcurrentExecutions"
+          alias = "aws.lambda.provisionedConcurrentExecutions"
+          conversion = "max"
+        },
+        {
+          name = "DeadLetterErrors"
+          alias = "aws.lambda.deadLetterErrors"
+          conversion = "sum,rate"
+        },
+        {
+          name = "Duration"
+          alias = "aws.lambda.duration"
+          conversion = "timer-millis"
+        },
+        {
+          name = "Errors"
+          alias = "aws.lambda.errors"
+          conversion = "sum,rate"
+        },
+        {
+          name = "Invocations"
+          alias = "aws.lambda.invocations"
+          conversion = "sum,rate"
+        },
+        {
+          name = "IteratorAge"
+          alias = "aws.lambda.iteratorAge"
+          conversion = "max"
+        },
+        {
+          name = "Throttles"
+          alias = "aws.lambda.throttles"
+          conversion = "sum,rate"
+        },
         {
           name = "UnreservedConcurrentExecutions"
           alias = "aws.lambda.unreservedConcurrentExecutions"
@@ -111,6 +194,11 @@ atlas {
           alias = "aws.lambda.throttles"
           conversion = "sum,rate"
         },
+        {
+          name = "UnreservedConcurrentExecutions"
+          alias = "aws.lambda.unreservedConcurrentExecutions"
+          conversion = "max"
+        }
       ]
     }
   }


### PR DESCRIPTION
Update the readme about standard vs detailed tag sets.