### PR TITLE
Use Caffeine cache for bridge query index

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -162,6 +162,7 @@ lazy val `iep-lwc-bridge` = project
   .settings(libraryDependencies ++= Seq(
     Dependencies.atlasCore,
     Dependencies.atlasSpringPekko,
+    Dependencies.caffeine,
     Dependencies.frigga,
     Dependencies.iepDynConfig,
     Dependencies.iepSpring,

--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/CaffeineCache.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/CaffeineCache.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014-2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.iep.lwc
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.netflix.spectator.atlas.impl.QueryIndex
+import com.netflix.spectator.impl.Cache
+
+/**
+  * Cache implementation to use with the query index. Mirrors the implementation used by the
+  * atlas-aggregator. The default LFU cache shipped with the query index mutates a shared
+  * frequency counter on every read, which becomes a contention hotspot under the bridge's
+  * read throughput. Caffeine records accesses without a per-read shared write, so the hit
+  * path stays cheap.
+  */
+class CaffeineCache[T] extends Cache[String, QueryIndex.CacheValue[T]] {
+
+  private val delegate = Caffeine
+    .newBuilder()
+    .maximumSize(10_000)
+    .build[String, QueryIndex.CacheValue[T]]()
+
+  override def get(key: String): QueryIndex.CacheValue[T] = {
+    delegate.getIfPresent(key)
+  }
+
+  override def peek(key: String): QueryIndex.CacheValue[T] = {
+    throw new UnsupportedOperationException()
+  }
+
+  override def put(key: String, value: QueryIndex.CacheValue[T]): Unit = {
+    delegate.put(key, value)
+  }
+
+  override def computeIfAbsent(
+    key: String,
+    f: java.util.function.Function[String, QueryIndex.CacheValue[T]]
+  ): QueryIndex.CacheValue[T] = {
+    delegate.get(key, f)
+  }
+
+  override def clear(): Unit = {
+    delegate.invalidateAll()
+  }
+
+  override def size(): Int = {
+    delegate.estimatedSize().toInt
+  }
+
+  override def asMap(): java.util.Map[String, QueryIndex.CacheValue[T]] = {
+    java.util.Collections.emptyMap()
+  }
+}

--- a/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExpressionsEvaluator.scala
+++ b/iep-lwc-bridge/src/main/scala/com/netflix/iep/lwc/ExpressionsEvaluator.scala
@@ -21,7 +21,6 @@ import com.netflix.iep.config.DynamicConfigManager
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicLong
-import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.api.Utils
 import com.netflix.spectator.atlas.impl.DataExpr.Aggregator
@@ -60,7 +59,8 @@ class ExpressionsEvaluator(configMgr: DynamicConfigManager, registry: Registry)
 
   private var subscriptions = Set.empty[Subscription]
 
-  @volatile private[lwc] var index = QueryIndex.newInstance[Subscription](new NoopRegistry)
+  @volatile private[lwc] var index =
+    QueryIndex.newInstance[Subscription](() => new CaffeineCache[Subscription])
 
   private val statsMap = new ConcurrentHashMap[String, SubscriptionStats]()
 


### PR DESCRIPTION
The query index defaults to an LFU cache that increments a shared per-entry LongAdder on every read. Under the bridge's read throughput that per-read shared write becomes a contention hotspot: profiling showed ~12% of CPU in the LongAdder CAS plus ~9% in the backing map lookup, all on the cache hit path (hit rate ~99.8%, near-zero misses). CPU climbed steadily over uptime and dropped ~50% on redeploy.

The atlas-aggregator, which uses the same QueryIndex with a similar expression set, does not exhibit this because it supplies a Caffeine-backed cache. Caffeine records accesses without a per-read shared write, keeping the hit path cheap. Switch the bridge to the same implementation.