### PR TITLE
Fix agentcore-runtime to match actual emitted dimensions

### DIFF
--- a/atlas-cloudwatch/src/main/resources/agentcore.conf
+++ b/atlas-cloudwatch/src/main/resources/agentcore.conf
@@ -296,6 +296,9 @@ atlas {
       ]
     }
 
+    // Runtime per-endpoint metrics. Per AWS docs, only resource usage metrics
+    // (CPU, Memory) are emitted at the [Service, Resource, Name] level.
+    // https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-runtime-metrics.html
     agentcore-runtime = {
       namespace = "AWS/Bedrock-AgentCore"
       period = 1m
@@ -305,6 +308,34 @@ atlas {
         "Service",
         "Resource",
         "Name"
+      ]
+
+      metrics = [
+        {
+          name = "MemoryUsed-GBHours"
+          alias = "aws.agentcore.memoryUsed"
+          conversion = "sum"
+        },
+        {
+          name = "CPUUsed-vCPUHours"
+          alias = "aws.agentcore.cpuUsed"
+          conversion = "sum"
+        }
+      ]
+    }
+
+    // Runtime per-resource (per-agent) metrics. Invocations, Latency, errors,
+    // throttles, sessions, and streaming metrics are emitted at the
+    // [Service, Resource] level (Resource = Agent ARN). CPU/Memory are also
+    // emitted at this level.
+    agentcore-runtime-svc = {
+      namespace = "AWS/Bedrock-AgentCore"
+      period = 1m
+      end-period-offset = 5
+
+      dimensions = [
+        "Resource",
+        "Service"
       ]
 
       metrics = [
@@ -339,6 +370,11 @@ atlas {
           conversion = "sum,rate"
         },
         {
+          name = "Sessions"
+          alias = "aws.agentcore.sessions"
+          conversion = "sum,rate"
+        },
+        {
           name = "InboundStreamingBytesProcessed"
           alias = "aws.agentcore.bytesProcessed"
           conversion = "sum,rate"
@@ -360,36 +396,11 @@ atlas {
             }
           ]
         },
-         {
+        {
           name = "ActiveStreamingConnections"
           alias = "aws.agentcore.activeStreamingConnections"
           conversion = "max"
         },
-        {
-          name = "MemoryUsed-GBHours"
-          alias = "aws.agentcore.memoryUsed"
-          conversion = "sum"
-        },
-        {
-          name = "CPUUsed-vCPUHours"
-          alias = "aws.agentcore.cpuUsed"
-          conversion = "sum"
-        }
-      ]
-    }
-
-    // Runtime resource usage rolled up without endpoint name
-    agentcore-runtime-svc = {
-      namespace = "AWS/Bedrock-AgentCore"
-      period = 1m
-      end-period-offset = 5
-
-      dimensions = [
-        "Resource",
-        "Service"
-      ]
-
-      metrics = [
         {
           name = "MemoryUsed-GBHours"
           alias = "aws.agentcore.memoryUsed"


### PR DESCRIPTION
Per AWS docs, only the resource usage metrics (CPUUsed-vCPUHours, MemoryUsed-GBHours) are emitted at the [Service, Resource, Name] endpoint level. Invocations, Latency, Errors, UserErrors, SystemErrors, Throttles, Sessions and the streaming metrics are emitted at the [Service, Resource] per-agent level and were never matched by the agentcore-runtime category, causing them to fall through unmatched.

Move those metrics to agentcore-runtime-svc (which already has [Service, Resource] dimensions) and trim agentcore-runtime down to the two metrics that AWS actually emits at endpoint granularity.