### PR TITLE
druid: adjust the step based on the datasource

### DIFF
--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -276,7 +276,7 @@ class DruidDatabaseActor(config: Config, service: DruidMetadataService)
   }
 
   private def explain(ref: ActorRef, request: DataRequest): Unit = {
-    val context = request.context
+    val context = determineStepSize(metadata, request.context, request.exprs)
     val druidQueryContext = toDruidQueryContext(request)
     val explanation = request.exprs
       .flatMap { expr =>
@@ -301,9 +301,10 @@ class DruidDatabaseActor(config: Config, service: DruidMetadataService)
   private def fetchData(ref: ActorRef, request: DataRequest): Unit = {
     try {
       request.exprs.foreach(expr => validate(expr.query))
+      val context = determineStepSize(metadata, request.context, request.exprs)
       val druidQueryContext = toDruidQueryContext(request)
       val druidQueries = request.exprs.map { expr =>
-        fetchData(druidQueryContext, request.context, expr).map(ts => expr -> ts)
+        fetchData(druidQueryContext, context, expr).map(ts => expr -> ts)
       }
       Source(druidQueries)
         .flatMapMerge(Int.MaxValue, v => v)
@@ -312,7 +313,7 @@ class DruidDatabaseActor(config: Config, service: DruidMetadataService)
         }
         .runWith(Sink.head)
         .onComplete {
-          case Success(data) => ref ! DataResponse(data)
+          case Success(data) => ref ! DataResponse(context.step, data)
           case Failure(t)    => ref ! Failure(t)
         }
     } catch {
@@ -626,6 +627,22 @@ object DruidDatabaseActor {
       "atlasQueryString" -> request.config.map(_.query).getOrElse("unknown"),
       "atlasQueryGuid"   -> UUID.randomUUID().toString
     )
+  }
+
+  /**
+    * Druid data sources can potentially have different step sizes. This method will look
+    * at the step size of matching data sources as well as the request step in the context
+    * and use the maximum of those values.
+    */
+  def determineStepSize(metadata: Metadata, context: EvalContext, exprs: List[DataExpr]): EvalContext = {
+    val metricSteps = exprs.flatMap { expr =>
+      val query = expr.query
+      metadata.datasources.flatMap { ds =>
+        ds.metrics.filter(m => query.couldMatch(m.tags)).map(_.metric.primaryStep)
+      }
+    }
+    val step = if (metricSteps.isEmpty) context.step else math.max(context.step, metricSteps.max)
+    context.increaseStep(step)
   }
 
   def toDruidQueries(

--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -634,7 +634,11 @@ object DruidDatabaseActor {
     * at the step size of matching data sources as well as the request step in the context
     * and use the maximum of those values.
     */
-  def determineStepSize(metadata: Metadata, context: EvalContext, exprs: List[DataExpr]): EvalContext = {
+  def determineStepSize(
+    metadata: Metadata,
+    context: EvalContext,
+    exprs: List[DataExpr]
+  ): EvalContext = {
     val metricSteps = exprs.flatMap { expr =>
       val query = expr.query
       metadata.datasources.flatMap { ds =>

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
@@ -328,27 +328,41 @@ class DruidDatabaseActorSuite extends FunSuite {
     }
   }
 
-  private val testMetadata = Metadata(List(
-    DatasourceMetadata("ds1", Datasource(
-      Nil, List(
-        Metric("a", primaryStep = 5_000),
-        Metric("b", primaryStep = 30_000),
-        Metric("c", primaryStep = 60_000)
+  private val testMetadata = Metadata(
+    List(
+      DatasourceMetadata(
+        "ds1",
+        Datasource(
+          Nil,
+          List(
+            Metric("a", primaryStep = 5_000),
+            Metric("b", primaryStep = 30_000),
+            Metric("c", primaryStep = 60_000)
+          )
+        )
+      ),
+      DatasourceMetadata(
+        "ds2",
+        Datasource(
+          Nil,
+          List(
+            Metric("a", primaryStep = 20_000)
+          )
+        )
+      ),
+      DatasourceMetadata(
+        "ds3",
+        Datasource(
+          Nil,
+          List(
+            Metric("d", primaryStep = 60_000),
+            Metric("e", primaryStep = 60_000),
+            Metric("f", primaryStep = 60_000)
+          )
+        )
       )
-    )),
-    DatasourceMetadata("ds2", Datasource(
-      Nil, List(
-        Metric("a", primaryStep = 20_000)
-      )
-    )),
-    DatasourceMetadata("ds3", Datasource(
-      Nil, List(
-        Metric("d", primaryStep = 60_000),
-        Metric("e", primaryStep = 60_000),
-        Metric("f", primaryStep = 60_000)
-      )
-    )),
-  ))
+    )
+  )
 
   test("determineStepSize: same ds, single step size") {
     val context = EvalContext(0L, 60_000L, 1_000L)
@@ -366,7 +380,8 @@ class DruidDatabaseActorSuite extends FunSuite {
 
   test("determineStepSize: same ds, different step sizes subset of metrics") {
     val context = EvalContext(0L, 60_000L, 1_000L)
-    val expr = DataExpr.Sum(Query.Equal("nf.datasource", "ds1").and(Query.In("name", List("a", "b"))))
+    val expr =
+      DataExpr.Sum(Query.Equal("nf.datasource", "ds1").and(Query.In("name", List("a", "b"))))
     val step = determineStepSize(testMetadata, context, List(expr)).step
     assertEquals(step, 30_000L)
   }

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
@@ -407,6 +407,14 @@ class DruidDatabaseActorSuite extends FunSuite {
     assertEquals(step, 120_000L)
   }
 
+  test("determineStepSize: multiple expressions") {
+    val context = EvalContext(0L, 60_000L, 5_000L)
+    val expr1 = DataExpr.Sum(Query.Equal("name", "a"))
+    val expr2 = DataExpr.Sum(Query.Equal("name", "b"))
+    val step = determineStepSize(testMetadata, context, List(expr1, expr2)).step
+    assertEquals(step, 30_000L)
+  }
+
   test("simplify: single name with or") {
     val q = evalQuery("name,a,:eq,dim,1,:eq,:and,name,b,:eq,dim,2,:eq,:and,:or")
     val expected = evalQuery("dim,1,:eq")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val atlas      = "1.8.0-rc.30"
+    val atlas      = "1.8.0-SNAPSHOT"
     val aws2       = "2.30.38"
     val iep        = "5.0.33"
     val log4j      = "2.24.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val atlas      = "1.8.0-SNAPSHOT"
+    val atlas      = "1.8.0-rc.34"
     val aws2       = "2.30.38"
     val iep        = "5.0.33"
     val log4j      = "2.24.3"


### PR DESCRIPTION
For druid the data sources can potentially have different step sizes. With this change, it will choose the maximum step size across all potential data sources that could match an expression on the graph and the computed context step.

If a higher resolution metric is included on the same graph as a lower resolution metric, the lower resolution will be used for both so the data will align for math and stats.