### PR TITLE
cloudwatch_poller: Keep a 5sec frequency for high resolution metrics poller

### DIFF
--- a/atlas-cloudwatch/src/main/resources/mediaconnect.conf
+++ b/atlas-cloudwatch/src/main/resources/mediaconnect.conf
@@ -61,6 +61,18 @@ atlas {
 
       metrics = [
         {
+          name = "BitRate"
+          alias = "aws.mediaconnect.bitRate"
+          conversion = "max"
+          tags = []
+        },
+        {
+          name = "TotalPackets"
+          alias = "aws.mediaconnect.totalPackets"
+          conversion = "sum,rate"
+          tags = []
+        },
+        {
           name = "ARQRequests"
           alias = "aws.mediaconnect.arqRequests"
           conversion = "sum,rate"

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -115,6 +115,9 @@ atlas {
       // How often to run the polling scheduler to see if a polling run needs to
       // execute.
       frequency = 1m
+
+      // frequency for high resolution metrics
+      hrmFrequency = 5s
     }
 
     // Whether or not metrics should be pre-pended with TEST.

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchPollerSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchPollerSuite.scala
@@ -118,6 +118,7 @@ class CloudWatchPollerSuite extends FunSuite with TestKitBase {
         |    account.polling.fastPolling = []
         |    categories = ["cfg1", "cfg2"]
         |    poller.frequency = "5m"
+        |    poller.hrmFrequency = "5s"
         |
         |    cfg1 = {
         |      namespace = "AWS/CFG1"


### PR DESCRIPTION
Add a High resolution metric polling frequency of 5 sec and adding few more metric which are getting non-zero values  