### PR TITLE
enable cross-building for scala 3

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         java: [21]
-        scala: [2.13.16]
+        scala: [2.13.16, 3.6.4]
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java }}

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val `atlas-aggregator` = project
   ))
 
 lazy val `atlas-cloudwatch` = project
-  .configure(BuildSettings.profile)
+  .configure(BuildSettings.profileScala2Only)
   .enablePlugins(ProtobufPlugin)
   .settings(libraryDependencies ++= Seq(
     Dependencies.atlasCore,

--- a/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ApiSuite.scala
+++ b/iep-lwc-fwding-admin/src/test/scala/com/netflix/iep/lwc/fwd/admin/ApiSuite.scala
@@ -164,7 +164,7 @@ class MarkerServiceTest(implicit
 
   var result = List.newBuilder[Report]
 
-  override var queue: SourceQueue[Report] = StreamOps
+  override val queue: SourceQueue[Report] = StreamOps
     .blockingQueue[Report](new NoopRegistry(), "fwdingAdminCwReports", 1)
     .map(result += _)
     .toMat(Sink.ignore)(Keep.left)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
     val spring     = "6.1.16"
     val avroV      = "1.12.0"
 
-    val crossScala = Seq(scala)
+    val crossScala = Seq(scala, "3.6.4")
   }
 
   import Versions._


### PR DESCRIPTION
Enables cross-building for scala 3 on most sub-projects. The cloudwatch sub-project is skipped because the mockito stuff is not compatible with scala 3.