### PR TITLE
cloudwatch: Fix metric recording exception.

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
@@ -569,9 +569,9 @@ abstract class CloudWatchMetricsProcessor(
     } catch {
       case ex: Exception =>
         registry
-          .counter(publishEx.withTags("aws.namespace", "ex", ex.getClass.getSimpleName))
+          .counter(publishEx.withTags("ex", ex.getClass.getSimpleName))
           .increment()
-        logger.error("Unexpected exception publishing", ex)
+        logger.error(s"Unexpected exception publishing from key: ${key}", ex)
     }
   }
 


### PR DESCRIPTION
The routing exception handler was missing an AWS namespace value when recording metrics on routing exceptions resulting in an error that threw off processing a batch. Now we properly record and log the exception without throwing.