### PR TITLE
druid: support restrictions on percentile dimension

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidFilter.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidFilter.scala
@@ -61,6 +61,7 @@ object DruidFilter {
     val newQuery = query.rewrite {
       case kq: KeyQuery if kq.k == "nf.datasource" => Query.True
       case kq: KeyQuery if kq.k == "name"          => Query.True
+      case kq: KeyQuery if kq.k == "percentile"    => Query.True
     }
     Query.simplify(newQuery.asInstanceOf[Query], true)
   }

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
@@ -296,6 +296,14 @@ class DruidDatabaseActorSuite extends FunSuite {
     queries.forall(_._3.asInstanceOf[TimeseriesQuery].context == toTestDruidQueryContext(expr))
   }
 
+  test("toDruidQueries: percentile restriction") {
+    val expr = DataExpr.Sum(Query.And(Query.Equal("a", "1"), Query.LessThan("percentile", "T00F2")))
+    val queries = toDruidQueries(metadata, toTestDruidQueryContext(expr), context, expr)
+    assertEquals(queries.size, 4)
+    assert(queries.forall(_._1.contains("a")))
+    queries.forall(_._3.asInstanceOf[TimeseriesQuery].context == toTestDruidQueryContext(expr))
+  }
+
   test("toDruidQueries: or with name dimension") {
     val expr = DataExpr.Sum(
       Query.Or(

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidFilterSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidFilterSuite.scala
@@ -67,6 +67,24 @@ class DruidFilterSuite extends FunSuite {
     assertEquals(actual, expected)
   }
 
+  test("forQuery - percentile :eq") {
+    val actual = DruidFilter.forQuery(eval("percentile,T0090,:eq"))
+    val expected = None
+    assertEquals(actual, expected)
+  }
+
+  test("forQuery - percentile :lt") {
+    val actual = DruidFilter.forQuery(eval("percentile,T0090,:lt"))
+    val expected = None
+    assertEquals(actual, expected)
+  }
+
+  test("forQuery - percentile :and") {
+    val actual = DruidFilter.forQuery(eval("country,US,:eq,percentile,T0090,:lt,:and"))
+    val expected = Some(DruidFilter.Equal("country", "US"))
+    assertEquals(actual, expected)
+  }
+
   test("forQuery - :true") {
     val actual = DruidFilter.forQuery(eval(":true"))
     val expected = None


### PR DESCRIPTION
Update integration to handle the percentile dimension that is part of the histogram type on druid. As a result if trying to restrict based on that dimension, the histogram must be maintained and the restrictions evaluated locally.

This allows operations like `:sampie-count` to work when using the druid bridge.