### PR TITLE
lwc-bridge: allow ids to log to be set dynamically

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -178,6 +178,7 @@ lazy val `iep-lwc-bridge` = project
     Dependencies.atlasCore,
     Dependencies.atlasSpringPekko,
     Dependencies.frigga,
+    Dependencies.iepDynConfig,
     Dependencies.iepSpring,
     Dependencies.iepSpringAtlas,
     Dependencies.log4jApi,

--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/AppConfiguration.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/AppConfiguration.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.iep.lwc
 
+import com.netflix.iep.config.DynamicConfigManager
 import org.apache.pekko.actor.ActorSystem
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
@@ -30,10 +31,10 @@ class AppConfiguration {
 
   @Bean
   def expressionsEvaluator(
-    config: Optional[Config],
+    config: Optional[DynamicConfigManager],
     registry: Optional[Registry]
   ): ExpressionsEvaluator = {
-    val c = config.orElseGet(() => ConfigFactory.load())
+    val c = config.orElseGet(() => DynamicConfigManager.create(ConfigFactory.load()))
     val r = registry.orElseGet(() => new NoopRegistry)
     new ExpressionsEvaluator(c, r)
   }

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/BridgeApiSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/BridgeApiSuite.scala
@@ -19,6 +19,7 @@ import org.apache.pekko.http.scaladsl.model.StatusCodes
 import org.apache.pekko.http.scaladsl.testkit.RouteTestTimeout
 import com.netflix.atlas.pekko.RequestHandler
 import com.netflix.atlas.pekko.testkit.MUnitRouteSuite
+import com.netflix.iep.config.DynamicConfigManager
 import com.netflix.spectator.api.Id
 import com.netflix.spectator.api.NoopRegistry
 import com.typesafe.config.ConfigFactory
@@ -29,7 +30,8 @@ class BridgeApiSuite extends MUnitRouteSuite {
   private implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.second)
 
   private val config = ConfigFactory.load()
-  private val evaluator = new ExpressionsEvaluator(config, new NoopRegistry)
+  private val configMgr = DynamicConfigManager.create(config)
+  private val evaluator = new ExpressionsEvaluator(configMgr, new NoopRegistry)
   private val endpoint = new BridgeApi(config, new NoopRegistry, evaluator, system)
   private val routes = RequestHandler.standardOptions(endpoint.routes)
 

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExprUpdateServiceSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExprUpdateServiceSuite.scala
@@ -15,6 +15,7 @@
  */
 package com.netflix.iep.lwc
 
+import com.netflix.iep.config.DynamicConfigManager
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.model.HttpResponse
 import org.apache.pekko.http.scaladsl.model.StatusCodes
@@ -39,9 +40,10 @@ class ExprUpdateServiceSuite extends FunSuite {
   private implicit val system: ActorSystem = ActorSystem()
 
   private val config = ConfigFactory.load()
+  private val configMgr = DynamicConfigManager.create(config)
   private val clock = new ManualClock()
   private val registry = new DefaultRegistry(clock)
-  private val evaluator = new ExpressionsEvaluator(config, registry)
+  private val evaluator = new ExpressionsEvaluator(configMgr, registry)
 
   private val service = new ExprUpdateService(config, registry, evaluator, system)
 

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/StatsApiSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/StatsApiSuite.scala
@@ -23,6 +23,7 @@ import org.apache.pekko.http.scaladsl.testkit.RouteTestTimeout
 import com.netflix.atlas.pekko.RequestHandler
 import com.netflix.atlas.pekko.testkit.MUnitRouteSuite
 import com.netflix.atlas.json.Json
+import com.netflix.iep.config.DynamicConfigManager
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.atlas.impl.Subscription
 import com.typesafe.config.ConfigFactory
@@ -35,7 +36,8 @@ class StatsApiSuite extends MUnitRouteSuite {
   private implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.second)
 
   private val config = ConfigFactory.load()
-  private val evaluator = new ExpressionsEvaluator(config, new NoopRegistry)
+  private val configMgr = DynamicConfigManager.create(config)
+  private val evaluator = new ExpressionsEvaluator(configMgr, new NoopRegistry)
   private val endpoint = new StatsApi(evaluator)
   private val routes = RequestHandler.standardOptions(endpoint.routes)
 


### PR DESCRIPTION
To ease debugging make the set of subscription ids to log a dynamic property.