### PR TITLE
Fix tagger for nf.asg to cluster/app conversion

### DIFF
--- a/atlas-cloudwatch/src/test/resources/application.conf
+++ b/atlas-cloudwatch/src/test/resources/application.conf
@@ -18,6 +18,7 @@ atlas {
     categories = ${?atlas.cloudwatch.categories} [
       "ut1",
       "ut5",
+      "ut-ec2",
       "ut-asg",
       "ut-timeout",
       "ut-offset",

--- a/atlas-cloudwatch/src/test/resources/test-rules.conf
+++ b/atlas-cloudwatch/src/test/resources/test-rules.conf
@@ -61,6 +61,22 @@ atlas {
       ]
     }
 
+    ut-ec2 = {
+      namespace = "AWS/UT1"
+      period = 5m
+
+      dimensions = [
+        "AutoScalingGroupName"
+      ]
+
+      metrics = [
+        {
+          name = "EBSReadBytes"
+          alias = "aws.ec2.ebs.ebsReadBytes"
+          conversion = "sum,rate"
+        }
+      ]
+    }
     ut-asg = {
       namespace = "AWS/UT1"
       period = 1m

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CWMPProcessSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CWMPProcessSuite.scala
@@ -327,6 +327,39 @@ class CWMPProcessSuite extends BaseCloudWatchMetricsProcessorSuite {
     assertCounters(1)
   }
 
+  test("processDatapoints ec2 bytes") {
+    val dp = makeFirehoseMetric(
+      "AWS/UT1",
+      "EBSReadBytes",
+      List(
+        Dimension.builder().name("AutoScalingGroupName").value("someApp-someStack-v001").build()
+      ),
+      Array(1, 1, 1, 1),
+      "Bytes",
+      ts(-5.minute)
+    )
+    processor.processDatapoints(List(dp), ts(-5.minute))
+
+    assertPublished(
+      List(
+        com.netflix.atlas.core.model.Datapoint(
+          Map(
+            "name"         -> "aws.ec2.ebs.ebsReadBytes",
+            "nf.region"    -> "us-west-2",
+            "atlas.dstype" -> "rate",
+            "nf.stack"     -> "someStack",
+            "nf.app"       -> "someApp",
+            "nf.asg"       -> "someApp-someStack-v001",
+            "nf.cluster"   -> "someApp-someStack"
+          ),
+          ts,
+          0.0033333333333333335
+        )
+      )
+    )
+    assertCounters(1)
+  }
+
   test("processDatapoints matched percent") {
     processor.processDatapoints(
       List(


### PR DESCRIPTION
For nf.asg, the extracted app/cluster tag  was getting overridden, added a test to confirm new behavior. 