### PR TITLE
atlas cloudwatch: Fix typo for DX `ConnectionErrorCount`

### DIFF
--- a/atlas-cloudwatch/src/main/resources/dx.conf
+++ b/atlas-cloudwatch/src/main/resources/dx.conf
@@ -19,8 +19,18 @@ atlas {
           conversion = "max"
         },
         {
-          name = "ConnectErrorCount"
-          alias = "aws.dx.connectErrorCount"
+          name = "ConnectionEncryptionState"
+          alias = "aws.dx.encryptionState"
+          conversion = "max"
+        },
+        {
+          name = "ConnectionCRCErrorCount"
+          alias = "aws.dx.connectionCRCErrorCount"
+          conversion = "sum,rate"
+        },
+        {
+          name = "ConnectionErrorCount"
+          alias = "aws.dx.connectionErrorCount"
           conversion = "sum,rate"
         },
         {


### PR DESCRIPTION
Add DX ConnectionCRCErrorCount and ConnectionEncryptionState