### PR TITLE
send entire log batch over a single TCP connection to fix OTel collec…

### DIFF
--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/LogsPublishQueue.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/LogsPublishQueue.scala
@@ -27,22 +27,23 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 /**
- * Bounded async queue that drains log batches to OtelTcpLogger.sendLog.
+ * Bounded async queue that drains log batches to OtelTcpLogger.sendBatch.
  *
  * Each element in the queue is a batch of OtelLog entries from a single log stream.
- * Up to `parallelism` batches are processed concurrently (one per stream), while logs
- * within each batch are sent sequentially — preserving intra-stream order.
+ * Up to `parallelism` batches are processed concurrently (one per stream), with each
+ * batch sent over a single TCP connection — one socket open/write/close per batch
+ * instead of one per log. This eliminates per-log goroutine pressure on the OTel collector.
  *
  * Absorbs traffic bursts: callers never block on TCP I/O. When the queue is full the
  * batch is dropped (counted) rather than causing OOM in the OTel collector.
  *
  * TCP sends run on a dedicated thread pool (logs-sink-dispatcher) so blocking calls
- * and retry sleeps inside sendLog never starve the main Akka dispatcher.
+ * and retry sleeps never starve the main Akka dispatcher.
  */
 class LogsPublishQueue(
   config: Config,
   registry: Registry,
-  sendLog: OtelLog => Unit
+  tcpSendBatch: Seq[OtelLog] => Unit
 )(implicit system: ActorSystem)
     extends OtelLogSink
     with StrictLogging {
@@ -64,10 +65,9 @@ class LogsPublishQueue(
     .blockingQueue[Seq[OtelLog]](registry, "logsQueue", queueSize)
     .mapAsync(parallelism) { batch =>
       Future {
-        batch.foreach { log =>
-          sendLog(log)
-          logsSent.increment()
-        }
+        // One TCP connection for the entire batch — all logs written then socket closed.
+        tcpSendBatch(batch)
+        logsSent.increment(batch.size)
       }(sinkDispatcher).recover {
         case e: Exception =>
           logger.warn(s"Failed to send log batch to OTel collector: ${e.getMessage}", e)

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/OtelLog.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/OtelLog.scala
@@ -63,18 +63,22 @@ object OtelTcpLogger extends StrictLogging {
     )
   }
 
-  private def trySend(line: String, attempt: Int): Boolean = {
+  // Serialize all logs up-front so JSON encoding never happens inside the socket write.
+  private def trySendBatch(lines: Seq[String], attempt: Int): Boolean = {
     var socket: Socket = null
     try {
       socket = new Socket()
       socket.connect(new InetSocketAddress(host, port), connectTimeout.toMillis.toInt)
       val writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream, "UTF-8"))
-      writer.write(line)
+      lines.foreach(writer.write)
       writer.flush()
       true
     } catch {
       case e: Exception =>
-        logger.warn(s"[otel-tcp-logger] attempt $attempt: error sending log: ${e.getMessage}", e)
+        logger.warn(
+          s"[otel-tcp-logger] attempt $attempt: error sending batch of ${lines.size}: ${e.getMessage}",
+          e
+        )
         false
     } finally {
       if (socket != null) {
@@ -90,14 +94,17 @@ object OtelTcpLogger extends StrictLogging {
     }
   }
 
-  def sendLog(log: OtelLog): Unit = {
-    val json = Json.encode(log)
-    val line = json + "\n"
+  /**
+   * Send all logs in a single TCP connection — one socket open/write/close per batch
+   * instead of one per log. Retries the whole batch on connection or write failure.
+   */
+  def sendBatch(logs: Seq[OtelLog]): Unit = {
+    val lines = logs.map(log => Json.encode(log) + "\n")
 
     var attempt = 1
     var done = false
     while (attempt <= maxAttempts && !done) {
-      if (trySend(line, attempt)) {
+      if (trySendBatch(lines, attempt)) {
         done = true
       } else if (attempt < maxAttempts) {
         Thread.sleep(retryDelay.toMillis)
@@ -112,7 +119,5 @@ object OtelTcpLogger extends StrictLogging {
 
 object OtelTcpSink extends OtelLogSink {
 
-  override def sendBatch(logs: Seq[OtelLog]): Unit = {
-    logs.foreach(OtelTcpLogger.sendLog)
-  }
+  override def sendBatch(logs: Seq[OtelLog]): Unit = OtelTcpLogger.sendBatch(logs)
 }

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/spring/CloudWatchConfiguration.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/spring/CloudWatchConfiguration.scala
@@ -88,7 +88,7 @@ class CloudWatchConfiguration extends StrictLogging {
     system: ActorSystem
   ): OtelLogSink = {
     val r = registry.orElseGet(() => globalRegistry())
-    new LogsPublishQueue(config, r, OtelTcpLogger.sendLog)(system)
+    new LogsPublishQueue(config, r, OtelTcpLogger.sendBatch)(system)
   }
 
   @Bean

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/LogsPublishQueueSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/LogsPublishQueueSuite.scala
@@ -34,7 +34,7 @@ class LogsPublishQueueSuite extends FunSuite with TestKitBase {
     OtelLog(System.currentTimeMillis(), msg, "INFO", "test.logger", Map("env" -> "test"))
 
   private def makeQueue(
-    sendLog: OtelLog => Unit,
+    tcpSendBatch: Seq[OtelLog] => Unit,
     registry: Registry = new DefaultRegistry(),
     queueSize: Int = 1000,
     parallelism: Int = 4
@@ -43,25 +43,25 @@ class LogsPublishQueueSuite extends FunSuite with TestKitBase {
       s"""atlas.cloudwatch.logs.queue.queueSize = $queueSize
          |atlas.cloudwatch.logs.queue.parallelism = $parallelism""".stripMargin
     )
-    new LogsPublishQueue(cfg, registry, sendLog)
+    new LogsPublishQueue(cfg, registry, tcpSendBatch)
   }
 
-  test("batch is delivered to sendLog") {
-    val received = new LinkedBlockingQueue[OtelLog]()
-    val queue = makeQueue(log => received.put(log))
+  test("batch is delivered to sendBatch as a single call") {
+    val received = new LinkedBlockingQueue[Seq[OtelLog]]()
+    val queue = makeQueue(batch => received.put(batch))
 
-    queue.sendBatch(List(sampleLog("hello")))
+    val logs = List(sampleLog("a"), sampleLog("b"), sampleLog("c"))
+    queue.sendBatch(logs)
 
     val delivered = received.poll(10, TimeUnit.SECONDS)
     assertNotEquals(delivered, null)
-    assertEquals(delivered.message, "hello")
+    assertEquals(delivered.map(_.message), List("a", "b", "c"))
   }
 
   test("logs within a batch are delivered in order") {
     val received = new LinkedBlockingQueue[String]()
-    val queue = makeQueue(log => received.put(log.message))
+    val queue = makeQueue(batch => batch.foreach(log => received.put(log.message)))
 
-    // Single batch — logs are always sequential within a batch regardless of parallelism
     queue.sendBatch((1 to 5).map(i => sampleLog(s"msg-$i")))
 
     val messages = (1 to 5).map(_ => received.poll(10, TimeUnit.SECONDS))
@@ -70,52 +70,47 @@ class LogsPublishQueueSuite extends FunSuite with TestKitBase {
 
   test("batches from different streams are processed concurrently") {
     val received = new LinkedBlockingQueue[String]()
-    val queue = makeQueue(log => received.put(log.message))
+    val queue = makeQueue(batch => batch.foreach(log => received.put(log.message)))
 
     queue.sendBatch(List(sampleLog("stream-a-1"), sampleLog("stream-a-2")))
     queue.sendBatch(List(sampleLog("stream-b-1"), sampleLog("stream-b-2")))
 
     val messages = (1 to 4).map(_ => received.poll(10, TimeUnit.SECONDS)).toSet
-    assertEquals(
-      messages,
-      Set("stream-a-1", "stream-a-2", "stream-b-1", "stream-b-2")
-    )
+    assertEquals(messages, Set("stream-a-1", "stream-a-2", "stream-b-1", "stream-b-2"))
   }
 
-  test("sent counter increments once per log") {
+  test("sent counter increments by batch size on success") {
     val registry = new DefaultRegistry()
-    val received = new LinkedBlockingQueue[OtelLog]()
-    val queue = makeQueue(log => received.put(log), registry)
+    val received = new LinkedBlockingQueue[Seq[OtelLog]]()
+    val queue = makeQueue(batch => received.put(batch), registry)
 
     queue.sendBatch(List(sampleLog("a"), sampleLog("b"), sampleLog("c")))
-    (1 to 3).foreach(_ => received.poll(10, TimeUnit.SECONDS))
+    received.poll(10, TimeUnit.SECONDS)
     Thread.sleep(200)
 
     assertEquals(registry.counter("atlas.cloudwatch.logs.queue.sent").count(), 3L)
   }
 
-  test("sendLog exception drops the batch and increments dropped by batch size") {
+  test("sendBatch exception drops whole batch and increments dropped by batch size") {
     val registry = new DefaultRegistry()
-    val successReceived = new LinkedBlockingQueue[String]()
+    val received = new LinkedBlockingQueue[String]()
     val callCount = new AtomicInteger(0)
 
     val queue = makeQueue(
-      log => {
+      batch => {
         if (callCount.incrementAndGet() == 1)
           throw new RuntimeException("TCP error")
         else
-          successReceived.put(log.message)
+          batch.foreach(log => received.put(log.message))
       },
       registry
     )
 
-    // First batch will fail on the first log (exception thrown mid-batch)
     queue.sendBatch(List(sampleLog("will-fail"), sampleLog("also-dropped")))
-    // Second batch succeeds
     queue.sendBatch(List(sampleLog("ok-1"), sampleLog("ok-2")))
 
-    assertEquals(successReceived.poll(10, TimeUnit.SECONDS), "ok-1")
-    assertEquals(successReceived.poll(10, TimeUnit.SECONDS), "ok-2")
+    assertEquals(received.poll(10, TimeUnit.SECONDS), "ok-1")
+    assertEquals(received.poll(10, TimeUnit.SECONDS), "ok-2")
 
     Thread.sleep(200)
     assertEquals(registry.counter("atlas.cloudwatch.logs.queue.dropped").count(), 2L)


### PR DESCRIPTION

Previously OtelTcpLogger opened a new socket per log — with parallelism=4 and maxPerBatch=10 this created rapid-fire TCP connections, each spawning a goroutine on the collector. Goroutines accumulated faster than GC causing the OOM kill.

Now trySendBatch() opens one socket, writes all JSON lines, flushes and closes — N logs per batch = 1 goroutine on the collector instead of N. Retry logic retries the whole batch on connection or write failure.