### PR TITLE
druid: require name clause on queries

### DIFF
--- a/atlas-druid/src/main/resources/application.conf
+++ b/atlas-druid/src/main/resources/application.conf
@@ -4,7 +4,6 @@ atlas {
   // URI for the druid service
   druid {
     //uri = "http://localhost:7103/druid/v2"
-    uri = "http://bdp_druid-metricsext-router.cluster.us-east-1.prod.cloud.netflix.net:7103/druid/v2"
 
     // Interval used when fetching metadata about data sources that are available
     metadata-interval = 21d

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
@@ -396,4 +396,55 @@ class DruidDatabaseActorSuite extends FunSuite {
     val mapper = createValueMapper(false, context.copy(step = 300000), expr)
     assertEquals(mapper(1.0), 1.0)
   }
+
+  test("validate: simple expr with name") {
+    val query = evalQuery("app,www,:eq,name,cpu,:eq,:and")
+    validate(query)
+  }
+
+  test("validate: simple expr without name") {
+    val query = evalQuery("app,www,:eq,not_name,cpu,:eq,:and")
+    intercept[IllegalArgumentException] {
+      validate(query)
+    }
+  }
+
+  test("validate: OR with name") {
+    val query = evalQuery("app,www,:eq,name,cpu,:eq,:and,name,disk,:eq,:or")
+    validate(query)
+  }
+
+  test("validate: OR one side without name") {
+    val query = evalQuery("app,www,:eq,not_name,cpu,:eq,:and,name,disk,:eq,:or")
+    intercept[IllegalArgumentException] {
+      validate(query)
+    }
+  }
+
+  test("validate: name only in NOT") {
+    val query = evalQuery("app,www,:eq,name,cpu,:eq,:not,:and")
+    intercept[IllegalArgumentException] {
+      validate(query)
+    }
+  }
+
+  test("validate: IN name") {
+    val query = evalQuery("app,www,:eq,name,(,cpu,disk,),:in,:and")
+    validate(query)
+  }
+
+  test("validate: haskey name") {
+    val query = evalQuery("app,www,:eq,name,:has,:and")
+    validate(query)
+  }
+
+  test("validate: regex name") {
+    val query = evalQuery("app,www,:eq,name,cpu,:re,:and")
+    validate(query)
+  }
+
+  test("validate: greater than name") {
+    val query = evalQuery("app,www,:eq,name,cpu,:gt,:and")
+    validate(query)
+  }
 }


### PR DESCRIPTION
Without a name clause, it can result in many broad druid queries that are quite expensive. These vague queries can be common as intermediates when building a query, but are not typically useful.