### PR TITLE
Simplify polled cw-dp to atlas-dp match/conversion

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
@@ -155,9 +155,9 @@ class PublishRouter(
    * @param datapoint
    *     The non-null data point.
    */
-  def publishToRegistry(datapoint: AtlasDatapoint): Unit = {
+  def publishToRegistry(datapoint: AtlasDatapoint, cwDataPoint: CloudWatchDatapoint): Unit = {
     getQueue(datapoint) match {
-      case Some(queue) => queue.updateRegistry(datapoint)
+      case Some(queue) => queue.updateRegistry(datapoint, cwDataPoint)
       case None        => missingAccount.increment()
     }
   }

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/package.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/package.scala
@@ -33,4 +33,6 @@ package object cloudwatch {
   type Conversion = (MetricMetadata, Datapoint) => Double
 
   type AtlasDatapoint = com.netflix.atlas.core.model.Datapoint
+
+  type CloudWatchDatapoint = software.amazon.awssdk.services.cloudwatch.model.Datapoint
 }


### PR DESCRIPTION
* ``sendToRegistry `` does not require full category scan to match a given metric-name, we can pass the existing metadata from poller, to directly transform to an Atlas datapoint.

* Added some more metric/tag/logs for debugging purpose only, will remove later as this will be 5s frequency noise. 