### PR TITLE
Adding OldestRunningTransactionXidAge metric to Atlas

### DIFF
--- a/atlas-cloudwatch/src/main/resources/rds.conf
+++ b/atlas-cloudwatch/src/main/resources/rds.conf
@@ -437,6 +437,11 @@ atlas {
           alias = "aws.rds.maxUsedTransactionIds"
           conversion = "max"
         },
+        {
+          name = "OldestRunningTransactionXidAge"
+          alias = "aws.rds.oldestRunningTransactionXidAge"
+          conversion = "max"
+        },
       ]
     }
 


### PR DESCRIPTION
Adds OldestRunningTransactionXidAge to enable Atlas alerting on long-running transactions.