### PR TITLE
lwc-bridge: avoid double counting with OR

### DIFF
--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExpressionsEvaluator.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExpressionsEvaluator.scala
@@ -91,9 +91,11 @@ class ExpressionsEvaluator(configMgr: DynamicConfigManager, registry: Registry)
     * of the LWC API service.
     */
   def eval(timestamp: Long, values: List[BridgeDatapoint]): EvalPayload = {
-    val aggregates = collection.mutable.AnyRefMap.empty[String, Aggregator]
+    val aggregates = collection.mutable.HashMap.empty[String, Aggregator]
     values.filter(!_.value.isNaN).foreach { v =>
-      val subs = index.findMatches(v.id)
+      // Wrap results in HashSet to dedup if an expression has OR clauses where multiple
+      // match a given id.
+      val subs = new java.util.HashSet(index.findMatches(v.id))
       if (!subs.isEmpty) {
         val pair = new TagsValuePair(v.tagsMap, v.value)
         subs.forEach { sub =>

--- a/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExpressionsEvaluatorSuite.scala
+++ b/iep-lwc-bridge/src/test/scala/com/netflix/iep/lwc/ExpressionsEvaluatorSuite.scala
@@ -110,6 +110,20 @@ class ExpressionsEvaluatorSuite extends FunSuite {
     assertEquals(m.getTags.get("name"), "unknown")
   }
 
+  test("eval with OR both matching") {
+    val evaluator = new ExpressionsEvaluator(configMgr, registry)
+    evaluator.sync(createSubs("node,(,i-00,i-01,),:in,name,cpu,:eq,:or,:sum"))
+    val payload = evaluator.eval(timestamp, data(1.0) ::: data(4.0))
+    assertEquals(payload.getTimestamp, timestamp)
+    assertEquals(payload.getMetrics.size(), 1)
+
+    val m = payload.getMetrics.get(0)
+    assertEquals(m.getId, "0")
+    assertEquals(m.getValue, 5.0)
+    assert(!m.getTags.isEmpty)
+    assertEquals(m.getTags.get("name"), "unknown")
+  }
+
   test("eval with no exact tags and group by") {
     val evaluator = new ExpressionsEvaluator(configMgr, registry)
     evaluator.sync(createSubs("node,(,i-00,i-01,),:in,:sum,(,node,),:by"))


### PR DESCRIPTION
If both sides of an OR clause matched an id, then it was adding the datapoint multiple times since the index uses a DNF with each OR clause considered separately. We now dedup the matches to avoid updating the data point multiple times.