### PR TITLE
scalafmt: use the scala3 dialect

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version = 3.11.5
-runner.dialect = Scala213Source3
+runner.dialect = scala3
 
 style = defaultWithAlign
 


### PR DESCRIPTION
The repo stopped cross-building for 2.13 in #654 (June 2025) and has been Scala 3 only since — `Versions.scala` is `3.8.4` and `crossScala = Seq(scala)` — but `runner.dialect` was left at `Scala213Source3`.

Nothing was broken by this: the current sources are all still 2.13-compatible syntax, so the narrower dialect parses them fine. But it silently rejects Scala 3-only syntax, which is a confusing failure the first time someone reaches for it.

Formatting is unchanged — `scalafmtAll` under the new dialect processes every source and reformats none.

Note on the sibling repo: atlas keeps `Scala213Source3` because it still cross-builds 2.13.18 + 3.8.4, so that one is correct as-is.

Out of scope, noticed while verifying: `scalafmtSbt` reformats four `project/*.scala` files on current main, independent of this change — CI runs `scalafmtCheckAll` but not `scalafmtSbtCheck`, so the build files have drifted. Left alone here to keep this diff to one line; happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)