### PR TITLE
druid: support data with mixed step sizes

### DIFF
--- a/atlas-druid/src/main/resources/application.conf
+++ b/atlas-druid/src/main/resources/application.conf
@@ -23,6 +23,8 @@ atlas {
     normalize-rates = true
   }
 
+  core.model.step = 5s
+
   pekko {
     api-endpoints = ${?atlas.pekko.api-endpoints} [
       "com.netflix.atlas.druid.ExplainApi",

--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/ReduceStepTimeSeq.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/ReduceStepTimeSeq.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.druid
+
+import com.netflix.atlas.core.model.DsType
+import com.netflix.atlas.core.model.TimeSeq
+
+class ReduceStepTimeSeq(ts: TimeSeq, val step: Long) extends TimeSeq {
+
+  require(
+    ts.step % step == 0,
+    "original step must be a multiple of reduced step"
+  )
+
+  def dsType: DsType = ts.dsType
+
+  def apply(timestamp: Long): Double = {
+    val t = timestamp / ts.step * ts.step
+    ts(t + ts.step)
+  }
+}

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
@@ -19,6 +19,7 @@ import java.time.Duration
 import java.time.Instant
 import com.netflix.atlas.core.model.ConsolidationFunction
 import com.netflix.atlas.core.model.DataExpr
+import com.netflix.atlas.core.model.DefaultSettings
 import com.netflix.atlas.core.model.EvalContext
 import com.netflix.atlas.core.model.Query
 import com.netflix.atlas.core.model.QueryVocabulary
@@ -339,7 +340,8 @@ class DruidDatabaseActorSuite extends FunSuite {
   test("createValueMapper: avg consolidation") {
     val expr = DataExpr.Sum(Query.Equal("a", "1"))
     val mapper = createValueMapper(false, context.copy(step = 300000), expr)
-    assertEquals(mapper(1.0), 1.0 / 5)
+    val multiple = 300000 / DefaultSettings.stepSize
+    assertEquals(mapper(1.0), 1.0 / multiple)
   }
 
   test("createValueMapper: max consolidation") {


### PR DESCRIPTION
Update so that some data sources can be more granular than others and get blended together on the graphs. If a data source doesn't support the fine granularity, then it will be retrieved at its supported granularity and mapped to the requested step for the graph.

This will not work for data sources that are consolidated historically. That would add quite a bit of complexity to processing the data, but may be desirable in the future to help mitigate cost.