### PR TITLE
add CloudWAN (AWS/NetworkManager) metrics config

### DIFF
--- a/atlas-cloudwatch/src/main/resources/cloudwan.conf
+++ b/atlas-cloudwatch/src/main/resources/cloudwan.conf
@@ -1,0 +1,504 @@
+atlas {
+  cloudwatch {
+
+    // Cloud WAN metrics scoped to a core network edge location.
+    // https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-metrics.html
+    cloudwan-core = {
+      namespace = "AWS/NetworkManager"
+      period = 1m
+      end-period-offset = 9
+
+      dimensions = [
+        "CoreNetwork",
+        "EdgeLocation"
+      ]
+
+      metrics = [
+        {
+          name = "BytesIn"
+          alias = "aws.cloudwan.bytes"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "BytesIn"
+          alias = "aws.cloudwan.maxBytes"
+          conversion = "max"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "BytesOut"
+          alias = "aws.cloudwan.bytes"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "BytesOut"
+          alias = "aws.cloudwan.maxBytes"
+          conversion = "max"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "PacketsIn"
+          alias = "aws.cloudwan.packets"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "PacketsIn"
+          alias = "aws.cloudwan.maxPackets"
+          conversion = "max"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "PacketsOut"
+          alias = "aws.cloudwan.packets"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "PacketsOut"
+          alias = "aws.cloudwan.maxPackets"
+          conversion = "max"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "BytesDropCountBlackhole"
+          alias = "aws.cloudwan.bytesDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "BytesDropCountBlackhole"
+          alias = "aws.cloudwan.maxBytesDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "BytesDropCountNoRoute"
+          alias = "aws.cloudwan.bytesDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "BytesDropCountNoRoute"
+          alias = "aws.cloudwan.maxBytesDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "PacketDropCountBlackhole"
+          alias = "aws.cloudwan.packetsDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "PacketDropCountBlackhole"
+          alias = "aws.cloudwan.maxPacketsDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "PacketDropCountNoRoute"
+          alias = "aws.cloudwan.packetsDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "PacketDropCountNoRoute"
+          alias = "aws.cloudwan.maxPacketsDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "PacketDropTTLExpired"
+          alias = "aws.cloudwan.packetsDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "TTLExpired"}]
+        },
+        {
+          name = "PacketDropTTLExpired"
+          alias = "aws.cloudwan.maxPacketsDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "TTLExpired"}]
+        },
+      ]
+    }
+
+    // Cloud WAN metrics scoped to a core network attachment.
+    // https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-metrics.html
+    cloudwan-attachment = {
+      namespace = "AWS/NetworkManager"
+      period = 1m
+      end-period-offset = 9
+
+      dimensions = [
+        "Attachment",
+        "CoreNetwork"
+      ]
+
+      metrics = [
+        {
+          name = "BytesIn"
+          alias = "aws.cloudwan.bytes"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "BytesIn"
+          alias = "aws.cloudwan.maxBytes"
+          conversion = "max"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "BytesOut"
+          alias = "aws.cloudwan.bytes"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "BytesOut"
+          alias = "aws.cloudwan.maxBytes"
+          conversion = "max"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "PacketsIn"
+          alias = "aws.cloudwan.packets"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "PacketsIn"
+          alias = "aws.cloudwan.maxPackets"
+          conversion = "max"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "PacketsOut"
+          alias = "aws.cloudwan.packets"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "PacketsOut"
+          alias = "aws.cloudwan.maxPackets"
+          conversion = "max"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "BytesDropCountBlackhole"
+          alias = "aws.cloudwan.bytesDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "BytesDropCountBlackhole"
+          alias = "aws.cloudwan.maxBytesDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "BytesDropCountNoRoute"
+          alias = "aws.cloudwan.bytesDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "BytesDropCountNoRoute"
+          alias = "aws.cloudwan.maxBytesDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "PacketDropCountBlackhole"
+          alias = "aws.cloudwan.packetsDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "PacketDropCountBlackhole"
+          alias = "aws.cloudwan.maxPacketsDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "PacketDropCountNoRoute"
+          alias = "aws.cloudwan.packetsDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "PacketDropCountNoRoute"
+          alias = "aws.cloudwan.maxPacketsDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "PacketDropTTLExpired"
+          alias = "aws.cloudwan.packetsDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "TTLExpired"}]
+        },
+        {
+          name = "PacketDropTTLExpired"
+          alias = "aws.cloudwan.maxPacketsDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "TTLExpired"}]
+        },
+      ]
+    }
+
+    // Cloud WAN metrics scoped to a core network edge location and availability zone.
+    // Only applicable for Direct Connect attachments.
+    // https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-metrics.html
+    cloudwan-core-az = {
+      namespace = "AWS/NetworkManager"
+      period = 1m
+      end-period-offset = 9
+
+      dimensions = [
+        "AvailabilityZone",
+        "CoreNetwork",
+        "EdgeLocation"
+      ]
+
+      metrics = [
+        {
+          name = "BytesIn"
+          alias = "aws.cloudwan.bytes"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "BytesIn"
+          alias = "aws.cloudwan.maxBytes"
+          conversion = "max"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "BytesOut"
+          alias = "aws.cloudwan.bytes"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "BytesOut"
+          alias = "aws.cloudwan.maxBytes"
+          conversion = "max"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "PacketsIn"
+          alias = "aws.cloudwan.packets"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "PacketsIn"
+          alias = "aws.cloudwan.maxPackets"
+          conversion = "max"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "PacketsOut"
+          alias = "aws.cloudwan.packets"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "PacketsOut"
+          alias = "aws.cloudwan.maxPackets"
+          conversion = "max"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "BytesDropCountBlackhole"
+          alias = "aws.cloudwan.bytesDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "BytesDropCountBlackhole"
+          alias = "aws.cloudwan.maxBytesDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "BytesDropCountNoRoute"
+          alias = "aws.cloudwan.bytesDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "BytesDropCountNoRoute"
+          alias = "aws.cloudwan.maxBytesDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "PacketDropCountBlackhole"
+          alias = "aws.cloudwan.packetsDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "PacketDropCountBlackhole"
+          alias = "aws.cloudwan.maxPacketsDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "PacketDropCountNoRoute"
+          alias = "aws.cloudwan.packetsDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "PacketDropCountNoRoute"
+          alias = "aws.cloudwan.maxPacketsDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "PacketDropTTLExpired"
+          alias = "aws.cloudwan.packetsDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "TTLExpired"}]
+        },
+        {
+          name = "PacketDropTTLExpired"
+          alias = "aws.cloudwan.maxPacketsDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "TTLExpired"}]
+        },
+      ]
+    }
+
+    // Cloud WAN metrics scoped to a core network attachment and availability zone.
+    // Only applicable for Direct Connect attachments.
+    // https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-metrics.html
+    cloudwan-attachment-az = {
+      namespace = "AWS/NetworkManager"
+      period = 1m
+      end-period-offset = 9
+
+      dimensions = [
+        "Attachment",
+        "AvailabilityZone",
+        "CoreNetwork"
+      ]
+
+      metrics = [
+        {
+          name = "BytesIn"
+          alias = "aws.cloudwan.bytes"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "BytesIn"
+          alias = "aws.cloudwan.maxBytes"
+          conversion = "max"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "BytesOut"
+          alias = "aws.cloudwan.bytes"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "BytesOut"
+          alias = "aws.cloudwan.maxBytes"
+          conversion = "max"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "PacketsIn"
+          alias = "aws.cloudwan.packets"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "PacketsIn"
+          alias = "aws.cloudwan.maxPackets"
+          conversion = "max"
+          tags = [{key = "id", value = "in"}]
+        },
+        {
+          name = "PacketsOut"
+          alias = "aws.cloudwan.packets"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "PacketsOut"
+          alias = "aws.cloudwan.maxPackets"
+          conversion = "max"
+          tags = [{key = "id", value = "out"}]
+        },
+        {
+          name = "BytesDropCountBlackhole"
+          alias = "aws.cloudwan.bytesDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "BytesDropCountBlackhole"
+          alias = "aws.cloudwan.maxBytesDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "BytesDropCountNoRoute"
+          alias = "aws.cloudwan.bytesDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "BytesDropCountNoRoute"
+          alias = "aws.cloudwan.maxBytesDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "PacketDropCountBlackhole"
+          alias = "aws.cloudwan.packetsDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "PacketDropCountBlackhole"
+          alias = "aws.cloudwan.maxPacketsDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "Blackhole"}]
+        },
+        {
+          name = "PacketDropCountNoRoute"
+          alias = "aws.cloudwan.packetsDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "PacketDropCountNoRoute"
+          alias = "aws.cloudwan.maxPacketsDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "NoRoute"}]
+        },
+        {
+          name = "PacketDropTTLExpired"
+          alias = "aws.cloudwan.packetsDropped"
+          conversion = "sum,rate"
+          tags = [{key = "id", value = "TTLExpired"}]
+        },
+        {
+          name = "PacketDropTTLExpired"
+          alias = "aws.cloudwan.maxPacketsDropped"
+          conversion = "max"
+          tags = [{key = "id", value = "TTLExpired"}]
+        },
+      ]
+    }
+  }
+}

