### PR TITLE
atlas cw: Move high res cumulative rate conversion to the publish queue.

### DIFF
--- a/atlas-cloudwatch/src/main/resources/mediaconnect.conf
+++ b/atlas-cloudwatch/src/main/resources/mediaconnect.conf
@@ -146,8 +146,8 @@ atlas {
       metrics = [
         {
           name = "SourceBitRate"
-          alias = "aws.mediaconnect.sourceBitRate"
-          conversion = "sum,rate"
+          alias = "aws.mediaconnect.sourceByteRate"
+          conversion = "max,rate"
         },
         {
           name = "SourceDisconnections"

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchMetricsProcessor.scala
@@ -897,20 +897,18 @@ abstract class CloudWatchMetricsProcessor(
     step: Int
   ): AtlasDatapoint = {
     val definition = metric.meta.definition
-    val ts = tagger(metric.meta.dimensions) ++ definition.tags + ("name" ->
-      // TODO - clean this out once tests are finished
-      // (if (testMode) s"TEST.${definition.alias}" else definition.alias))
-      definition.alias)
+    val ts = tagger(metric.meta.dimensions) ++ definition.tags + ("name" -> definition.alias)
+    val dp = metric.datapoint(Instant.ofEpochMilli(timestamp))
 
     val newValue = definition.conversion(
       metric.meta,
-      metric.datapoint(Instant.ofEpochMilli(timestamp))
+      dp
     )
 
     // NOTE - the polling CW code uses now for the timestamp, likely for LWC. BUT data could be off by
     // minutes potentially. And it didn't account for the offset value as far as I could tell. Now we'll at least
     // use the offset value.
-    new AtlasDatapoint(ts, timestamp, newValue)
+    new AtlasDatapoint(ts, timestamp, newValue, step * 1000)
   }
 
   def expSeconds(step: Int): Int = {

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/Conversions.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/Conversions.scala
@@ -99,11 +99,8 @@ object Conversions {
   private def rate(f: Conversion): Conversion = (m, d) => {
     val v = f(m, d)
     val unit = d.unitAsString()
-    val applyRateConversion = m.category.period >= 60
 
-    if (!applyRateConversion && unit.endsWith("/Second")) {
-      v * m.category.period // Convert back to cumulative value
-    } else if (applyRateConversion && !unit.endsWith("/Second")) {
+    if (!unit.endsWith("/Second")) {
       v / m.category.period // Convert to rate
     } else {
       v // No conversion needed

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/RedisClusterCloudWatchMetricsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/RedisClusterCloudWatchMetricsProcessor.scala
@@ -497,7 +497,7 @@ class RedisClusterCloudWatchMetricsProcessor(
       } else {
         CloudWatchCacheEntry.parseFrom(prevBytes).toString
       }
-      logger.warn(
+      logger.debug(
         s"CAS Failure: Got $got but expected $expected. Current: $current.  Originally expected: $original"
       )
       casFailure.increment()

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/poller/PublishClient.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/poller/PublishClient.scala
@@ -27,7 +27,7 @@ import com.typesafe.scalalogging.StrictLogging
 
 import scala.annotation.nowarn
 
-class PublishClient(config: PublishConfig) extends StrictLogging {
+class PublishClient(val config: PublishConfig) extends StrictLogging {
 
   private val publishRegistry = new AtlasRegistry(Clock.SYSTEM, config)
 

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CWMPProcessSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CWMPProcessSuite.scala
@@ -409,7 +409,8 @@ class CWMPProcessSuite extends BaseCloudWatchMetricsProcessorSuite {
             "nf.cluster"   -> "someApp-someStack"
           ),
           ts,
-          0.0033333333333333335
+          0.0033333333333333335,
+          300_000
         )
       )
     )
@@ -546,7 +547,8 @@ class CWMPProcessSuite extends BaseCloudWatchMetricsProcessorSuite {
             "nf.cluster"   -> "cloudwatch"
           ),
           ts,
-          0.0033333333333333335
+          0.0033333333333333335,
+          300_000
         )
       )
     )

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/ConversionSuite.scala
@@ -98,6 +98,52 @@ class ConversionsSuite extends FunSuite {
     assertEquals(v, 6.0)
   }
 
+  test("sum rate already, no unit, 5s") {
+    val cnv = Conversions.fromName("sum,rate")
+    val meta = MetricMetadata(
+      MetricCategory("NFLX/Test", 5, -1, Nil, null, Nil, Some(Query.True)),
+      MetricDefinition("test", "test-alias", cnv, false, Map.empty),
+      Nil
+    )
+    val v = cnv(meta, newDatapoint(280.0, StandardUnit.NONE))
+    // still converts since we don't have units.
+    assertEquals(v, 56.0)
+  }
+
+  test("sum rate already, bits/sec, 5s") {
+    val cnv = Conversions.fromName("sum,rate")
+    val meta = MetricMetadata(
+      MetricCategory("NFLX/Test", 5, -1, Nil, null, Nil, Some(Query.True)),
+      MetricDefinition("test", "test-alias", cnv, false, Map.empty),
+      Nil
+    )
+    val v = cnv(meta, newDatapoint(280.0, StandardUnit.BITS_SECOND))
+    // bits per second
+    assertEquals(v, 35.0)
+  }
+
+  test("max rate already, no unit, 5s") {
+    val cnv = Conversions.fromName("max,rate")
+    val meta = MetricMetadata(
+      MetricCategory("NFLX/Test", 5, -1, Nil, null, Nil, Some(Query.True)),
+      MetricDefinition("test", "test-alias", cnv, false, Map.empty),
+      Nil
+    )
+    val v = cnv(meta, newDatapoint(56.0, StandardUnit.NONE))
+    assertEquals(v, 11.2)
+  }
+
+  test("max rate already, bits/sec, 5s") {
+    val cnv = Conversions.fromName("max,rate")
+    val meta = MetricMetadata(
+      MetricCategory("NFLX/Test", 5, -1, Nil, null, Nil, Some(Query.True)),
+      MetricDefinition("test", "test-alias", cnv, false, Map.empty),
+      Nil
+    )
+    val v = cnv(meta, newDatapoint(56.0, StandardUnit.BITS_SECOND))
+    assertEquals(v, 7.0)
+  }
+
   test("bad conversion") {
     intercept[IllegalArgumentException] {
       Conversions.fromName("foo")

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricCategorySuite.scala
@@ -21,7 +21,10 @@ import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
 import junit.framework.TestCase.assertFalse
 import munit.FunSuite
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint
 import software.amazon.awssdk.services.cloudwatch.model.Dimension
+
+import java.time.Instant
 
 class MetricCategorySuite extends FunSuite {
 
@@ -157,6 +160,38 @@ class MetricCategorySuite extends FunSuite {
       """.stripMargin)
 
     val category = MetricCategory.fromConfig(cfg)
+    val definitions = category.metrics
+
+    val config = ConfigFactory.load()
+    val tagger = new NetflixTagger(config.getConfig("atlas.cloudwatch.tagger"))
+
+    definitions.foreach { d =>
+      val metric = MetricMetadata(
+        category,
+        d,
+        List.empty
+      )
+
+      val ts = tagger(metric.dimensions) ++ d.tags + ("name" -> d.alias)
+
+      val data = d.conversion(
+        metric,
+        Datapoint
+          .builder()
+          .minimum(5.605376e7)
+          .maximum(5.605376e7)
+          .sum(2.8004032e8)
+          .sampleCount(5)
+          .timestamp(Instant.now())
+          .unit("Count")
+          .build()
+      )
+
+      // so rate * 12 = actual rate.
+      val adp = new AtlasDatapoint(ts, Instant.now().toEpochMilli, data, 5_000)
+      System.out.println("DATA: " + adp.value * (adp.step / 1000))
+    }
+
     assertEquals(category.filter, Some(Query.Equal("name", "RequestCount")))
   }
 

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/MetricDefinitionSuite.scala
@@ -60,6 +60,7 @@ class MetricDefinitionSuite extends FunSuite {
       """.stripMargin)
 
     val definitions = MetricDefinition.fromConfig(cfg)
+    definitions.head.conversion
     assertEquals(definitions.size, 1)
     assertEquals(definitions.head.tags, Map("atlas.dstype" -> "rate"))
   }


### PR DESCRIPTION
Fixes an issue where the high-res  rate was not reporting to the stream or backend properly. And fix the MediaConnect source bit rate name to reflect it is converted to bytes. Also cleanup the pub router config duplication a bit.