### PR TITLE
cloudwatch: switch to spectator QueryIndex

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,7 @@ lazy val `atlas-cloudwatch` = project
     Dependencies.log4jSlf4j,
     Dependencies.openHFT,
     Dependencies.protobuf,
+    Dependencies.spectatorAtlas,
 
     Dependencies.atlasPekkoTestkit % "test",
     Dependencies.atlasWebApi % "test",


### PR DESCRIPTION
Phase out usage of legacy QueryIndex.