### PR TITLE
Create MSK Serverless scrape config

### DIFF
--- a/atlas-cloudwatch/src/main/resources/msk-serverless.conf
+++ b/atlas-cloudwatch/src/main/resources/msk-serverless.conf
@@ -1,0 +1,104 @@
+atlas {
+  cloudwatch {
+
+    // https://docs.aws.amazon.com/msk/latest/developerguide/serverless-monitoring.html
+    msk-serverless-cluster = {
+      namespace = "AWS/Kafka"
+      period = 1m
+      end-period-offset = 5
+
+      dimensions = [
+        "Cluster Name",
+        "Topic"
+      ]
+
+      metrics = [
+        {
+          name = "BytesIn"
+          alias = "aws.mskserverless.bytes"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        },
+        {
+          name = "BytesOut"
+          alias = "aws.mskserverless.bytes"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "out"
+            }
+          ]
+        },
+        {
+          name = "FetchMessageConversions"
+          alias = "aws.mskserverless.messageConversions"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "fetch"
+            }
+          ]
+        },
+        {
+          name = "ProduceMessageConversions"
+          alias = "aws.mskserverless.messageConversions"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "produce"
+            }
+          ]
+        },
+        {
+          name = "MessagesIn"
+          alias = "aws.mskserverless.messages"
+          conversion = "sum,rate"
+          tags = [
+            {
+              key = "id"
+              value = "in"
+            }
+          ]
+        }
+      ]
+    }
+
+    msk-serverless-consumergroup = {
+      namespace = "AWS/Kafka"
+      period = 1m
+      end-period-offset = 5
+
+      dimensions = [
+        "Cluster Name",
+        "Topic",
+        "Consumer Group"
+      ]
+
+      metrics = [
+        {
+          name = "EstimatedMaxTimeLag"
+          alias = "aws.mskserverless.estimatedMaxTimeLag"
+          conversion = "max"
+        },
+        {
+          name = "MaxOffsetLag"
+          alias = "aws.mskserverless.maxOffsetLag"
+          conversion = "max"
+        },
+        {
+          name = "SumOffsetLag"
+          alias = "aws.mskserverless.sumOffsetLag"
+          conversion = "max"
+        }
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -303,6 +303,14 @@ atlas {
           alias = "aws.memorydb"
         },
         {
+          name = "Cluster Name"
+          alias = "aws.cluster"
+        },
+        {
+          name = "Consumer Group"
+          alias = "aws.consumerGroup"
+        },
+        {
           name = "ConnectionId"
           alias = "aws.connection"
         },
@@ -475,6 +483,10 @@ atlas {
           alias = "aws.table"
         },
         {
+          name = "Topic"
+          alias = "aws.topic"
+        },
+        {
           name = "TopicName"
           alias = "aws.topic"
         },
@@ -574,6 +586,8 @@ atlas {
       "medialive-output",
       "medialive-network",
       "memorydb",
+      "msk-serverless-cluster",
+      "msk-serverless-consumergroup",
       "nat-gateway",
       "neptune-cluster-role",
       "neptune-cluster-5m",
@@ -627,6 +641,7 @@ include "lambda.conf"
 include "mediaconnect.conf"
 include "medialive.conf"
 include "memorydb.conf"
+include "msk-serverless.conf"
 include "nat-gateway.conf"
 include "neptune.conf"
 include "nlb.conf"


### PR DESCRIPTION
InfraAPI is using AWS MSK Serverless for event streaming. Adds MSK serverless metrics config for atlas. See https://docs.aws.amazon.com/msk/latest/developerguide/serverless-monitoring.html for metrics details.