### PR TITLE
druid: ensure metadata is available when starting

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/AppConfiguration.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/AppConfiguration.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.druid
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class AppConfiguration {
+
+  @Bean
+  def metadataService: DruidMetadataService = {
+    new DruidMetadataService
+  }
+}

--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -53,7 +53,9 @@ import scala.concurrent.duration.*
 import scala.util.Failure
 import scala.util.Success
 
-class DruidDatabaseActor(config: Config) extends Actor with StrictLogging {
+class DruidDatabaseActor(config: Config, service: DruidMetadataService)
+    extends Actor
+    with StrictLogging {
 
   import DruidClient.*
   import DruidDatabaseActor.*
@@ -120,8 +122,11 @@ class DruidDatabaseActor(config: Config) extends Actor with StrictLogging {
       }
       .runWith(Sink.head)
       .onComplete {
-        case Success(m) => ref ! m
-        case Failure(t) => logger.warn("failed to refresh metadata", t)
+        case Success(m) =>
+          ref ! m
+          service.metadataRefreshed()
+        case Failure(t) =>
+          logger.warn("failed to refresh metadata", t)
       }
   }
 

--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidMetadataService.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidMetadataService.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.druid
+
+import com.netflix.iep.service.AbstractService
+
+/**
+  * Used to indicate the service is not healthy until the metadata has been updated
+  * at least once.
+  */
+class DruidMetadataService extends AbstractService {
+
+  @volatile private var metadataAvailable: Boolean = false
+
+  def metadataRefreshed(): Unit = {
+    metadataAvailable = true
+  }
+
+  override def isHealthy: Boolean = {
+    super.isHealthy && metadataAvailable
+  }
+
+  override def startImpl(): Unit = {}
+
+  override def stopImpl(): Unit = {}
+}


### PR DESCRIPTION
Add a service included in the healthcheck to ensure that the metadata has been updated at least once before marking the service as healthy. Before it could become healthy even if it was failing to refresh the metadata.