### PR TITLE
druid: add warning log for segment metadata

### DIFF
--- a/atlas-druid/src/main/resources/application.conf
+++ b/atlas-druid/src/main/resources/application.conf
@@ -55,6 +55,10 @@ pekko.http {
     idle-timeout = 120s
     client.idle-timeout = 30s
 
+    // Adjust the log level for the header logger, druid has invalid ETag headers
+    // that cause a lot of warnings.
+    client.parsing.illegal-header-warnings = off
+
     // https://github.com/akka/akka-http/issues/1836
     response-entity-subscription-timeout = 35s
   }

--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -141,6 +141,12 @@ class DruidClient(
           Json.decode[List[SegmentMetadataResult]](in)
         }
       }
+      .recover {
+        case t: Throwable =>
+          val json = Json.encode(query)
+          logger.warn(s"failed to load segment metadata for data source: $json")
+          throw t
+      }
   }
 
   def search(query: SearchQuery): Source[List[SearchResult], NotUsed] = {

--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -124,6 +124,7 @@ class DruidDatabaseActor(config: Config, service: DruidMetadataService)
       .runWith(Sink.head)
       .onComplete {
         case Success(m) =>
+          logger.info("completed loading metadata")
           ref ! m
           service.metadataRefreshed()
         case Failure(t) =>


### PR DESCRIPTION
Log warning for specific metadata request that fails. Makes it easier to debug since the primary information is in the payload. Also disable warnings about invalid ETag headers coming back from druid.