### PR TITLE
add api endpoints for clusters

### DIFF
--- a/atlas-slotting/README.md
+++ b/atlas-slotting/README.md
@@ -84,7 +84,7 @@ point at which slots are calculated. The instance is sized appropriately for the
         <td width="30%">Healthcheck
         <td><code>GET /healthcheck</code>
     <tr>
-        <td width="30%">List of Available AutoScalingGroups
+        <td width="30%">List of AutoScalingGroups
         <td><code>GET /api/v1/autoScalingGroups</code>
     <tr>
         <td width="30%">All AutoScalingGroup Details
@@ -93,10 +93,16 @@ point at which slots are calculated. The instance is sized appropriately for the
         <td width="30%">Single AutoScalingGroup Details
         <td><code>GET /api/v1/autoScalingGroups/:asgName</code>
     <tr>
-        <td width="30%">List of AutoScalingGroups Matching a Cluster Name
+        <td width="30%">List of Clusters
+        <td><code>GET /api/v1/clusters</code>
+    <tr>
+        <td width="30%">Map of Clusters to Lists of AutoScalingGroup Details
+        <td><code>GET /api/v1/clusters?verbose=true</code>
+    <tr>
+        <td width="30%">List of AutoScalingGroups Matching a Cluster
         <td><code>GET /api/v1/clusters/:clusterName</code>
     <tr>
-        <td width="30%">All AutoScalingGroup Details Matching a Cluster Name
+        <td width="30%">All AutoScalingGroup Details Matching a Cluster
         <td><code>GET /api/v1/clusters/:clusterName?verbose=true</code>
 </table>
 
@@ -168,7 +174,11 @@ export NETFLIX_STACK="local"
 ```
 
 ```
-sbt "project atlas-slotting" clean compile test
+# verbose form, from project root
+sbt "project atlas-slotting" test
+
+# short form, from project root
+sbt atlas-slotting/test
 ```
 
 Using `sbt` to `run` the project no longer works for version > 1.5.6, due to [sbt/issues/6767](https://github.com/sbt/sbt/issues/6767).

--- a/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/DynamoOps.scala
+++ b/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/DynamoOps.scala
@@ -245,7 +245,7 @@ trait DynamoOps extends StrictLogging {
     }
   }
 
-  def syncCapacity(
+  private def syncCapacity(
     ddbClient: DynamoDbClient,
     tableName: String,
     desiredRead: Long,
@@ -284,7 +284,7 @@ trait DynamoOps extends StrictLogging {
     table.tableStatusAsString()
   }
 
-  def createTable(
+  private def createTable(
     ddbClient: DynamoDbClient,
     tableName: String,
     desiredRead: Long,

--- a/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/Grouping.scala
+++ b/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/Grouping.scala
@@ -139,7 +139,9 @@ trait Grouping extends StrictLogging {
     * @return
     *     A list of case classes with selected fields representing the Instances.
     */
-  def mkAsgInstanceDetailsList(instances: java.util.List[AsgInstance]): List[AsgInstanceDetails] = {
+  private def mkAsgInstanceDetailsList(
+    instances: java.util.List[AsgInstance]
+  ): List[AsgInstanceDetails] = {
     instances.asScala.toList
       .map { i =>
         AsgInstanceDetails(
@@ -286,7 +288,7 @@ trait Grouping extends StrictLogging {
     * @return
     *   A map of instanceIds to slot numbers.
     */
-  def mkSlotMap(asgDetails: SlottedAsgDetails): Map[String, Int] = {
+  private def mkSlotMap(asgDetails: SlottedAsgDetails): Map[String, Int] = {
     asgDetails.instances
       .map(i => i.instanceId -> i.slot)
       .toMap

--- a/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/SlottingCache.scala
+++ b/atlas-slotting/src/main/scala/com/netflix/atlas/slotting/SlottingCache.scala
@@ -17,7 +17,7 @@ package com.netflix.atlas.slotting
 
 import scala.collection.immutable.SortedMap
 
-class SlottingCache() {
+class SlottingCache {
 
   @volatile
   var asgs: SortedMap[String, SlottedAsgDetails] = SortedMap.empty[String, SlottedAsgDetails]

--- a/atlas-slotting/src/test/resources/atlas_app-main-all-v002.json
+++ b/atlas-slotting/src/test/resources/atlas_app-main-all-v002.json
@@ -1,0 +1,40 @@
+{
+  "name": "atlas_app-main-all-v002",
+  "cluster": "atlas_app-main-all",
+  "createdTime": 1552023610994,
+  "desiredCapacity": 3,
+  "maxSize": 6,
+  "minSize": 0,
+  "instances": [
+    {
+      "availabilityZone": "us-west-2b",
+      "imageId": "ami-001",
+      "instanceId": "i-101",
+      "instanceType": "r4.large",
+      "launchTime": 1552023619000,
+      "lifecycleState": "InService",
+      "privateIpAddress": "192.168.2.1",
+      "slot": 0
+    },
+    {
+      "availabilityZone": "us-west-2a",
+      "imageId": "ami-001",
+      "instanceId": "i-102",
+      "instanceType": "r4.large",
+      "launchTime": 1552023619000,
+      "lifecycleState": "InService",
+      "privateIpAddress": "192.168.2.2",
+      "slot": 1
+    },
+    {
+      "availabilityZone": "us-west-2b",
+      "imageId": "ami-001",
+      "instanceId": "i-103",
+      "instanceType": "r4.large",
+      "launchTime": 1552023619000,
+      "lifecycleState": "InService",
+      "privateIpAddress": "192.168.2.3",
+      "slot": 2
+    }
+  ]
+}


### PR DESCRIPTION
Provide a few additional views of the data, to assist with exploration and an alternate means of parsing.

Fix warnings for methods that can be marked private.