### PR TITLE
druid: support ignoring metadata failures

### DIFF
--- a/atlas-druid/src/main/resources/application.conf
+++ b/atlas-druid/src/main/resources/application.conf
@@ -19,6 +19,10 @@ atlas {
     // be exposed.
     datasource-filter = ".*"
 
+    // Should it ignore failures to fetch metadata for a data source. In these cases that data
+    // source will not be available to query until it is fixed.
+    datasource-ignore-metadata-failures = false
+
     // Normalize rates by default in line with Atlas rates convention
     normalize-rates = true
   }

--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -132,7 +132,10 @@ class DruidClient(
       }
   }
 
-  def segmentMetadata(query: SegmentMetadataQuery): Source[List[SegmentMetadataResult], NotUsed] = {
+  def segmentMetadata(
+    query: SegmentMetadataQuery,
+    ignoreFailures: Boolean
+  ): Source[List[SegmentMetadataResult], NotUsed] = {
     Source
       .single(mkRequest(query))
       .via(loggingClient)
@@ -144,8 +147,13 @@ class DruidClient(
       .recover {
         case t: Throwable =>
           val json = Json.encode(query)
-          logger.warn(s"failed to load segment metadata for data source: $json")
-          throw t
+          if (ignoreFailures) {
+            logger.warn(s"failed to load segment metadata, ignoring data source: $json", t)
+            Nil
+          } else {
+            logger.warn(s"failed to load segment metadata: $json")
+            throw t
+          }
       }
   }
 

--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -100,7 +100,7 @@ class DruidClient(
     new IOException(s"request failed with status ${res.status.intValue()}")
   }
 
-  private def mkRequest[T: JavaTypeable](data: T): HttpRequest = {
+  private def mkRequest(data: Any): HttpRequest = {
     val json = Json.encode(data)
     logger.trace(s"raw request payload: $json")
     val entity = HttpEntity(MediaTypes.`application/json`, json)

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
@@ -136,7 +136,7 @@ class DruidClientSuite extends FunSuite {
     val response = HttpResponse(StatusCodes.OK, entity = payload)
     val client = newClient(Success(response))
     val query = SegmentMetadataQuery("test")
-    val future = client.segmentMetadata(query).runWith(Sink.head)
+    val future = client.segmentMetadata(query, false).runWith(Sink.head)
     Await.result(future, Duration.Inf)
   }
 


### PR DESCRIPTION
For some test clusters there are a lot of bad data sources that pop up and have failures loading the segment metadata. Add an option to ignore those so it doesn't impact other usage.