--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -302,6 +302,10 @@ atlas {
           alias = "aws.api"
         },
         {
+          name = "Attachment"
+          alias = "aws.attachment"
+        },
+        {
           name = "AudioDescriptionName"
           alias = "aws.audio-description"
         },
@@ -362,6 +366,10 @@ atlas {
           alias = "aws.connection"
         },
         {
+          name = "CoreNetwork"
+          alias = "aws.core-network"
+        },
+        {
           name = "Currency"
           alias = "aws.currency"
         },
@@ -396,6 +404,10 @@ atlas {
         {
           name = "DomainName"
           alias = "aws.domain"
+        },
+        {
+          name = "EdgeLocation"
+          alias = "aws.edge-location"
         },
         {
           name = "EndpointId"
@@ -661,6 +673,10 @@ atlas {
       "billing",
       "cloudhsm",
       "cloudfront",
+      "cloudwan-core",
+      "cloudwan-attachment",
+      "cloudwan-core-az",
+      "cloudwan-attachment-az",
       "cw-metric-streams",
       "cw-logs",
       "dx-connection",
@@ -751,6 +767,7 @@ include "billing.conf"
 include "cloudhsm.conf"
 include "cloudwatch.conf"
 include "cloudfront.conf"
+include "cloudwan.conf"
 include "dx.conf"
 include "dynamodb.conf"
 include "ec2.conf"

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/LogsPublishQueue.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/LogsPublishQueue.scala
@@ -27,10 +27,14 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 /**
- * Bounded async queue that drains OtelLog entries to OtelTcpLogger.sendLog.
+ * Bounded async queue that drains log batches to OtelTcpLogger.sendLog.
+ *
+ * Each element in the queue is a batch of OtelLog entries from a single log stream.
+ * Up to `parallelism` batches are processed concurrently (one per stream), while logs
+ * within each batch are sent sequentially — preserving intra-stream order.
  *
  * Absorbs traffic bursts: callers never block on TCP I/O. When the queue is full the
- * entry is dropped (counted) rather than causing OOM in the OTel collector.
+ * batch is dropped (counted) rather than causing OOM in the OTel collector.
  *
  * TCP sends run on a dedicated thread pool (logs-sink-dispatcher) so blocking calls
  * and retry sleeps inside sendLog never starve the main Akka dispatcher.
@@ -57,19 +61,21 @@ class LogsPublishQueue(
   private val logsDropped = registry.counter("atlas.cloudwatch.logs.queue.dropped")
 
   private val queue = StreamOps
-    .blockingQueue[OtelLog](registry, "logsQueue", queueSize)
-    .mapAsync(parallelism) { log =>
+    .blockingQueue[Seq[OtelLog]](registry, "logsQueue", queueSize)
+    .mapAsync(parallelism) { batch =>
       Future {
-        sendLog(log)
-        logsSent.increment()
+        batch.foreach { log =>
+          sendLog(log)
+          logsSent.increment()
+        }
       }(sinkDispatcher).recover {
         case e: Exception =>
-          logger.warn(s"Failed to send log to OTel collector: ${e.getMessage}", e)
-          logsDropped.increment()
+          logger.warn(s"Failed to send log batch to OTel collector: ${e.getMessage}", e)
+          logsDropped.increment(batch.size)
       }
     }
     .toMat(Sink.ignore)(Keep.left)
     .run()
 
-  override def send(log: OtelLog): Unit = queue.offer(log)
+  override def sendBatch(logs: Seq[OtelLog]): Unit = queue.offer(logs)
 }

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/OTelCloudWatchLogsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/OTelCloudWatchLogsProcessor.scala
@@ -28,11 +28,9 @@ class OTelCloudWatchLogsProcessor(
 ) extends CloudWatchLogsProcessor
     with StrictLogging {
 
-  private val maxPerBatch: Int =
-    if (config.hasPath("atlas.cloudwatch.logs.maxPerBatch"))
-      config.getInt("atlas.cloudwatch.logs.maxPerBatch")
-    else
-      10
+  // Max events per sendBatch chunk — bounds burst rate to the OTel collector.
+  // Large streams are split into multiple chunks rather than truncated.
+  private val maxPerBatch: Int = config.getInt("atlas.cloudwatch.logs.maxPerBatch")
 
   // Local in‑memory cache for log group tags
   private val tagCache = new LogGroupTagCache(clientFactory)
@@ -60,7 +58,9 @@ class OTelCloudWatchLogsProcessor(
         region  <- regionOpt.get
       } yield tagCache.getTags(logGroup, account, region)).getOrElse(Map.empty)
 
-    val batch = events.take(maxPerBatch).zipWithIndex.map {
+    // Build OtelLog for every event, preserving global line_index across chunks
+    // so the collector can reconstruct exact order even across chunk boundaries.
+    val allLogs = events.zipWithIndex.map {
       case (ev, idx) =>
         val (requestIdOpt, levelRaw, msg) = parseLogLine(ev.message)
         val level = Option(levelRaw).filter(_.nonEmpty).getOrElse("INFO").toUpperCase
@@ -88,7 +88,10 @@ class OTelCloudWatchLogsProcessor(
         )
     }
 
-    sink.sendBatch(batch)
+    // Split into bounded chunks so each sendBatch call delivers at most maxPerBatch
+    // events to the OTel collector — prevents a single large stream from causing
+    // a burst of TCP sends that could OOM the collector.
+    allLogs.grouped(maxPerBatch).foreach(sink.sendBatch)
   }
 
   /**

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/OTelCloudWatchLogsProcessor.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/OTelCloudWatchLogsProcessor.scala
@@ -60,7 +60,7 @@ class OTelCloudWatchLogsProcessor(
         region  <- regionOpt.get
       } yield tagCache.getTags(logGroup, account, region)).getOrElse(Map.empty)
 
-    events.take(maxPerBatch).zipWithIndex.foreach {
+    val batch = events.take(maxPerBatch).zipWithIndex.map {
       case (ev, idx) =>
         val (requestIdOpt, levelRaw, msg) = parseLogLine(ev.message)
         val level = Option(levelRaw).filter(_.nonEmpty).getOrElse("INFO").toUpperCase
@@ -77,19 +77,18 @@ class OTelCloudWatchLogsProcessor(
           "source"         -> subscriptionFilters.mkString("/")
         )
 
-        // logGroupTags: Map[String, String] from cache
-        val mergedTags: Map[String, Any] =
-          baseTags ++ logGroupTags // logGroupTags values win for duplicate keys
+        // logGroupTags values win for duplicate keys
+        val mergedTags: Map[String, Any] = baseTags ++ logGroupTags
 
-        val logDoc = OtelTcpLogger.buildLog(
+        OtelTcpLogger.buildLog(
           message = msg,
           level = level,
           loggerName = "cwlogs.subscription",
           tags = mergedTags
         )
-
-        sink.send(logDoc)
     }
+
+    sink.sendBatch(batch)
   }
 
   /**

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/OtelLog.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/OtelLog.scala
@@ -112,7 +112,7 @@ object OtelTcpLogger extends StrictLogging {
 
 object OtelTcpSink extends OtelLogSink {
 
-  override def send(log: OtelLog): Unit = {
-    OtelTcpLogger.sendLog(log)
+  override def sendBatch(logs: Seq[OtelLog]): Unit = {
+    logs.foreach(OtelTcpLogger.sendLog)
   }
 }

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/OtelLogSink.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/OtelLogSink.scala
@@ -16,5 +16,10 @@
 package com.netflix.atlas.cloudwatch
 
 trait OtelLogSink {
-  def send(log: OtelLog): Unit
+
+  /**
+   * Send a batch of logs that all belong to the same log stream.
+   * Implementations must preserve the order of logs within the batch.
+   */
+  def sendBatch(logs: Seq[OtelLog]): Unit
 }

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/LogsPublishQueueSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/LogsPublishQueueSuite.scala
@@ -46,44 +46,57 @@ class LogsPublishQueueSuite extends FunSuite with TestKitBase {
     new LogsPublishQueue(cfg, registry, sendLog)
   }
 
-  test("log is delivered to sendLog") {
+  test("batch is delivered to sendLog") {
     val received = new LinkedBlockingQueue[OtelLog]()
     val queue = makeQueue(log => received.put(log))
 
-    val log = sampleLog("hello")
-    queue.send(log)
+    queue.sendBatch(List(sampleLog("hello")))
 
     val delivered = received.poll(10, TimeUnit.SECONDS)
     assertNotEquals(delivered, null)
     assertEquals(delivered.message, "hello")
   }
 
-  test("multiple logs are all delivered in order") {
+  test("logs within a batch are delivered in order") {
     val received = new LinkedBlockingQueue[String]()
     val queue = makeQueue(log => received.put(log.message))
 
-    (1 to 5).foreach(i => queue.send(sampleLog(s"msg-$i")))
+    // Single batch — logs are always sequential within a batch regardless of parallelism
+    queue.sendBatch((1 to 5).map(i => sampleLog(s"msg-$i")))
 
     val messages = (1 to 5).map(_ => received.poll(10, TimeUnit.SECONDS))
     assertEquals(messages.toList, List("msg-1", "msg-2", "msg-3", "msg-4", "msg-5"))
   }
 
-  test("sent counter increments on success") {
+  test("batches from different streams are processed concurrently") {
+    val received = new LinkedBlockingQueue[String]()
+    val queue = makeQueue(log => received.put(log.message))
+
+    queue.sendBatch(List(sampleLog("stream-a-1"), sampleLog("stream-a-2")))
+    queue.sendBatch(List(sampleLog("stream-b-1"), sampleLog("stream-b-2")))
+
+    val messages = (1 to 4).map(_ => received.poll(10, TimeUnit.SECONDS)).toSet
+    assertEquals(
+      messages,
+      Set("stream-a-1", "stream-a-2", "stream-b-1", "stream-b-2")
+    )
+  }
+
+  test("sent counter increments once per log") {
     val registry = new DefaultRegistry()
     val received = new LinkedBlockingQueue[OtelLog]()
     val queue = makeQueue(log => received.put(log), registry)
 
-    queue.send(sampleLog())
-    received.poll(10, TimeUnit.SECONDS)
-    // give stream time to record the counter after sendLog returns
+    queue.sendBatch(List(sampleLog("a"), sampleLog("b"), sampleLog("c")))
+    (1 to 3).foreach(_ => received.poll(10, TimeUnit.SECONDS))
     Thread.sleep(200)
 
-    assertEquals(registry.counter("atlas.cloudwatch.logs.queue.sent").count(), 1L)
+    assertEquals(registry.counter("atlas.cloudwatch.logs.queue.sent").count(), 3L)
   }
 
-  test("sendLog exception is swallowed and dropped counter increments") {
+  test("sendLog exception drops the batch and increments dropped by batch size") {
     val registry = new DefaultRegistry()
-    val successReceived = new LinkedBlockingQueue[OtelLog]()
+    val successReceived = new LinkedBlockingQueue[String]()
     val callCount = new AtomicInteger(0)
 
     val queue = makeQueue(
@@ -91,31 +104,30 @@ class LogsPublishQueueSuite extends FunSuite with TestKitBase {
         if (callCount.incrementAndGet() == 1)
           throw new RuntimeException("TCP error")
         else
-          successReceived.put(log)
+          successReceived.put(log.message)
       },
       registry
     )
 
-    queue.send(sampleLog("will-fail"))
-    queue.send(sampleLog("will-succeed"))
+    // First batch will fail on the first log (exception thrown mid-batch)
+    queue.sendBatch(List(sampleLog("will-fail"), sampleLog("also-dropped")))
+    // Second batch succeeds
+    queue.sendBatch(List(sampleLog("ok-1"), sampleLog("ok-2")))
 
-    val delivered = successReceived.poll(10, TimeUnit.SECONDS)
-    assertNotEquals(delivered, null)
-    assertEquals(delivered.message, "will-succeed")
+    assertEquals(successReceived.poll(10, TimeUnit.SECONDS), "ok-1")
+    assertEquals(successReceived.poll(10, TimeUnit.SECONDS), "ok-2")
 
     Thread.sleep(200)
-    assertEquals(registry.counter("atlas.cloudwatch.logs.queue.dropped").count(), 1L)
-    assertEquals(registry.counter("atlas.cloudwatch.logs.queue.sent").count(), 1L)
+    assertEquals(registry.counter("atlas.cloudwatch.logs.queue.dropped").count(), 2L)
+    assertEquals(registry.counter("atlas.cloudwatch.logs.queue.sent").count(), 2L)
   }
 
-  test("send does not throw when queue is full") {
-    // Use a tiny queue and a slow sender to saturate it
+  test("sendBatch does not throw when queue is full") {
     val queue = makeQueue(
       _ => Thread.sleep(5000),
       queueSize = 1
     )
 
-    // Should not throw even when the queue is saturated
-    (1 to 20).foreach(_ => queue.send(sampleLog()))
+    (1 to 20).foreach(_ => queue.sendBatch(List(sampleLog())))
   }
 }

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/TestableOTelCloudWatchLogsProcessor.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/TestableOTelCloudWatchLogsProcessor.scala
@@ -27,7 +27,7 @@ import scala.jdk.CollectionConverters.*
 class TestableOTelCloudWatchLogsProcessor(
   val sinkStub: StubOtelLogSink = new StubOtelLogSink
 ) extends OTelCloudWatchLogsProcessor(
-      ConfigFactory.load().getConfig("atlas.cloudwatch.logs"),
+      ConfigFactory.load(),
       sinkStub,
       null
     ) {

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/TestableOTelCloudWatchLogsProcessor.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/TestableOTelCloudWatchLogsProcessor.scala
@@ -49,8 +49,8 @@ class StubOtelLogSink extends OtelLogSink {
 
   private val queue = new ConcurrentLinkedQueue[OtelLog]()
 
-  override def send(log: OtelLog): Unit = {
-    queue.add(log)
+  override def sendBatch(logs: Seq[OtelLog]): Unit = {
+    logs.foreach(queue.add)
   }
 
   def logs: List[OtelLog] =


### PR DESCRIPTION
Covers all 9 metrics across the 4 valid dimension combinations from: https://docs.aws.amazon.com/network-manager/latest/cloudwan/cloudwan-metrics.html

- cloudwan-core: CoreNetwork + EdgeLocation
- cloudwan-attachment: Attachment + CoreNetwork
- cloudwan-core-az: AvailabilityZone + CoreNetwork + EdgeLocation (Direct Connect)
- cloudwan-attachment-az: Attachment + AvailabilityZone + CoreNetwork (Direct Connect)

Adds dimension mappings for Attachment, CoreNetwork, and EdgeLocation to reference.conf.