### PR TITLE
fix DEFAULT queue, if current region routing is defined

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
@@ -111,7 +111,9 @@ class PublishRouter(
             }
 
             // Skip the _DEFAULT queue, if current region entry already present in "routing"
-            if (!routes.contains(NetflixEnvironment.region())) {
+            if (routes.contains(NetflixEnvironment.region())) {
+              routes += defaultKey -> routes.get(NetflixEnvironment.region())
+            } else {
               routes += defaultKey -> new PublishQueue(
                 config.getConfig("atlas.cloudwatch.account.routing"),
                 registry,

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
@@ -112,7 +112,7 @@ class PublishRouter(
 
             // Skip the _DEFAULT queue, if current region entry already present in "routing"
             if (routes.contains(NetflixEnvironment.region())) {
-              routes += defaultKey -> routes.get(NetflixEnvironment.region())
+              routes += (defaultKey -> routes.getOrElse(NetflixEnvironment.region(), throw new NoSuchElementException(s"Region ${NetflixEnvironment.region()} not found in routes")))
             } else {
               routes += defaultKey -> new PublishQueue(
                 config.getConfig("atlas.cloudwatch.account.routing"),

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
@@ -112,7 +112,12 @@ class PublishRouter(
 
             // Skip the _DEFAULT queue, if current region entry already present in "routing"
             if (routes.contains(NetflixEnvironment.region())) {
-              routes += (defaultKey -> routes.getOrElse(NetflixEnvironment.region(), throw new NoSuchElementException(s"Region ${NetflixEnvironment.region()} not found in routes")))
+              routes += (defaultKey -> routes.getOrElse(
+                NetflixEnvironment.region(),
+                throw new NoSuchElementException(
+                  s"Region ${NetflixEnvironment.region()} not found in routes"
+                )
+              ))
             } else {
               routes += defaultKey -> new PublishQueue(
                 config.getConfig("atlas.cloudwatch.account.routing"),

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/PublishRouter.scala
@@ -110,23 +110,26 @@ class PublishRouter(
                 .toMap
             }
 
-            routes += defaultKey -> new PublishQueue(
-              config.getConfig("atlas.cloudwatch.account.routing"),
-              registry,
-              stack + "-" + NetflixEnvironment.region(),
-              baseURI
-                .replaceAll("\\$\\{STACK\\}", stack)
-                .replaceAll("\\$\\{REGION}", NetflixEnvironment.region()),
-              baseConfigURI
-                .replaceAll("\\$\\{STACK\\}", stack)
-                .replaceAll("\\$\\{REGION}", NetflixEnvironment.region()),
-              baseEvalURI
-                .replaceAll("\\$\\{STACK\\}", stack)
-                .replaceAll("\\$\\{REGION}", NetflixEnvironment.region()),
-              status,
-              httpClient,
-              schedulers
-            )
+            // Skip the _DEFAULT queue, if current region entry already present in "routing"
+            if (!routes.contains(NetflixEnvironment.region())) {
+              routes += defaultKey -> new PublishQueue(
+                config.getConfig("atlas.cloudwatch.account.routing"),
+                registry,
+                stack + "-" + NetflixEnvironment.region(),
+                baseURI
+                  .replaceAll("\\$\\{STACK\\}", stack)
+                  .replaceAll("\\$\\{REGION}", NetflixEnvironment.region()),
+                baseConfigURI
+                  .replaceAll("\\$\\{STACK\\}", stack)
+                  .replaceAll("\\$\\{REGION}", NetflixEnvironment.region()),
+                baseEvalURI
+                  .replaceAll("\\$\\{STACK\\}", stack)
+                  .replaceAll("\\$\\{REGION}", NetflixEnvironment.region()),
+                status,
+                httpClient,
+                schedulers
+              )
+            }
 
             accounts += account -> routes
           }


### PR DESCRIPTION
If we have defined a routing for region ``r1`` => ``r2``

---------------
## when current region``r2`` (No Change)
 * < r1 :: Queue(r2)>         ``any r1 data will go to r2``      
 * < _DEFAULT :: Queue(r2)>   ``all other regions data will go to r2``    

---------------

## when current region ``r1`` 

 * < r1 :: Queue(r2)>                  ``any r1 data will go to r2``       (No Change)

    ##### Before 
          * < _DEFAULT :: Queue(r1)>     ``any non r1 data should go to r1 (not an ideal case)``
 
     ##### After
         * < _DEFAULT :: Queue(r2)>     ``any non r1 data should go same as defined routing``


 




