### PR TITLE
atlas 1.9.0-rc.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ target
 .ivy2.cache
 .sbt
 
+# Metals
+.metals
+
 # Intellij
 *.iml
 *.ipr

--- a/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
+++ b/atlas-druid/src/main/scala/com/netflix/atlas/druid/DruidDatabaseActor.scala
@@ -89,11 +89,11 @@ class DruidDatabaseActor(config: Config, service: DruidMetadataService, client: 
     case Tick        => refreshMetadata(sender())
     case m: Metadata => metadata = Metadata(m.datasources.filter(_.nonEmpty))
 
-    case ListTagsRequest(tq)   => listValues(sendTags(sender()), tq)
-    case ListKeysRequest(tq)   => listKeys(sender(), tq)
-    case ListValuesRequest(tq) => listValues(sendValues(sender()), tq)
-    case req: DataRequest      => fetchData(sender(), req)
-    case req: ExplainRequest   => explain(sender(), req.dataRequest)
+    case req: ListTagsRequest   => listValues(sendTags(sender()), req.q)
+    case req: ListKeysRequest   => listKeys(sender(), req.q)
+    case req: ListValuesRequest => listValues(sendValues(sender()), req.q)
+    case req: DataRequest       => fetchData(sender(), req)
+    case req: ExplainRequest    => explain(sender(), req.dataRequest)
   }
 
   private def refreshMetadata(ref: ActorRef): Unit = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val atlas      = "1.9.0-rc.12"
+    val atlas      = "1.9.0-rc.16"
     val aws2       = "2.46.21"
     val iep        = "6.0.4"
     val log4j      = "2.26.1"


### PR DESCRIPTION
Adapt DruidDatabaseActor to the caller context added to the tags requests in atlas 1.9.0-rc.16. The Druid backend does not consume the caller, matching the local database in atlas.

Also ignore the .metals directory.