### PR TITLE
Canonicalize strings in internal payload decoder

### DIFF
--- a/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PayloadDecoder.scala
+++ b/atlas-aggregator/src/main/scala/com/netflix/atlas/aggregator/PayloadDecoder.scala
@@ -280,9 +280,12 @@ object PayloadDecoder {
 
   /**
     * For internal usage after validation has already been performed. Avoids the cost of
-    * validation and data cleaning steps that are normally done while reading.
+    * validation and data cleaning steps that are normally done while reading. The strings
+    * are still canonicalized through the cache so that equal tag keys/values share a single
+    * instance. This lets downstream equality checks (registry getOrCreate, query index match
+    * caches) short-circuit on reference equality rather than comparing characters.
     */
-  val internal: PayloadDecoder = new PayloadDecoder(s => s, NoValidation, ts => ts)
+  val internal: PayloadDecoder = new PayloadDecoder(canonicalize, NoValidation, ts => ts)
 
   /**
     * Get a default instance for reading/writing the payloads. It will perform full validation
@@ -297,6 +300,18 @@ object PayloadDecoder {
       // occur multiple times for the same string, but that is not a problem here.
       value = allowedCharacters.replaceNonMembers(s, '_')
       stringCache.put(s, value)
+    }
+    value
+  }
+
+  private def canonicalize(s: String): String = {
+    var value = stringCache.getIfPresent(s)
+    if (value == null) {
+      // No character replacement is needed for internal traffic, so the first-seen instance
+      // becomes the canonical one. As with replaceInvalidCharacters, a benign race may briefly
+      // leave two instances for the same value until the cache settles.
+      stringCache.put(s, s)
+      value = s
     }
     value
   }

--- a/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/PayloadDecoderSuite.scala
+++ b/atlas-aggregator/src/test/scala/com/netflix/atlas/aggregator/PayloadDecoderSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.atlas.aggregator
+
+import com.netflix.atlas.json3.Json
+import com.netflix.spectator.api.Id
+import munit.FunSuite
+
+import scala.collection.mutable
+
+class PayloadDecoderSuite extends FunSuite {
+
+  private class CapturingAggregator extends Aggregator {
+
+    val ids: mutable.ArrayBuffer[Id] = mutable.ArrayBuffer.empty[Id]
+    override def add(id: Id, value: Double): Unit = ids += id
+    override def max(id: Id, value: Double): Unit = ids += id
+  }
+
+  private def valueForKey(id: Id, key: String): String = {
+    var result: String = null
+    val n = id.size()
+    var i = 0
+    while (i < n) {
+      if (id.getKey(i) == key) result = id.getValue(i)
+      i += 1
+    }
+    result
+  }
+
+  // Single counter update: name=cpu_user, app=www
+  private def payload() =
+    Json.newJsonParser(
+      Json.encode(List(4, "name", "cpu_user", "app", "www", 2, 0, 1, 2, 3, 0, 1.0))
+    )
+
+  test("internal decoder canonicalizes tag values across separate payloads") {
+    val agg = new CapturingAggregator
+    // Two independent decode calls produce independent string tables; only the shared
+    // string cache can make equal values resolve to the same instance.
+    PayloadDecoder.internal.decode(payload(), agg)
+    PayloadDecoder.internal.decode(payload(), agg)
+
+    assertEquals(agg.ids.size, 2)
+    val v0 = valueForKey(agg.ids(0), "app")
+    val v1 = valueForKey(agg.ids(1), "app")
+    assertEquals(v0, "www")
+    assertEquals(v1, "www")
+    assert(v0 ne null)
+    assert(
+      v0 eq v1,
+      "equal tag values from separate payloads should be the same interned instance"
+    )
+  }
+}


### PR DESCRIPTION
The internal decoder used an identity string cleaner (s => s), so each parsed tag key/value was a fresh String instance per request. Equal-valued ids built from internal traffic therefore failed reference-equality checks, forcing full character comparison in registry getOrCreate (ArrayTagSet.equals) and the query index match caches on every measurement.

Route the internal decoder through the existing string cache to canonicalize instances (without the validation/char-replacement done for external traffic), so equal tag keys/values share one instance and downstream equality checks short-circuit on reference equality.