### PR TITLE
cloudwatch: add hrmEndOffset to avoid CW HRM publish lag trailing edge

### DIFF
--- a/atlas-cloudwatch/src/main/resources/reference.conf
+++ b/atlas-cloudwatch/src/main/resources/reference.conf
@@ -166,6 +166,11 @@ atlas {
 
       // how many data points to fetch for the lookback
       hrmLookback = 3
+
+      // seconds to subtract from the query end-time to avoid the unpublished trailing edge;
+      // CW HRM metrics have a ~2-3s publish lag so setting this to 1 or 2 seconds ensures the
+      // window only covers timestamps CW has already published
+      hrmEndOffset = 1
     }
 
     // Whether or not metrics should be pre-pended with TEST.

--- a/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
+++ b/atlas-cloudwatch/src/main/scala/com/netflix/atlas/cloudwatch/CloudWatchPoller.scala
@@ -167,6 +167,7 @@ class CloudWatchPoller(
   private[cloudwatch] val highResTimeCache = new ConcurrentHashMap[Long, RecentTimestamps]()
 
   private[cloudwatch] val hrmLookback = config.getInt("atlas.cloudwatch.poller.hrmLookback")
+  private[cloudwatch] val hrmEndOffset = config.getInt("atlas.cloudwatch.poller.hrmEndOffset")
 
   // Cache for ListMetrics results: key = account|region|namespace|dims|metricName
   private[cloudwatch] val metricsCache =
@@ -755,8 +756,9 @@ class CloudWatchPoller(
               registry
                 .counter(hrmRequest.withTags("period", category.period.toString))
                 .increment()
-              start = Instant.ofEpochMilli(ts - (hrmLookback * category.period * 1000))
-              (start, Instant.ofEpochMilli(ts))
+              val end = ts - (hrmEndOffset * category.period * 1000)
+              start = Instant.ofEpochMilli(end - (hrmLookback * category.period * 1000))
+              (start, Instant.ofEpochMilli(end))
             } else {
               (start, now)
             }
@@ -911,9 +913,10 @@ class CloudWatchPoller(
               registry
                 .counter(hrmRequest.withTags("period", category.period.toString))
                 .increment()
-              start = Instant.ofEpochMilli(ts - (hrmLookback * category.period * 1000))
+              val end = ts - (hrmEndOffset * category.period * 1000)
+              start = Instant.ofEpochMilli(end - (hrmLookback * category.period * 1000))
               MetricMetadata(category, definition, metric.dimensions().asScala.toList)
-                .toGetRequest(start, Instant.ofEpochMilli(ts))
+                .toGetRequest(start, Instant.ofEpochMilli(end))
             } else {
               MetricMetadata(category, definition, metric.dimensions().asScala.toList)
                 .toGetRequest(start, now)

--- a/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchPollerSuite.scala
+++ b/atlas-cloudwatch/src/test/scala/com/netflix/atlas/cloudwatch/CloudWatchPollerSuite.scala
@@ -149,6 +149,7 @@ class CloudWatchPollerSuite extends FunSuite with TestKitBase {
         |    poller.hrmListFrequency = "5s"
         |    poller.useHrmMetricsCache = false
         |    poller.hrmLookback = 6
+        |    poller.hrmEndOffset = 1
         |
         |    cfg1 = {
         |      namespace = "AWS/CFG1"
@@ -473,6 +474,7 @@ class CloudWatchPollerSuite extends FunSuite with TestKitBase {
           |    poller.frequency = "5m"
           |    poller.hrmFrequency = "3s"
           |    poller.hrmLookback = 6
+          |    poller.hrmEndOffset = 1
           |
           |    ut-hrm-dedupe = {
           |      namespace = "AWS/UT1"
@@ -594,6 +596,7 @@ class CloudWatchPollerSuite extends FunSuite with TestKitBase {
           |    poller.frequency = "5m"
           |    poller.hrmFrequency = "5s"
           |    poller.hrmLookback = 2
+          |    poller.hrmEndOffset = 1
           |
           |    ut-hrm = {
           |      namespace = "AWS/UT1"
@@ -722,6 +725,7 @@ class CloudWatchPollerSuite extends FunSuite with TestKitBase {
           |    poller.frequency = "5m"
           |    poller.hrmFrequency = "5s"
           |    poller.hrmLookback = 2
+          |    poller.hrmEndOffset = 1
           |
           |    ut-hrm = {
           |      namespace = "AWS/UT1"
@@ -827,6 +831,7 @@ class CloudWatchPollerSuite extends FunSuite with TestKitBase {
           |    poller.frequency = "5m"
           |    poller.hrmFrequency = "3s"
           |    poller.hrmLookback = 6
+          |    poller.hrmEndOffset = 1
           |    poller.hrmListFrequency = "5s"
           |    poller.useHrmMetricsCache = false
           |
@@ -1033,6 +1038,7 @@ class CloudWatchPollerSuite extends FunSuite with TestKitBase {
         |    poller.frequency = "5m"
         |    poller.hrmFrequency = "5m"
         |    poller.hrmLookback = 6
+        |    poller.hrmEndOffset = 1
         |
         |    ut1 = {
         |      namespace = "AWS/UT1"


### PR DESCRIPTION
Subtracts hrmEndOffset periods from the query end-time so the window only covers timestamps CW has already published (~2-3s lag for HRM). Default value is 1 second.