### PR TITLE
druid: fold datapoints while parsing response

### DIFF
--- a/atlas-druid/src/main/resources/application.conf
+++ b/atlas-druid/src/main/resources/application.conf
@@ -13,7 +13,7 @@ atlas {
 
     // Maximum size for intermediate data response. If it is exceeded, then the
     // processing will be fail early.
-    max-data-size = 2g
+    max-data-size = 512m
 
     // Filter for the set of allowed data sources. Only datasources that match this regex will
     // be exposed.
@@ -51,6 +51,9 @@ atlas {
 pekko.http {
 
   server.request-timeout = 55s
+
+  // List the max response size of druid response payloads
+  client.parsing.max-content-length = 25m
 
   host-connection-pool {
     max-open-requests = 1024

--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -21,6 +21,7 @@ import java.time.Duration
 import java.time.Instant
 import org.apache.pekko.NotUsed
 import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.EntityStreamSizeException
 import org.apache.pekko.http.scaladsl.model.HttpEntity
 import org.apache.pekko.http.scaladsl.model.HttpMethods
 import org.apache.pekko.http.scaladsl.model.HttpRequest
@@ -79,10 +80,7 @@ class DruidClient(
       case Failure(t)                => Source.failed[HttpResponse](t)
     }
     .flatMapConcat { res =>
-      res.entity
-        .withoutSizeLimit()
-        .dataBytes
-        .fold(ByteString.empty)(_ ++ _)
+      res.entity.dataBytes.fold(ByteString.empty)(_ ++ _)
     }
     .map { data =>
       if (data.startsWith(gzipMagicHeader)) {
@@ -91,6 +89,10 @@ class DruidClient(
         logger.trace(s"raw response payload: ${data.decodeString(StandardCharsets.UTF_8)}")
       }
       data
+    }
+    .mapError {
+      case e: EntityStreamSizeException =>
+        new IllegalStateException(s"druid response size exceeds limit of ${e.limit} bytes", e)
     }
 
   private def isOK(res: HttpResponse): Boolean = res.status == StatusCodes.OK

--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidClient.scala
@@ -207,14 +207,59 @@ class DruidClient(
     }
   }
 
+  /**
+    * Parse a data query response, folding each datapoint into `consumer` as it is decoded rather
+    * than collecting the datapoints into a `List`, and emit the populated consumer so the caller
+    * reads its result from the stream. The consumer is expected to fold into a compact
+    * representation (e.g. one array per output series), which for a wide group by with many time
+    * buckets bounds peak memory by the size of that result rather than by the response size.
+    */
+  def parseDatapoints[C <: DatapointConsumer](query: DataQuery)(consumer: C): Source[C, NotUsed] = {
+    query match {
+      case q: GroupByQuery =>
+        val dimensions = q.dimensions.map(_.outputName)
+        val timer = q.aggregations.exists(_.aggrType == "timer")
+        Source
+          .single(mkRequest(q))
+          .via(loggingClient)
+          .map { data =>
+            decodeGroupBy(dimensions, timer, data)(consumer)
+            consumer
+          }
+      case q: TimeseriesQuery =>
+        Source
+          .single(mkRequest(q))
+          .via(loggingClient)
+          .map { data =>
+            Using
+              .resource(inputStream(data)) { in =>
+                Json.decode[List[TimeseriesDatapoint]](in)
+              }
+              .foreach(d => consumer.accept(d.timestampMillis, Map.empty, d.result.value))
+            consumer
+          }
+    }
+  }
+
   private def parseResult(
     dimensions: List[String],
     timer: Boolean,
     data: ByteString
   ): List[GroupByDatapoint] = {
+    val builder = List.newBuilder[GroupByDatapoint]
+    decodeGroupBy(dimensions, timer, data) { (timestamp, tags, value) =>
+      builder += GroupByDatapoint(timestamp, tags, value)
+    }
+    builder.result()
+  }
+
+  private def decodeGroupBy(
+    dimensions: List[String],
+    timer: Boolean,
+    data: ByteString
+  )(consumer: DatapointConsumer): Unit = {
     Using.resource(Json.newJsonParser(inputStream(data))) { parser =>
       import com.netflix.atlas.json3.JsonParserHelper.*
-      val builder = List.newBuilder[GroupByDatapoint]
       foreachItem(parser) {
         require(parser.currentToken() == JsonToken.START_ARRAY)
         val timestamp = nextLong(parser)
@@ -223,13 +268,14 @@ class DruidClient(
         // null values as being the same. Some older threads suggest server side filtering
         // for null values may not be reliable. This could be fixed now, but as it is a fairly
         // rare occurrence in our use-cases and unlikely to have a big performance benefit, we
-        // do a client side filtering to remove entries with null values.
-        val tags = dimensions
-          .map { d =>
-            d -> parser.nextStringValue()
-          }
-          .filterNot(t => isNullOrEmpty(t._2))
-          .toMap
+        // do a client side filtering to remove entries with null values. The tag map is built
+        // directly to avoid the intermediate list of pairs allocated per datapoint.
+        val tagsBuilder = Map.newBuilder[String, String]
+        dimensions.foreach { d =>
+          val v = parser.nextStringValue()
+          if (!isNullOrEmpty(v)) tagsBuilder += d -> v
+        }
+        val tags = tagsBuilder.result()
 
         val valueToken = parser.nextToken()
         if (valueToken == JsonToken.START_OBJECT) {
@@ -237,7 +283,7 @@ class DruidClient(
           foreachField(parser) { idx =>
             val key = toPercentileBucket(idx, timer)
             val datapointTags = tags + (TagKey.percentile -> key)
-            builder += GroupByDatapoint(timestamp, datapointTags, nextLong(parser).toDouble)
+            consumer.accept(timestamp, datapointTags, nextLong(parser).toDouble)
           }
         } else if (valueToken != JsonToken.VALUE_NULL) {
           // Floating point value. In some cases histogram can be null, ignore those entries.
@@ -248,11 +294,10 @@ class DruidClient(
             case VALUE_STRING       => java.lang.Double.parseDouble(parser.getString)
             case t => JsonParserHelper.fail(parser, s"expected VALUE_NUMBER_FLOAT but received $t")
           }
-          builder += GroupByDatapoint(timestamp, tags, value)
+          consumer.accept(timestamp, tags, value)
         }
         parser.nextToken() // skip end array token
       }
-      builder.result()
     }
   }
 
@@ -588,11 +633,22 @@ object DruidClient {
 
   case class GroupByDatapoint(timestamp: Long, tags: Map[String, String], value: Double)
 
+  /**
+    * Consumer invoked for each datapoint as a data query response is parsed. The timestamp and
+    * value are passed as primitives rather than wrapped in a `GroupByDatapoint` so that callers
+    * folding the stream avoid both the wrapper allocation and the boxing a generic function would
+    * incur on the per-datapoint hot path.
+    */
+  trait DatapointConsumer {
+    def accept(timestamp: Long, tags: Map[String, String], value: Double): Unit
+  }
+
   case class TimeseriesDatapoint(timestamp: String, result: TimeseriesResult) {
 
+    def timestampMillis: Long = Instant.parse(timestamp).toEpochMilli
+
     def toGroupByDatapoint: GroupByDatapoint = {
-      val t = Instant.parse(timestamp).toEpochMilli
-      GroupByDatapoint(t, Map.empty, result.value)
+      GroupByDatapoint(timestampMillis, Map.empty, result.value)
     }
   }
 

--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -344,8 +344,9 @@ class DruidDatabaseActor(config: Config, service: DruidMetadataService, client: 
             (v: Double) => v
           else
             createValueMapper(normalizeRates, metricContext, expr)
-        client.data(groupByQuery).map { result =>
-          val candidates = toTimeSeries(tags, metricContext, result, maxDataSize, valueMapper)
+        val accumulator = new TimeSeriesAccumulator(tags, metricContext, maxDataSize, valueMapper)
+        client.parseDatapoints(groupByQuery)(accumulator).map { acc =>
+          val candidates = acc.result()
           // See behavior on multi-value dimensions:
           // http://druid.io/docs/latest/querying/groupbyquery.html
           //
@@ -585,42 +586,51 @@ object DruidDatabaseActor {
     case _                    => false
   }
 
-  def toTimeSeries(
+  /**
+    * Folds group by datapoints into one array per output series as they are consumed. Doing this
+    * incrementally as the response is parsed avoids materializing the full set of datapoints,
+    * bounding peak memory by the number of output series rather than the response size.
+    */
+  class TimeSeriesAccumulator(
     commonTags: Map[String, String],
     context: EvalContext,
-    data: List[GroupByDatapoint],
     limit: Long,
     valueMapper: Double => Double
-  ): List[TimeSeries] = {
-    val arrays = scala.collection.mutable.HashMap.empty[Map[String, String], Array[Double]]
-    val length = context.bufferSize
-    val bytesPerTimeSeries = 8L * length
-    data.foreach { d =>
-      val t = d.timestamp
-      val i = ((t - context.start) / context.step).toInt
+  ) extends DatapointConsumer {
+
+    private val arrays = scala.collection.mutable.HashMap.empty[Map[String, String], Array[Double]]
+    private val length = context.bufferSize
+    private val bytesPerTimeSeries = 8L * length
+
+    override def accept(timestamp: Long, tags: Map[String, String], value: Double): Unit = {
+      val i = ((timestamp - context.start) / context.step).toInt
       if (i >= 0 && i < length) {
-        val v = valueMapper(d.value)
+        val v = valueMapper(value)
         // Only materialize a buffer for groups with a non-NaN value in the window. Groups
         // with data only in neighboring time segments, or that are entirely NaN, contribute
         // nothing and are skipped to avoid allocating and aggregating empty arrays.
         if (!java.lang.Double.isNaN(v)) {
-          val array = arrays.getOrElseUpdate(d.tags, ArrayHelper.fill(length, Double.NaN))
+          val array = arrays.getOrElseUpdate(tags, ArrayHelper.fill(length, Double.NaN))
           array(i) = v
         }
       }
-      // Stop early if data size is too large to avoid GC issues
+      // Stop early if data size is too large to avoid GC issues. This caps the number of
+      // retained series and now fires while the response is still being parsed.
       if (arrays.size * bytesPerTimeSeries > limit) {
         throw new IllegalStateException(s"data size exceeds $limit bytes")
       }
     }
-    arrays.toList.map {
-      case (tags, vs) =>
-        val seq = new ArrayTimeSeq(DsType.Rate, context.start + context.step, context.step, vs)
-        // Use TimeSeriesBuffer rather than TimeSeries(tags, seq) so the label is
-        // computed lazily. These raw rows are immediately re-aggregated and re-labeled
-        // by the eval below, so their labels are never read and the toLabel cost (a
-        // large share of allocations for big group by queries) is avoided.
-        new TimeSeriesBuffer(commonTags ++ tags, seq)
+
+    def result(): List[TimeSeries] = {
+      arrays.toList.map {
+        case (tags, vs) =>
+          val seq = new ArrayTimeSeq(DsType.Rate, context.start + context.step, context.step, vs)
+          // Use TimeSeriesBuffer rather than TimeSeries(tags, seq) so the label is
+          // computed lazily. These raw rows are immediately re-aggregated and re-labeled
+          // by the eval below, so their labels are never read and the toLabel cost (a
+          // large share of allocations for big group by queries) is avoided.
+          new TimeSeriesBuffer(commonTags ++ tags, seq)
+      }
     }
   }
 

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
@@ -300,7 +300,10 @@ class DruidClientSuite extends FunSuite {
 
   test("parseDatapoints matches groupBy: histogram response") {
     val query = GroupByQuery("test", Nil, Nil, List(Aggregation.timer("value")))
-    assertEquals(collectViaParse("groupByResponseHisto.json", query), executeGroupByHistogramRequest)
+    assertEquals(
+      collectViaParse("groupByResponseHisto.json", query),
+      executeGroupByHistogramRequest
+    )
   }
 
   test("aggregation encode, timer type") {

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
@@ -19,6 +19,7 @@ import java.io.IOException
 import java.net.ConnectException
 import java.nio.charset.StandardCharsets
 import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.EntityStreamSizeException
 import org.apache.pekko.http.scaladsl.model.HttpEntity
 import org.apache.pekko.http.scaladsl.model.HttpRequest
 import org.apache.pekko.http.scaladsl.model.HttpResponse
@@ -99,6 +100,18 @@ class DruidClientSuite extends FunSuite {
       val future = client.datasources.runWith(Sink.head)
       Await.result(future, Duration.Inf)
     }
+  }
+
+  test("response exceeding size limit maps to IllegalStateException") {
+    val ex = intercept[IllegalStateException] {
+      val data = Source.failed[ByteString](EntityStreamSizeException(10L, Some(20L)))
+      val entity = HttpEntity(MediaTypes.`application/json`, data)
+      val response = HttpResponse(StatusCodes.OK, entity = entity)
+      val client = newClient(Success(response))
+      val future = client.datasources.runWith(Sink.head)
+      Await.result(future, Duration.Inf)
+    }
+    assert(ex.getMessage.contains("response size exceeds"))
   }
 
   test("get datasources bad json output") {

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidClientSuite.scala
@@ -279,6 +279,30 @@ class DruidClientSuite extends FunSuite {
     assertEquals(actual, expected)
   }
 
+  private def collectViaParse(file: String, query: DataQuery): List[GroupByDatapoint] = {
+    import com.netflix.atlas.core.util.Streams.*
+    val payload = Using.resource(resource(file))(byteArray)
+    val response = HttpResponse(StatusCodes.OK, entity = payload)
+    val client = newClient(Success(response))
+    val builder = List.newBuilder[GroupByDatapoint]
+    val consumer: DatapointConsumer = (timestamp, tags, value) =>
+      builder += GroupByDatapoint(timestamp, tags, value)
+    val future = client.parseDatapoints(query)(consumer).runWith(Sink.ignore)
+    Await.result(future, Duration.Inf)
+    builder.result()
+  }
+
+  test("parseDatapoints matches groupBy: array response with null filtering") {
+    val query =
+      GroupByQuery("test", List(DefaultDimensionSpec("percentile", "percentile")), Nil, Nil)
+    assertEquals(collectViaParse("groupByResponseArray.json", query), executeGroupByRequest)
+  }
+
+  test("parseDatapoints matches groupBy: histogram response") {
+    val query = GroupByQuery("test", Nil, Nil, List(Aggregation.timer("value")))
+    assertEquals(collectViaParse("groupByResponseHisto.json", query), executeGroupByHistogramRequest)
+  }
+
   test("aggregation encode, timer type") {
     val aggr = Aggregation.timer("foo")
     val json = Json.encode(aggr)

--- a/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
+++ b/atlas-druid/src/test/scala/com/netflix/atlas/druid/DruidDatabaseActorSuite.scala
@@ -492,18 +492,39 @@ class DruidDatabaseActorSuite extends FunSuite {
     assertEquals(mapper(1.0), 1.0)
   }
 
-  test("toTimeSeries: drops NaN-only and out-of-window groups") {
+  test("TimeSeriesAccumulator: drops NaN-only and out-of-window groups") {
     val ctx = EvalContext(0L, 300_000L, 60_000L)
-    val mapper: Double => Double = v => v
-    val data = List(
-      GroupByDatapoint(60_000L, Map("k" -> "in"), 1.0), // in window
-      GroupByDatapoint(60_000L, Map("k" -> "nan"), Double.NaN), // in window but NaN
-      GroupByDatapoint(-60_000L, Map("k" -> "below"), 2.0), // before window
-      GroupByDatapoint(600_000L, Map("k" -> "above"), 3.0) // after window
-    )
-    val result = toTimeSeries(Map("name" -> "foo"), ctx, data, Long.MaxValue, mapper)
+    val acc = new TimeSeriesAccumulator(Map("name" -> "foo"), ctx, Long.MaxValue, v => v)
+    acc.accept(60_000L, Map("k" -> "in"), 1.0) // in window
+    acc.accept(60_000L, Map("k" -> "nan"), Double.NaN) // in window but NaN
+    acc.accept(-60_000L, Map("k" -> "below"), 2.0) // before window
+    acc.accept(600_000L, Map("k" -> "above"), 3.0) // after window
+    val result = acc.result()
     assertEquals(result.map(_.tags("k")), List("in"))
     assertEquals(result.head.tags("name"), "foo")
+  }
+
+  test("TimeSeriesAccumulator: multiple datapoints fold into one series") {
+    val ctx = EvalContext(0L, 300_000L, 60_000L)
+    val acc = new TimeSeriesAccumulator(Map("name" -> "foo"), ctx, Long.MaxValue, v => v)
+    acc.accept(60_000L, Map("k" -> "a"), 1.0)
+    acc.accept(120_000L, Map("k" -> "a"), 2.0)
+    val result = acc.result()
+    assertEquals(result.size, 1)
+    assertEquals(result.head.tags, Map("name" -> "foo", "k" -> "a"))
+  }
+
+  test("TimeSeriesAccumulator: enforces byte limit across groups") {
+    val ctx = EvalContext(0L, 300_000L, 60_000L)
+    val bytesPerSeries = 8L * ctx.bufferSize
+    // Limit only allows a single series; a second distinct group should trip the guard.
+    val acc = new TimeSeriesAccumulator(Map("name" -> "foo"), ctx, bytesPerSeries, v => v)
+    acc.accept(60_000L, Map("k" -> "a"), 1.0)
+    acc.accept(120_000L, Map("k" -> "a"), 2.0) // same group, still one series
+    val ex = intercept[IllegalStateException] {
+      acc.accept(60_000L, Map("k" -> "b"), 3.0)
+    }
+    assert(ex.getMessage.contains("data size exceeds"))
   }
 
   test("validate: simple expr with name") {


### PR DESCRIPTION
Add DruidClient.parseDatapoints, which parses a data query response and folds each datapoint into a DatapointConsumer as it is decoded instead of collecting a List[GroupByDatapoint], then emits the populated consumer so the result flows through the stream. DruidDatabaseActor folds into a TimeSeriesAccumulator (one array per output series), bounding peak memory by the number of output series rather than the response size, which was the original OOM concern. The existing max-data-size guard now fires while the response is still being parsed.

The consumer takes timestamp, tags, and value as primitives to avoid both the per-datapoint wrapper allocation and the boxing a generic function would incur on the hot path. The tag map is also built directly during parsing to drop the intermediate list of pairs allocated per datapoint.