### PR TITLE
cloudwatch: update to build with scala 3

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/RedisClusterCloudWatchMetricsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/RedisClusterCloudWatchMetricsProcessor.scala
@@ -306,7 +306,8 @@ class RedisClusterCloudWatchMetricsProcessor(
           Using.resource(jedis.getClusterNodes.get(node).getResource) { jedis =>
             try {
               var cursor: Array[Byte] = ScanParams.SCAN_POINTER_START_BINARY
-              do {
+              var continue = true
+              while (continue) {
                 val scanResult = jedis.executeCommand(commandObjects.scan(cursor, scanParams))
                 val keys = scanResult.getResult.asScala.toSeq
                 logger.debug(s"Scanned keys ${keys.size} from node ${node}")
@@ -319,7 +320,8 @@ class RedisClusterCloudWatchMetricsProcessor(
                   sum += keys.size
                 }
                 cursor = scanResult.getCursorAsBytes
-              } while (!util.Arrays.equals(cursor, ScanParams.SCAN_POINTER_START_BINARY))
+                continue = !util.Arrays.equals(cursor, ScanParams.SCAN_POINTER_START_BINARY)
+              }
               true
             } catch {
               case ex: Exception =>

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/BaseCloudWatchMetricsProcessorSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/BaseCloudWatchMetricsProcessorSuite.scala
@@ -29,8 +29,8 @@ import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.testkit.ImplicitSender
 import org.apache.pekko.testkit.TestKitBase
 import org.junit.Ignore
-import org.mockito.MockitoSugar.mock
-import org.mockito.captor.ArgCaptor
+import org.mockito.Mockito.mock
+import org.mockito.ArgumentCaptor
 import software.amazon.awssdk.services.cloudwatch.model.Datapoint
 import software.amazon.awssdk.services.cloudwatch.model.Dimension
 
@@ -47,7 +47,7 @@ class BaseCloudWatchMetricsProcessorSuite extends FunSuite with TestKitBase with
   var registry: Registry = null
   var publishRouter: PublishRouter = null
   var processor: CloudWatchMetricsProcessor = null
-  var routerCaptor = ArgCaptor[AtlasDatapoint]
+  var routerCaptor = ArgumentCaptor.forClass(classOf[AtlasDatapoint])
   var debugger: CloudWatchDebugger = null
   val config = ConfigFactory.load()
   val tagger = new NetflixTagger(config.getConfig("atlas.cloudwatch.tagger"))
@@ -62,11 +62,11 @@ class BaseCloudWatchMetricsProcessorSuite extends FunSuite with TestKitBase with
 
   override def beforeEach(context: BeforeEach): Unit = {
     registry = new DefaultRegistry()
-    publishRouter = mock[PublishRouter]
+    publishRouter = mock(classOf[PublishRouter])
     debugger = new CloudWatchDebugger(config, registry)
     processor =
       new LocalCloudWatchMetricsProcessor(config, registry, rules, tagger, publishRouter, debugger)
-    routerCaptor = ArgCaptor[AtlasDatapoint]
+    routerCaptor = ArgumentCaptor.forClass(classOf[AtlasDatapoint])
   }
 
 }

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/PublishRouterSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/PublishRouterSuite.scala
@@ -25,7 +25,7 @@ import com.netflix.spectator.api.DefaultRegistry
 import com.netflix.spectator.api.Registry
 import com.typesafe.config.ConfigFactory
 import munit.FunSuite
-import org.mockito.MockitoSugar.mock
+import org.mockito.Mockito.mock
 
 class PublishRouterSuite extends FunSuite with TestKitBase {
 
@@ -34,8 +34,8 @@ class PublishRouterSuite extends FunSuite with TestKitBase {
   private val registry: Registry = new DefaultRegistry()
   private val config = ConfigFactory.load()
   private val tagger = new NetflixTagger(config.getConfig("atlas.cloudwatch.tagger"))
-  private val httpClient = mock[PekkoHttpClient]
-  var leaderStatus: LeaderStatus = mock[LeaderStatus]
+  private val httpClient = mock(classOf[PekkoHttpClient])
+  var leaderStatus: LeaderStatus = mock(classOf[LeaderStatus])
   private val router = new PublishRouter(config, registry, tagger, httpClient, leaderStatus)
 
   test("initialize") {

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val `atlas-aggregator` = project
   ))
 
 lazy val `atlas-cloudwatch` = project
-  .configure(BuildSettings.profileScala2Only)
+  .configure(BuildSettings.profile)
   .enablePlugins(ProtobufPlugin)
   .settings(libraryDependencies ++= Seq(
     Dependencies.atlasCore,
@@ -65,7 +65,6 @@ lazy val `atlas-cloudwatch` = project
     Dependencies.pekkoHttpTestkit % "test",
     Dependencies.pekkoTestkit % "test",
     Dependencies.mockitoCore % "test",
-    Dependencies.mockitoScala % "test",
     Dependencies.munit % "test"
   ))
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,14 +10,14 @@ object Dependencies {
     val log4j      = "2.24.3"
     val pekko      = "1.1.3"
     val pekkoHttpV = "1.2.0"
-    val scala      = "2.13.16"
+    val scala      = "3.6.4"
     val servo      = "0.13.2"
     val slf4j      = "2.0.17"
     val spectator  = "1.8.14"
     val spring     = "6.1.16"
     val avroV      = "1.12.0"
 
-    val crossScala = Seq(scala, "3.6.4")
+    val crossScala = Seq(scala)
   }
 
   import Versions._
@@ -59,7 +59,6 @@ object Dependencies {
   val log4jJul           = "org.apache.logging.log4j" % "log4j-jul" % log4j
   val log4jSlf4j         = "org.apache.logging.log4j" % "log4j-slf4j2-impl" % log4j
   val mockitoCore        = "org.mockito" % "mockito-core" % "5.10.0"
-  val mockitoScala       = "org.mockito" % "mockito-scala_2.13" % "1.17.30"
   val munit              = "org.scalameta" %% "munit" % "1.1.1"
   val openHFT            = "net.openhft" % "zero-allocation-hashing" % "0.16"
   val pekkoActor         = "org.apache.pekko" %% "pekko-actor" % pekko


### PR DESCRIPTION
Remove the use of mockito-scala and fix some issues with `return` to build using scala 3. This clears up a special case with the build where this sub-project was held back.

Since these are all end apps and not libraries, drop the 2.13 support and just build for scala 3.